### PR TITLE
Update legacy nmkr_last_sync_time option after final sync

### DIFF
--- a/includes/synchronization/nmkr-sync-core.php
+++ b/includes/synchronization/nmkr-sync-core.php
@@ -1040,7 +1040,8 @@ function nmkr_sync_data() {
             $live['total_tokens'] = count($token_project_map);
             
             // Set last sync time and save
-            $live['last_sync_time'] = current_time('mysql');
+            $live['last_sync_time'] = nmkr_get_timestamp();
+            update_option('nmkr_last_sync_time', $live['last_sync_time']);
             set_transient('nmkr_current_sync_stats_summary', $live, NMKR_SYNC_TRANSIENT_TTL);
             
             // Save metrics with validation - only saves if all validation passes


### PR DESCRIPTION
### Motivation
- Ensure the legacy WordPress option `nmkr_last_sync_time` is updated alongside `wp_nmkr_sync_metrics.last_sync_time` so dashboard/AJAX/manual-stop/statistics consumers show a consistent completion timestamp after a full sync.

### Description
- In `includes/synchronization/nmkr-sync-core.php` replace `current_time('mysql')` with `nmkr_get_timestamp()` and add `update_option('nmkr_last_sync_time', $live['last_sync_time']);` before `set_transient('nmkr_current_sync_stats_summary', ...)` so the legacy option is kept in sync with the saved metrics.

### Testing
- Ran `php -l includes/synchronization/nmkr-sync-core.php` and the file lint check passed; no other automated tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e5c73d334833395d1fe0bcb9bf754)