### PR TITLE
Harden performance log option handling

### DIFF
--- a/includes/helpers/nmkr-performance-functions.php
+++ b/includes/helpers/nmkr-performance-functions.php
@@ -166,7 +166,10 @@ function nmkr_log_performance_data($performance_data) {
     // Log to dashboard (database) if enabled
     if (nmkr_should_log_to('dashboard')) {
         // Store in WordPress options with configurable retention limit
-        $performance_logs = get_option('nmkr_performance_logs', []);
+        $performance_logs = get_option('nmkr_performance_logs', array());
+        if (!is_array($performance_logs)) {
+            $performance_logs = array();
+        }
         array_unshift($performance_logs, $performance_data);
         $performance_logs = array_slice($performance_logs, 0, nmkr_get_log_retention_limit());
         update_option('nmkr_performance_logs', $performance_logs, false); // Set autoload=false to prevent performance issues


### PR DESCRIPTION
### Motivation
- Prevent `array_unshift()` from failing when the `nmkr_performance_logs` option is corrupt or not an array by defensively ensuring an array before prepending a new performance entry.

### Description
- Update `nmkr_log_performance_data()` in `includes/helpers/nmkr-performance-functions.php` to fetch `nmkr_performance_logs` with an array default and reset it to an empty array when `!is_array($performance_logs)`, preserving the existing retention trimming and `update_option(..., false)` behavior.

### Testing
- Ran PHP syntax check with `php -l includes/helpers/nmkr-performance-functions.php`, which reported no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e23a3bee88333a2fb70cce4b2bb18)