### PR TITLE
Add Phase 1 smoke tests (Playwright admin + WP-CLI)

### DIFF
--- a/.env.tests.example
+++ b/.env.tests.example
@@ -1,0 +1,17 @@
+# Copy to a VM-local file such as .env.tests and fill in values there.
+# Never commit real secrets, private domains, tokens, screenshots, traces, videos, or logs.
+
+WP_BASE_URL=
+WP_ADMIN_USER=
+WP_ADMIN_PASSWORD=
+WP_ADMIN_PATH=/wp-admin
+NMKR_DASHBOARD_PATH=/wp-admin/admin.php?page=nmkr-connect-dashboard
+NMKR_SETTINGS_PATH=/wp-admin/options-general.php?page=nmkr-connect-settings
+RUN_REAL_SYNC=false
+PW_SAVE_ARTIFACTS=false
+
+WP_PATH=
+WP_CLI_BIN=wp
+NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php
+NMKR_DEBUG_LOG_RELATIVE_PATH=wp-content/debug.log
+NMKR_DEBUG_LOG_LOOKBACK_MINUTES=30

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,20 @@
+/vendor/
+node_modules/
 composer.phar
 composer-setup.php
-/vendor
-/node_modules
-*.log
 *.zip
 .idea/
 .DS_Store
 .env
+
+# Phase 1 smoke-test local files and Playwright artifacts
+.env.*
+!.env.tests.example
+playwright-report/
+test-results/
+playwright/.cache/
+*.trace.zip
+*.webm
+screenshots/
+videos/
+traces/

--- a/README.md
+++ b/README.md
@@ -271,3 +271,7 @@ When building from source, run `composer install --no-dev --prefer-dist` to inst
 
 **Advanced/CI**  
 For automated deployments, you can predefine environment variables or `wp-config.php` constants to streamline activation per environment (e.g., staging vs. production).
+
+## Testing
+
+Phase 1 smoke testing for deployed WordPress development or staging sites is documented in [`docs/testing-phase-1.md`](docs/testing-phase-1.md). The tests use VM-local environment variables and avoid committing secrets or wp-admin artifacts.

