### PR TITLE
Guard sync stats cleanup updates

### DIFF
--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -708,11 +708,37 @@ function nmkr_stop_sync_handler() {
         }
 
         if ($sync_stats_id) {
-            nmkr_update_sync_stats($sync_stats_id, [
-                'status' => 'stopped',
-                'end_time' => nmkr_get_timestamp(),
-                'error_message' => 'Manual stop requested by user'
-            ]);
+            global $wpdb;
+            $table_name = $wpdb->prefix . 'nmkr_sync_stats';
+            $sync_stats = $wpdb->get_row(
+                $wpdb->prepare("SELECT * FROM $table_name WHERE id = %d", $sync_stats_id),
+                ARRAY_A
+            );
+            $current_status = isset($sync_stats['status']) ? $sync_stats['status'] : null;
+            $end_time = isset($sync_stats['end_time']) ? $sync_stats['end_time'] : null;
+            $terminal_statuses = array('completed', 'failed', 'cancelled', 'stopped');
+            $active_statuses = array('initializing', 'processing_projects', 'processing_tokens', 'in_progress', 'running');
+            $has_end_time = !empty($end_time);
+            $is_terminal = in_array($current_status, $terminal_statuses, true);
+            $is_active_or_incomplete = in_array($current_status, $active_statuses, true) || (!$has_end_time && !$is_terminal);
+
+            if ($is_active_or_incomplete) {
+                nmkr_update_sync_stats($sync_stats_id, [
+                    'status' => 'stopped',
+                    'end_time' => nmkr_get_timestamp(),
+                    'error_message' => 'Manual stop requested by user'
+                ]);
+            } else {
+                nmkr_log_data_sync(
+                    'Manual stop preserved immutable historical sync stats row',
+                    'info',
+                    array(
+                        'sync_stats_id' => $sync_stats_id,
+                        'status' => $current_status,
+                        'end_time' => $end_time
+                    )
+                );
+            }
         }
 
         // Log the stop in the cron job

--- a/includes/synchronization/nmkr-sync-error-handling.php
+++ b/includes/synchronization/nmkr-sync-error-handling.php
@@ -120,20 +120,41 @@ function nmkr_clear_sync_jobs($context = 'manual_cleanup', $clear_data = true, $
     if ($sync_stats_id) {
         // If force is true or the status is stuck in processing, force it to 'stopped'
         $current_status = isset($sync_stats) ? $sync_stats['status'] : null;
-        if ($force || $current_status === 'processing_tokens' || $current_status === 'processing_projects') {
-            nmkr_update_sync_stats($sync_stats_id, [
-                'status' => 'stopped',
-                'end_time' => nmkr_get_timestamp(),
-                'error_message' => "Sync stopped forcibly: {$context}"
-            ]);
-            
-            $result['status_update'] = "Updated sync status from '{$current_status}' to 'stopped'";
+        $end_time = isset($sync_stats['end_time']) ? $sync_stats['end_time'] : null;
+        $terminal_statuses = array('completed', 'failed', 'cancelled', 'stopped');
+        $active_statuses = array('initializing', 'processing_projects', 'processing_tokens', 'in_progress', 'running');
+        $has_end_time = !empty($end_time);
+        $is_terminal = in_array($current_status, $terminal_statuses, true);
+        $is_active_or_incomplete = in_array($current_status, $active_statuses, true) || (!$has_end_time && !$is_terminal);
+
+        if ($is_active_or_incomplete) {
+            if ($force || $current_status === 'processing_tokens' || $current_status === 'processing_projects') {
+                nmkr_update_sync_stats($sync_stats_id, [
+                    'status' => 'stopped',
+                    'end_time' => nmkr_get_timestamp(),
+                    'error_message' => "Sync stopped forcibly: {$context}"
+                ]);
+                
+                $result['status_update'] = "Updated sync status from '{$current_status}' to 'stopped'";
+            } else {
+                nmkr_update_sync_stats($sync_stats_id, [
+                    'status' => 'cancelled',
+                    'end_time' => nmkr_get_timestamp(),
+                    'error_message' => "Sync cancelled manually: {$context}"
+                ]);
+            }
         } else {
-            nmkr_update_sync_stats($sync_stats_id, [
-                'status' => 'cancelled',
-                'end_time' => nmkr_get_timestamp(),
-                'error_message' => "Sync cancelled manually: {$context}"
-            ]);
+            $result['status_update'] = "Preserved immutable historical sync stats row '{$sync_stats_id}' with status '{$current_status}'";
+            nmkr_log_data_sync(
+                'Cleanup preserved immutable historical sync stats row',
+                'info',
+                array(
+                    'context' => $context,
+                    'sync_stats_id' => $sync_stats_id,
+                    'status' => $current_status,
+                    'end_time' => $end_time
+                )
+            );
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent cleanup code from overwriting historical sync stats rows that are already terminal or have an `end_time`.
- Avoid the manual-stop fallback path from modifying terminal rows when it uses a stale `sync_stats_id`.
- Preserve immutable sync history while ensuring only truly active/incomplete records are updated during cleanup.

### Description
- In `nmkr_clear_sync_jobs()` read `$end_time`, define `$terminal_statuses` and `$active_statuses`, compute an `$is_active_or_incomplete` guard, and only call `nmkr_update_sync_stats()` when the row is active or incomplete.
- When a row is terminal or already has an `end_time`, skip updating it and log the preservation via `nmkr_log_data_sync()`.
- Apply the same active/incomplete guard in `nmkr_stop_sync_handler()` before performing the manual-stop fallback update so stale `sync_stats_id` values do not overwrite terminal rows.
- All existing cleanup work that deletes transients/options and clears cron jobs remains unchanged; only updates to `nmkr_sync_stats` are guarded.

### Testing
- `php -l includes/synchronization/nmkr-sync-error-handling.php` — succeeded.
- `php -l includes/synchronization/nmkr-sync-ajax-handlers.php` — succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e6755b1bc8333813b8969f9b14fdd)