### PR TITLE
Allow intentional sync progress resets

### DIFF
--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -651,7 +651,7 @@ function nmkr_stop_sync_handler() {
     nmkr_log_ui_status('UI: User clicked Stop Synchronization button - stopping process', 'info');
     
     // Update sync status to indicate stopping is in progress (consistent 0→100 reset)
-    nmkr_update_sync_progress(0, 100, '⏹️ Cleaning Up Resources');
+    nmkr_update_sync_progress(0, 100, '⏹️ Cleaning Up Resources', true);
     
     // Log UI status update for the stage change
     nmkr_log_ui_status('UI: Changed status message to "⏹️ Stopping Synchronization - Cleaning Up Resources"', 'info');
@@ -737,7 +737,7 @@ function nmkr_stop_sync_handler() {
         // Mark sync as manually stopped
         update_option('nmkr_sync_in_progress', false);
         // Reset progress to 0% using consistent denominator (100 for UI reset)
-        nmkr_update_sync_progress(0, 100, '⛔ Synchronization Stopped');
+        nmkr_update_sync_progress(0, 100, '⛔ Synchronization Stopped', true);
         // Clear stale item label on manual stop for clean UI state
         update_option('nmkr_sync_current_item', '');
         

--- a/includes/synchronization/nmkr-sync-progress-tracking.php
+++ b/includes/synchronization/nmkr-sync-progress-tracking.php
@@ -20,18 +20,21 @@ if (!defined('ABSPATH')) {
  * @param int $steps_completed The number of steps completed so far
  * @param int $total_steps The total number of steps to process
  * @param string $current_item Optional item currently being processed
+ * @param bool $allow_backward Whether to allow intentional backward progress updates
  * @return int The current progress percentage
  */
-function nmkr_update_sync_progress($steps_completed, $total_steps, $current_item = '') {
+function nmkr_update_sync_progress($steps_completed, $total_steps, $current_item = '', $allow_backward = false) {
     // Calculate percentage internally based on steps
     $percent = $total_steps > 0
         ? (int) round($steps_completed / $total_steps * 100)
         : 0;
     
-    // Ensure progress never goes backward
+    // Ensure progress never goes backward unless explicitly allowed for intentional resets
     $current_progress = get_transient('nmkr_sync_progress');
-    $current_progress = ($current_progress !== false) ? $current_progress : 0;
-    $percent = max($current_progress, $percent);
+    $current_progress = ($current_progress !== false) ? (int) $current_progress : 0;
+    if (!$allow_backward) {
+        $percent = max($current_progress, $percent);
+    }
     
     // Ensure progress is between 0 and 100
     $percent = max(0, min(100, $percent));
@@ -123,7 +126,7 @@ function nmkr_sync_data_complete($success = true, $error_message = '') {
         nmkr_log_ui_status('UI: Updated last sync time to ' . $current_time, 'info');
     } else {
         // Failed - reset to 0% for consistent failure indication
-        nmkr_update_sync_progress(0, 100, '❌ Synchronization Failed: ' . $error_message);
+        nmkr_update_sync_progress(0, 100, '❌ Synchronization Failed: ' . $error_message, true);
         update_option('nmkr_sync_error', $error_message);
         update_option('nmkr_sync_status', 'failed');
         set_transient('nmkr_sync_error', $error_message, NMKR_SYNC_TRANSIENT_TTL);


### PR DESCRIPTION
## Summary
- Added an optional `$allow_backward` parameter to `nmkr_update_sync_progress()` while keeping monotonic progress protection as the default.
- Updated failure and manual stop reset paths to explicitly allow resetting stored progress back to 0%.

## Testing
- `php -l includes/synchronization/nmkr-sync-progress-tracking.php`
- `php -l includes/synchronization/nmkr-sync-ajax-handlers.php`
- `git diff --check`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e1797e4488333bbbd40faff523618)