--- a/docs/testing-phase-1.md
+++ b/docs/testing-phase-1.md
@@ -1,0 +1,143 @@
+# Phase 1 smoke testing
+
+Phase 1 adds lightweight, public-safe smoke checks for a WordPress site where NMKR Connect has already been deployed. The tests are intended for a private development or staging VM and use environment variables instead of committed secrets.
+
+## What Phase 1 checks
+
+- WordPress admin login works with VM-local credentials.
+- The WordPress admin area is reachable.
+- NMKR Connect appears active on the Plugins page.
+- The NMKR dashboard page loads without obvious WordPress fatal error text.
+- The NMKR settings page loads and expected controls exist.
+- The NMKR API key field is present and non-empty, without printing the key.
+- WP-CLI can confirm WordPress is installed, the plugin is active, required NMKR tables exist, the API key option is non-empty, sync timestamps are consistent, suspicious sync-history mutation patterns are absent, and fresh debug log errors are not present.
+
+## What Phase 1 does not check
+
+- It does not deploy the plugin.
+- It does not start a real NMKR sync by default.
+- It does not validate NMKR API responses or data correctness end-to-end.
+- It does not commit or publish Playwright screenshots, videos, traces, HTML reports, private logs, credentials, or private URLs.
+
+`RUN_REAL_SYNC=true` is reserved for a future phase. The current browser test explicitly skips real sync behavior even if that variable is enabled.
+
+## Secret handling
+
+Never commit real values for:
+
+- API keys
+- WordPress admin passwords
+- Basic Auth credentials
+- private URLs containing tokens
+- wp-admin screenshots, traces, or videos
+- UpdraftPlus backup metadata
+- private server logs
+
+Copy the example file to a private VM-local env file and fill it in there:
+
+```bash
+cp .env.tests.example .env.tests
+chmod 600 .env.tests
+```
+
+The committed `.env.tests.example` intentionally contains blank placeholders only.
+
+## Install dependencies
+
+From the repository root on the VM:
+
+```bash
+npm install
+npx playwright install chromium
+```
+
+If the Linux VM is missing browser system dependencies, install them according to Playwright's prompt or run the appropriate Playwright dependency install command for your OS.
+
+## Configure a VM-local environment
+
+Edit `.env.tests` on the VM. Example shape only; do not paste real values into committed files or public logs:
+
+```bash
+WP_BASE_URL=
+WP_ADMIN_USER=
+WP_ADMIN_PASSWORD=
+WP_ADMIN_PATH=/wp-admin
+NMKR_DASHBOARD_PATH=/wp-admin/admin.php?page=nmkr-connect-dashboard
+NMKR_SETTINGS_PATH=/wp-admin/options-general.php?page=nmkr-connect-settings
+RUN_REAL_SYNC=false
+PW_SAVE_ARTIFACTS=false
+
+WP_PATH=
+WP_CLI_BIN=wp
+NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php
+NMKR_DEBUG_LOG_RELATIVE_PATH=wp-content/debug.log
+NMKR_DEBUG_LOG_LOOKBACK_MINUTES=30
+```
+
+The dashboard and settings paths are configurable because admin menu slugs can change between plugin versions or deployments.
+
+## Run the Playwright smoke tests
+
+Load the private env file in your shell, then run the tests:
+
+```bash
+set -a
+. ./.env.tests
+set +a
+npm run test:e2e
+```
+
+Open the local HTML report after a run:
+
+```bash
+npm run test:e2e:report
+```
+
+The Playwright HTML report is written to `playwright-report/`, which is ignored by git.
+
+## Artifact safety
+
+By default, Playwright screenshots, videos, and traces are disabled because wp-admin pages may contain sensitive data. For private local debugging only, set:
+
+```bash
+PW_SAVE_ARTIFACTS=true
+```
+
+Do not commit or share generated artifacts if they contain wp-admin data, private URLs, or secrets. Generated report and artifact directories are ignored by git.
+
+## Run the WP-CLI smoke script
+
+Load the same VM-local env file and run:
+
+```bash
+set -a
+. ./.env.tests
+set +a
+bash scripts/nmkr-wpcli-smoke.sh
+```
+
+The script is read-only. It queries WordPress options and database tables, but does not mutate plugin state or start a sync.
+
+## Example VM run pattern
+
+After deploying the plugin by your private VM process, run the smoke checks with private env values already stored in `.env.tests`:
+
+```bash
+set -a
+. ./.env.tests
+set +a
+npm install
+npx playwright install chromium
+npm run test:e2e
+bash scripts/nmkr-wpcli-smoke.sh
+```
+
+## Troubleshooting
+
+- **Bad login:** confirm `WP_BASE_URL`, `WP_ADMIN_USER`, and `WP_ADMIN_PASSWORD` in the private env file. Do not echo passwords in logs.
+- **Wrong admin page slug:** update `NMKR_DASHBOARD_PATH` or `NMKR_SETTINGS_PATH` in `.env.tests`.
+- **Plugin inactive:** activate NMKR Connect in WordPress or verify `NMKR_PLUGIN_SLUG`.
+- **Missing `WP_PATH`:** set `WP_PATH` to the WordPress install directory on the VM.
+- **Missing WP-CLI:** install WP-CLI or set `WP_CLI_BIN` to the correct executable path.
+- **Playwright browser dependency issue on Linux:** run `npx playwright install chromium` first, then follow any OS dependency instructions printed by Playwright.
+- **Debug log failures:** the WP-CLI script prints only redacted matching excerpts. Inspect the private VM log directly if more detail is needed, but do not commit or share private logs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,92 @@
+{
+  "name": "wordpress-nmkr-connect-smoke-tests",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "wordpress-nmkr-connect-smoke-tests",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.53.0",
+        "dotenv": "^16.4.7"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "wordpress-nmkr-connect-smoke-tests",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Phase 1 smoke tests for the WordPress NMKR Connect plugin.",
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.53.0",
+    "dotenv": "^16.4.7"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: process.env.DOTENV_CONFIG_PATH || '.env.tests' });
+
+const saveArtifacts = process.env.PW_SAVE_ARTIFACTS === 'true';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  timeout: 60_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  reporter: [['html', { outputFolder: 'playwright-report', open: 'never' }], ['list']],
+  use: {
+    baseURL: process.env.WP_BASE_URL,
+    headless: true,
+    screenshot: saveArtifacts ? 'only-on-failure' : 'off',
+    video: saveArtifacts ? 'retain-on-failure' : 'off',
+    trace: saveArtifacts ? 'retain-on-failure' : 'off',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  outputDir: 'test-results',
+});

