### PR TITLE
Do not recreate UI log entry after clearing dashboard logs

### DIFF
--- a/includes/pages/dashboard/nmkr-dashboard-ajax.php
+++ b/includes/pages/dashboard/nmkr-dashboard-ajax.php
@@ -443,13 +443,12 @@ function nmkr_clear_all_logs_ajax() {
     
     try {
         // Clear all log types
-        update_option('nmkr_sync_logs', array());
-        update_option('nmkr_api_logs', array());
-        update_option('nmkr_ui_logs', array());
-        update_option('nmkr_performance_logs', array());
-        
-        // Log the action
-        nmkr_log_ui_status('UI: User cleared all debug logs from dashboard', 'info');
+        update_option('nmkr_sync_logs', array(), false);
+        update_option('nmkr_api_logs', array(), false);
+        update_option('nmkr_ui_logs', array(), false);
+        update_option('nmkr_performance_logs', array(), false);
+
+        // Intentionally do not write a dashboard log entry here; doing so would recreate a visible log immediately after clearing.
         
         wp_send_json_success(['message' => 'All logs cleared successfully']);
     } catch (Exception $e) {
@@ -496,10 +495,9 @@ function nmkr_clear_section_logs_ajax() {
     try {
         // Clear the specific log type
         $option_name = 'nmkr_' . $log_type . '_logs';
-        update_option($option_name, array());
-        
-        // Log the action
-        nmkr_log_ui_status('UI: User cleared ' . $log_type . ' logs from dashboard', 'info');
+        update_option($option_name, array(), false);
+
+        // Intentionally do not write a dashboard log entry here; doing so would recreate a visible log immediately after clearing.
         
         wp_send_json_success(['message' => ucfirst($log_type) . ' logs cleared successfully', 'log_type' => $log_type]);
     } catch (Exception $e) {


### PR DESCRIPTION
### Motivation
- Clearing logs from the dashboard would immediately write a new visible UI log, making the clear action appear to have failed.  
- The intent is to ensure cleared dashboard sections remain empty after a user-initiated clear operation while preserving existing guards and response shapes.

### Description
- Updated `nmkr_clear_all_logs_ajax()` to call `update_option()` with `autoload=false` for `nmkr_sync_logs`, `nmkr_api_logs`, `nmkr_ui_logs`, and `nmkr_performance_logs` and removed the immediate `nmkr_log_ui_status()` call.  
- Updated `nmkr_clear_section_logs_ajax()` to call `update_option($option_name, array(), false)` and removed the immediate `nmkr_log_ui_status()` call for the cleared section.  
- Added explanatory comments where logging was intentionally omitted to avoid recreating visible dashboard entries.  
- Preserved existing nonce checks, capability checks, the "do not clear while sync is in progress" guard, `nocache_headers()`, and the JSON response shapes.

### Testing
- Ran `php -l includes/pages/dashboard/nmkr-dashboard-ajax.php` and it reported no syntax errors.  
- Searched the file with ripgrep to verify the updated `update_option()` calls and removal of the immediate `nmkr_log_ui_status()` calls, and the search results matched the intended changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e1a9aad8c8333a0660bb0173c4605)