### PR TITLE
Avoid dashboard reload after clearing all logs

### DIFF
--- a/includes/pages/dashboard/nmkr-dashboard-ui.php
+++ b/includes/pages/dashboard/nmkr-dashboard-ui.php
@@ -1864,10 +1864,8 @@ function nmkr_render_dashboard_scripts($dashboard_nonce) {
                         if (response.success) {
                             // Show success message
                             showLogMessage('All logs cleared successfully', 'success');
-                            // Reload the debug logs panel after a short delay
-                            setTimeout(function() {
-                                location.reload();
-                            }, 1000);
+                            // Refresh visible log sections without reloading the dashboard page.
+                            ['sync', 'api', 'ui', 'performance'].forEach(updateLogSection);
                         } else {
                             showLogMessage(response.data.message || 'Failed to clear logs', 'error');
                         }


### PR DESCRIPTION
### Motivation
- Prevent the dashboard `location.reload()` after `Clear All Logs` from triggering a new UI log entry on page load by refreshing the visible log sections in-place instead of reloading the page.

### Description
- Replaced the success-path page reload in the Clear All Logs handler with `['sync', 'api', 'ui', 'performance'].forEach(updateLogSection);` in `includes/pages/dashboard/nmkr-dashboard-ui.php`, keeping the existing AJAX `action: 'nmkr_clear_all_logs'`, nonce, `_: Date.now()`, success message, error handling, and button disable/restore behavior unchanged.

### Testing
- Ran `git diff --check` with no issues; ran `php -l includes/pages/dashboard/nmkr-dashboard-ui.php` with no syntax errors; and extracted the inline dashboard script and ran `node --check` to validate the JavaScript syntax, all of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e1d3254488333885a8101cd0e62f9)