--- a/scripts/nmkr-wpcli-smoke.sh
+++ b/scripts/nmkr-wpcli-smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+WP_CLI_BIN="${WP_CLI_BIN:-wp}"
+WP_PATH="${WP_PATH:-}"
+NMKR_PLUGIN_SLUG="${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}"
+NMKR_DEBUG_LOG_RELATIVE_PATH="${NMKR_DEBUG_LOG_RELATIVE_PATH:-wp-content/debug.log}"
+NMKR_DEBUG_LOG_LOOKBACK_MINUTES="${NMKR_DEBUG_LOG_LOOKBACK_MINUTES:-30}"
+
+pass() { printf 'PASS: %s\n' "$1"; }
+notice() { printf 'NOTICE: %s\n' "$1"; }
+fail() { printf 'FAIL: %s\n' "$1" >&2; exit 1; }
+
+command -v "$WP_CLI_BIN" >/dev/null 2>&1 || fail "WP-CLI binary not found. Set WP_CLI_BIN."
+[[ -n "$WP_PATH" ]] || fail "WP_PATH is required and must point to the WordPress install."
+[[ -d "$WP_PATH" ]] || fail "WP_PATH does not exist or is not a directory."
+
+wp_cmd() { "$WP_CLI_BIN" --path="$WP_PATH" "$@"; }
+wp_sql() { wp_cmd db query --skip-column-names --silent "$1"; }
+
+wp_cmd core is-installed >/dev/null 2>&1 || fail "WordPress core is not installed at WP_PATH."
+pass "WordPress core is installed."
+
+if wp_cmd plugin is-active "$NMKR_PLUGIN_SLUG" >/dev/null 2>&1; then
+  pass "NMKR Connect plugin is active."
+else
+  fail "NMKR Connect plugin is not active for NMKR_PLUGIN_SLUG."
+fi
+
+prefix="$(wp_cmd db prefix)"
+[[ -n "$prefix" ]] || fail "Could not determine WordPress database prefix."
+
+required_tables=(
+  "${prefix}nmkr_projects"
+  "${prefix}nmkr_tokens"
+  "${prefix}nmkr_token_details"
+  "${prefix}nmkr_sync_stats"
+  "${prefix}nmkr_sync_metrics"
+)
+for table in "${required_tables[@]}"; do
+  exists="$(wp_sql "SHOW TABLES LIKE '${table//\'/\'\'}';" | wc -l | tr -d ' ')"
+  [[ "$exists" == "1" ]] || fail "Required NMKR table is missing: $table"
+  pass "Required NMKR table exists: $table"
+done
+
+api_key_present="$(wp_cmd eval '$options = get_option("nmkr_connect_options", array()); echo ! empty($options["api_key"]) ? "yes" : "no";')"
+[[ "$api_key_present" == "yes" ]] || fail "NMKR API key option is missing or empty."
+pass "NMKR API key option is present and non-empty (value redacted)."
+
+metrics_count="$(wp_sql "SELECT COUNT(*) FROM ${prefix}nmkr_sync_metrics;" | tr -d ' ')"
+if [[ "$metrics_count" == "0" ]]; then
+  notice "No sync metrics rows exist yet; skipping last sync time comparison."
+else
+  latest_metrics_time="$(wp_sql "SELECT last_sync_time FROM ${prefix}nmkr_sync_metrics ORDER BY last_sync_time DESC, id DESC LIMIT 1;" | head -n 1)"
+  option_last_sync="$(wp_cmd option get nmkr_last_sync_time 2>/dev/null || true)"
+  [[ -n "$option_last_sync" ]] || fail "nmkr_last_sync_time option is empty while sync metrics exist."
+  [[ "$option_last_sync" == "$latest_metrics_time" ]] || fail "nmkr_last_sync_time does not match latest nmkr_sync_metrics.last_sync_time."
+  pass "nmkr_last_sync_time matches latest sync metrics last_sync_time."
+fi
+
+completed_count="$(wp_sql "SELECT COUNT(*) FROM ${prefix}nmkr_sync_stats WHERE status = 'completed';" | tr -d ' ')"
+pass "Completed sync history rows visible: $completed_count."
+
+suspicious_cancelled="$(wp_sql "SELECT COUNT(*) FROM ${prefix}nmkr_sync_stats WHERE status = 'cancelled' AND end_time IS NOT NULL AND items_successful > 0 AND (items_failed = 0 OR items_failed IS NULL) AND (error_message IS NULL OR error_message = '');" | tr -d ' ')"
+[[ "$suspicious_cancelled" == "0" ]] || fail "Found suspicious cancelled sync rows that look like completed rows: $suspicious_cancelled."
+pass "No suspicious completed-to-cancelled sync history mutation pattern detected."
+
+in_progress="$(wp_cmd option get nmkr_sync_in_progress 2>/dev/null || true)"
+status="$(wp_cmd option get nmkr_sync_status 2>/dev/null || true)"
+if [[ "$in_progress" == "1" || "$status" == "running" || "$status" == "in_progress" ]]; then
+  notice "A sync appears to be in progress; Phase 1 smoke script did not start it."
+else
+  pass "Latest sync state is not marked in progress."
+fi
+
+debug_log="$WP_PATH/$NMKR_DEBUG_LOG_RELATIVE_PATH"
+if [[ ! -f "$debug_log" ]]; then
+  notice "Debug log not found at configured relative path; skipping debug.log check."
+  exit 0
+fi
+
+lookback_minutes_re='^[0-9]+$'
+[[ "$NMKR_DEBUG_LOG_LOOKBACK_MINUTES" =~ $lookback_minutes_re ]] || fail "NMKR_DEBUG_LOG_LOOKBACK_MINUTES must be numeric."
+if find "$debug_log" -mmin "-$NMKR_DEBUG_LOG_LOOKBACK_MINUTES" -print -quit | grep -q .; then
+  matches="$(tail -n 400 "$debug_log" | sed -E 's/(Authorization: Bearer )[A-Za-z0-9._~+\/-]+/\1[REDACTED]/g; s/(api[_ -]?key["'"'"']?[=:][[:space:]]*)[^[:space:]&"'"'"']+/\1[REDACTED]/Ig' | grep -E 'PHP Fatal error|PHP Parse error|PHP Warning|NMKR.*(Fatal|Error|Exception)' || true)"
+  if [[ -n "$matches" ]]; then
+    printf '%s\n' "$matches" | tail -n 20 >&2
+    fail "Recent debug.log contains PHP/plugin errors (redacted excerpt above)."
+  fi
+  pass "No fresh PHP/plugin errors found in recent debug.log tail."
+else
+  notice "debug.log has not changed within lookback window; no fresh errors to inspect."
+fi

