### PR TITLE
Fix NMKR settings save capability

### DIFF
--- a/includes/pages/settings/nmkr-settings-core.php
+++ b/includes/pages/settings/nmkr-settings-core.php
@@ -311,6 +311,20 @@ function nmkr_connect_register_settings() {
 add_action('admin_init', 'nmkr_connect_register_settings');
 
 /**
+ * Set the capability required to save NMKR Connect settings.
+ *
+ * @param string $capability Default option page capability.
+ * @return string Required capability for NMKR Connect settings saves.
+ */
+function nmkr_connect_settings_option_page_capability( $capability ) {
+    return 'nmkr_manage_settings';
+}
+add_filter(
+    'option_page_capability_nmkr_connect_settings_group',
+    'nmkr_connect_settings_option_page_capability'
+);
+
+/**
  * Add the settings page to WordPress Settings menu
  */
 function nmkr_connect_add_settings_page() {


### PR DESCRIPTION
### Motivation
- Fix a capability mismatch where the settings page and page rendering use `nmkr_manage_settings` but the Settings API save (via `options.php`) defaults to `manage_options`, which prevented users with only `nmkr_manage_settings` from saving settings.

### Description
- Add a small named function `nmkr_connect_settings_option_page_capability` that returns `'nmkr_manage_settings'` and attach it to the `option_page_capability_nmkr_connect_settings_group` filter in `includes/pages/settings/nmkr-settings-core.php` to make saves require the custom capability.

### Testing
- Ran `php -l includes/pages/settings/nmkr-settings-core.php` which returned no syntax errors, and the change was committed with only `includes/pages/settings/nmkr-settings-core.php` modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bf16fcaa88333a281db3cf794208d)