### PR TITLE
Harden settings page output

### DIFF
--- a/includes/pages/settings/nmkr-settings-core.php
+++ b/includes/pages/settings/nmkr-settings-core.php
@@ -441,7 +441,7 @@ function nmkr_connect_settings_page() {
                 $('#nmkr_api_key').val(currentApiKey);
                 
                 // Show success message
-                alert('Settings have been reset to defaults. Click "Save Changes" to apply.');
+                alert('Settings have been reset to defaults. Click "Save Settings" to apply.');
             }
         });
     });

--- a/includes/pages/settings/nmkr-settings-sections.php
+++ b/includes/pages/settings/nmkr-settings-sections.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) {
 
 // API Settings Section Callback
 function nmkr_connect_api_section_callback() {
-    echo '<p>Configure your NMKR API settings below. You can get your API key from <a href="https://studio.nmkr.io/apikeys" target="_blank">NMKR Studio</a>.</p>';
+    echo '<p>Configure your NMKR API settings below. You can get your API key from <a href="' . esc_url( 'https://studio.nmkr.io/apikeys' ) . '" target="_blank" rel="noopener noreferrer">NMKR Studio</a>.</p>';
 }
 
 // API Settings Field Callbacks
@@ -448,7 +448,7 @@ function nmkr_log_to_dashboard_field_callback() {
     <?php if ($log_to_dashboard): ?>
         <p style="margin-top: 10px;">
             🔍 <strong>View Debug Logs:</strong>
-            <a href="<?php echo admin_url('admin.php?page=nmkr-connect-dashboard#nmkr-debug-logs'); ?>">Jump to Debug Logs panel in Dashboard</a>
+            <a href="<?php echo esc_url(admin_url('admin.php?page=nmkr-connect-dashboard#nmkr-debug-logs')); ?>">Jump to Debug Logs panel in Dashboard</a>
         </p>
     <?php endif; ?>
     <?php


### PR DESCRIPTION
### Motivation
- Ensure settings UI outputs are safe when rendering external links and admin URLs to reduce XSS/reverse-tabnabbing risk. 
- Avoid confusing admin copy in the reset flow by aligning the confirmation message with the actual button label. 
- Make these fixes low-risk and backwards compatible without changing option keys, defaults, or validation rules. 

### Description
- Escape the external NMKR Studio link with `esc_url()` and add `rel="noopener noreferrer"` to the `target="_blank"` anchor to prevent reverse-tabnabbing. 
- Escape the dashboard debug-log admin URL with `esc_url()` before rendering the link in the settings UI. 
- Update the reset-defaults confirmation text to say `Save Settings` so it matches the settings page button label. 
- Changes are limited to rendering/UI text and do not modify stored option names, defaults, or validation logic. 

### Testing
- Ran `php -l includes/pages/settings/nmkr-settings-sections.php` and it returned no syntax errors. 
- Ran `php -l includes/pages/settings/nmkr-settings-core.php` and `php -l includes/pages/settings/nmkr-settings-validation.php` and both returned no syntax errors. 
- Ran `git diff --check` to validate whitespace/roundtrip issues and it reported no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bf33429f48333b982dca035e745ac)