--- a/tests/e2e/nmkr-admin.smoke.spec.ts
+++ b/tests/e2e/nmkr-admin.smoke.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from '@playwright/test';
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`${name} is required for NMKR admin smoke tests.`);
+  return value;
+}
+
+function siteUrl(path: string): string {
+  const base = requiredEnv('WP_BASE_URL').replace(/\/$/, '');
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+async function expectNoWordPressFatal(page: import('@playwright/test').Page) {
+  const body = page.locator('body');
+  await expect(body).not.toContainText(/There has been a critical error|Fatal error|Parse error|Warning:\s|Notice:\s/i);
+}
+
+test.describe('NMKR Connect WordPress admin smoke tests', () => {
+  test.beforeEach(async ({ page }) => {
+    const adminPath = process.env.WP_ADMIN_PATH || '/wp-admin';
+    const username = requiredEnv('WP_ADMIN_USER');
+    const password = requiredEnv('WP_ADMIN_PASSWORD');
+
+    await page.goto(siteUrl(`${adminPath.replace(/\/$/, '')}/`));
+    if (page.url().includes('wp-login.php')) {
+      await page.locator('#user_login').fill(username);
+      await page.locator('#user_pass').fill(password);
+      await page.getByRole('button', { name: /log in/i }).click();
+    }
+
+    await expect(page).toHaveURL(/\/wp-admin\//);
+    await expect(page.getByRole('heading', { name: /dashboard/i }).or(page.locator('#wpadminbar'))).toBeVisible();
+    await expectNoWordPressFatal(page);
+  });
+
+  test('WordPress admin is reachable and NMKR Connect is active', async ({ page }) => {
+    await page.goto(siteUrl('/wp-admin/plugins.php'));
+    await expectNoWordPressFatal(page);
+
+    const pluginRow = page.locator('tr.active[data-plugin*="nmkr-connect"], tr.active').filter({ hasText: /NMKR Connect/i });
+    await expect(pluginRow, 'NMKR Connect should appear as an active plugin without exposing credentials.').toBeVisible();
+  });
+
+  test('NMKR dashboard and settings pages load safely', async ({ page }) => {
+    const dashboardPath = process.env.NMKR_DASHBOARD_PATH || '/wp-admin/admin.php?page=nmkr-connect-dashboard';
+    const settingsPath = process.env.NMKR_SETTINGS_PATH || '/wp-admin/options-general.php?page=nmkr-connect-settings';
+
+    await page.goto(siteUrl(dashboardPath));
+    await expectNoWordPressFatal(page);
+    await expect(page.getByRole('heading', { name: /NMKR|Dashboard/i }).or(page.locator('body', { hasText: /NMKR Connect|Dashboard/i }))).toBeVisible();
+
+    await page.goto(siteUrl(settingsPath));
+    await expectNoWordPressFatal(page);
+    await expect(page.getByRole('heading', { name: /NMKR Connect Settings|Settings/i })).toBeVisible();
+    await expect(page.getByLabel(/API Key/i).or(page.locator('#nmkr_api_key'))).toBeVisible();
+    await expect(page.locator('#nmkr_sync_profile, select[name="nmkr_connect_options[sync_profile]"]')).toBeVisible();
+    await expect(page.getByRole('button', { name: /save settings/i })).toBeVisible();
+
+    const apiKeyInput = page.locator('#nmkr_api_key');
+    await expect(apiKeyInput).toHaveCount(1);
+    const hasApiKey = await apiKeyInput.evaluate((input) => (input as HTMLInputElement).value.length > 0);
+    expect(hasApiKey, 'Configured NMKR API key field should be non-empty; the value is intentionally never logged.').toBe(true);
+
+    if (process.env.RUN_REAL_SYNC === 'true') {
+      test.skip(true, 'RUN_REAL_SYNC=true is reserved for a future phase; Phase 1 does not start real NMKR syncs.');
+    } else {
+      expect(process.env.RUN_REAL_SYNC || 'false').toBe('false');
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide a lightweight, public-safe Phase 1 automated smoke-test capability to verify an already-deployed NMKR Connect plugin on a private dev/staging WordPress instance. 
- Keep tests read-only and secret-safe by using VM-local env files, avoiding screenshots/traces/videos by default, and never printing API keys or admin passwords.
- Make a practical developer experience with simple npm scripts and a small WP-CLI script so tests can run headless on Linux VMs.

### Description

- Add Playwright e2e test scaffolding and npm scripts (`package.json`, `package-lock.json`, `playwright.config.ts`) that load `.env.tests`, run headless Chromium, and enable an HTML report while keeping artifacts off by default. 
- Add the admin smoke spec `tests/e2e/nmkr-admin.smoke.spec.ts` which logs into WP admin using env vars, checks admin reachability, asserts NMKR Connect appears active, loads dashboard/settings pages, verifies expected controls and that the API key input exists and is non-empty without exposing its value, and explicitly does not start a real sync (placeholder gated by `RUN_REAL_SYNC`).
- Add a read-only WP-CLI smoke script `scripts/nmkr-wpcli-smoke.sh` that validates WordPress installation, plugin activation, required NMKR DB tables, API key presence (redacted check), sync-metrics consistency with `nmkr_last_sync_time`, suspicious sync-history mutation heuristics, and recent debug.log errors within a lookback window without printing secrets.
- Add docs and helpers: `docs/testing-phase-1.md`, a public-safe `.env.tests.example` with blank placeholders, README link update, and `.gitignore` entries to ignore local env files, Playwright reports/results, artifacts, and `node_modules`.

### Testing

- Installed dev dependencies via `npm install` which completed successfully. 
- Verified Playwright test discovery with `npm run test:e2e -- --list`, which listed the two smoke tests (success). 
- Performed a shell syntax check of the WP-CLI script with `bash -n scripts/nmkr-wpcli-smoke.sh` which passed. 
- Ran `git diff --cached --check` (pre-commit checks) and they passed; no automated full browser runs against a live site were executed in this environment — follow the documented steps (`npx playwright install chromium` and `npm run test:e2e`) to run the tests against a configured VM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e74be033483339ca6959f806c6168)