### PR TITLE
Fix timing inconsistency: total_api_time vs total_sync_duration unit conversion bug

### DIFF
--- a/includes/helpers/nmkr-performance-functions.php
+++ b/includes/helpers/nmkr-performance-functions.php
@@ -179,7 +179,7 @@ function nmkr_log_performance_data($performance_data) {
 
 // Track performance metrics for the current sync operation
 function nmkr_track_api_request($start_time, $end_time) {
-    $duration = ($end_time - $start_time) * 1000; // Convert to milliseconds
+    $duration = ($end_time - $start_time); // Keep in seconds
     
     // Get current stats
     $current_stats = get_transient('nmkr_current_sync_stats_live');
@@ -217,7 +217,7 @@ function nmkr_get_sync_stats() {
     // Calculate average response time from individual API request times
     $average_time = 0;
     if ($stats['request_count'] > 0 && !empty($stats['request_times'])) {
-        $average_time = round(array_sum($stats['request_times']) / $stats['request_count'], 2);
+        $average_time = round(array_sum($stats['request_times']) / $stats['request_count'] * 1000, 2); // Convert to milliseconds for display
     }
     
     $performance_data = array(
@@ -242,12 +242,12 @@ function nmkr_format_performance_metrics($perf) {
     
     // Format duration
     if (isset($perf['duration'])) {
-        $metrics[] = sprintf("Duration: %.2fms", max(0, $perf['duration']));
+        $metrics[] = sprintf("Duration: %.2fs", max(0, $perf['duration']));
     }
     
     // Format API time
     if (isset($perf['total_api_time'])) {
-        $metrics[] = sprintf("API: %.2fms", max(0, $perf['total_api_time']));
+        $metrics[] = sprintf("API: %.2fs", max(0, $perf['total_api_time']));
     }
     
     // Format request count
@@ -275,7 +275,7 @@ function nmkr_format_performance_metrics($perf) {
 
 // Function to track API request failure
 function nmkr_track_api_failure($start_time, $end_time) {
-    $duration = ($end_time - $start_time) * 1000; // Convert to milliseconds
+    $duration = ($end_time - $start_time); // Keep in seconds
     
     // Get current stats
     $current_stats = get_transient('nmkr_current_sync_stats_live');
@@ -312,7 +312,7 @@ function nmkr_get_performance_metrics($stats) {
     // Calculate average response time from individual API request times
     $average_time = 0;
     if ($stats['request_count'] > 0 && !empty($stats['request_times'])) {
-        $average_time = array_sum($stats['request_times']) / $stats['request_count']; // In seconds
+        $average_time = array_sum($stats['request_times']) / $stats['request_count'] * 1000; // Convert to milliseconds for display
     }
     
     $performance_data = array(

--- a/includes/synchronization/nmkr-sync-stats.php
+++ b/includes/synchronization/nmkr-sync-stats.php
@@ -100,6 +100,11 @@ function nmkr_save_sync_metrics($metrics) {
         'created_at' => nmkr_get_timestamp()
     );
 
+    // Validate timing relationships to prevent unit conversion bugs
+    if ($data['total_api_time'] > $data['total_sync_duration'] && $data['total_sync_duration'] > 0) {
+        nmkr_log_data_sync('⚠️ Warning: total_api_time (' . $data['total_api_time'] . 's) exceeds total_sync_duration (' . $data['total_sync_duration'] . 's). This may indicate a unit conversion issue.', 'warning');
+    }
+
     // Insert the data
     if ($wpdb->insert($table_name, $data)) {
         nmkr_log_data_sync('✅ Sync metrics saved successfully.');
@@ -249,4 +254,4 @@ function nmkr_get_recent_sync_stats($limit = 10) {
     }
     
     return $stats;
-} 
+}  


### PR DESCRIPTION
# Fix timing inconsistency: total_api_time vs total_sync_duration unit conversion bug

## Summary

Fixes a critical timing inconsistency bug where "Total API time" was displayed as larger than "Total sync duration" (e.g., 87.89s vs 63.36s), which is logically impossible since API time should be a subset of total sync time.

**Root Cause:** Unit conversion mismatch where `total_api_time` was accumulated in milliseconds while `total_sync_duration` was calculated in seconds. When both were displayed with the same unit label, API time appeared artificially inflated.

**Solution:** 
- Standardized all internal timing to use seconds consistently
- Added validation to detect and warn about future unit conversion issues
- Updated display formatting to maintain user-friendly millisecond display for average response times

## Review & Testing Checklist for Human

- [ ] **Run a complete sync operation** and verify that `total_sync_duration` >= `total_api_time` in the dashboard
- [ ] **Check dashboard displays** show reasonable timing values (not drastically different from before)
- [ ] **Verify historical data compatibility** - check that old sync records in the database still display properly
- [ ] **Test performance logging** works correctly with new units (check debug logs if enabled)
- [ ] **Review JavaScript timing functions** in `js/nmkr-sync-progress.js` for any unit conversion issues

**Recommended Test Plan:** 
1. Start a sync operation from the dashboard
2. Monitor real-time metrics during sync to ensure values are reasonable
3. After completion, verify final metrics show logical relationship (sync duration >= API time)
4. Check that average response times still display in milliseconds as expected

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    A["includes/helpers/nmkr-performance-functions.php"]:::major-edit --> B["nmkr_track_api_request()"]
    A --> C["nmkr_track_api_failure()"]
    A --> D["nmkr_get_sync_stats()"]
    A --> E["nmkr_format_performance_metrics()"]
    
    F["includes/synchronization/nmkr-sync-core.php"]:::context --> G["nmkr_log_sync_summary()"]
    G --> H["sync_duration calculation"]:::context
    
    I["includes/synchronization/nmkr-sync-stats.php"]:::minor-edit --> J["nmkr_save_sync_metrics()"]
    J --> K["Added timing validation"]
    
    A -.-> |"accumulates timing data"| I
    F -.-> |"calculates final duration"| I
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- **Session Details:** Link to Devin run: https://app.devin.ai/sessions/889e73992bc3499fbfa07113e74020aa | Requested by @mihaibarbulescu
- **Backward Compatibility:** Existing database records with old millisecond values should still work but may display differently
- **JavaScript Dependencies:** Frontend timing displays in `js/nmkr-sync-progress.js` expect seconds for API time and may need verification
- **Validation Added:** New warning will log if API time exceeds sync duration, helping catch future unit conversion bugs
- **Performance Impact:** Changes are minimal and should not affect sync performance