### PR TITLE
Hotfix Phase 1 smoke test robustness

### DIFF
--- a/tests/e2e/nmkr-admin.smoke.spec.ts
+++ b/tests/e2e/nmkr-admin.smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 function requiredEnv(name: string): string {
   const value = process.env[name];
@@ -11,34 +11,45 @@ function siteUrl(path: string): string {
   return `${base}${path.startsWith('/') ? path : `/${path}`}`;
 }
 
-async function expectNoWordPressFatal(page: import('@playwright/test').Page) {
+function pathExpectation(path: string): RegExp {
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`;
+  const escapedPath = normalizedPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return new RegExp(escapedPath);
+}
+
+async function expectNoWordPressFatal(page: Page) {
   const body = page.locator('body');
   await expect(body).not.toContainText(/There has been a critical error|Fatal error|Parse error|Warning:\s|Notice:\s/i);
 }
 
+async function loginToWordPressAdmin(page: Page) {
+  const adminPath = process.env.WP_ADMIN_PATH || '/wp-admin';
+  const username = requiredEnv('WP_ADMIN_USER');
+  const password = requiredEnv('WP_ADMIN_PASSWORD');
+
+  await page.goto(siteUrl(`${adminPath.replace(/\/$/, '')}/`));
+
+  if (page.url().includes('wp-login.php') || await page.locator('#loginform').isVisible()) {
+    await page.locator('#user_login').fill(username);
+    await page.locator('#user_pass').fill(password);
+    await page.locator('#wp-submit').click();
+  }
+
+  await expect(page).toHaveURL(/\/wp-admin\//);
+  await expect(page.locator('#wpadminbar'), 'WordPress admin toolbar should be visible after login.').toBeVisible();
+  await expectNoWordPressFatal(page);
+}
+
 test.describe('NMKR Connect WordPress admin smoke tests', () => {
   test.beforeEach(async ({ page }) => {
-    const adminPath = process.env.WP_ADMIN_PATH || '/wp-admin';
-    const username = requiredEnv('WP_ADMIN_USER');
-    const password = requiredEnv('WP_ADMIN_PASSWORD');
-
-    await page.goto(siteUrl(`${adminPath.replace(/\/$/, '')}/`));
-    if (page.url().includes('wp-login.php')) {
-      await page.locator('#user_login').fill(username);
-      await page.locator('#user_pass').fill(password);
-      await page.getByRole('button', { name: /log in/i }).click();
-    }
-
-    await expect(page).toHaveURL(/\/wp-admin\//);
-    await expect(page.getByRole('heading', { name: /dashboard/i }).or(page.locator('#wpadminbar'))).toBeVisible();
-    await expectNoWordPressFatal(page);
+    await loginToWordPressAdmin(page);
   });
 
   test('WordPress admin is reachable and NMKR Connect is active', async ({ page }) => {
     await page.goto(siteUrl('/wp-admin/plugins.php'));
     await expectNoWordPressFatal(page);
 
-    const pluginRow = page.locator('tr.active[data-plugin*="nmkr-connect"], tr.active').filter({ hasText: /NMKR Connect/i });
+    const pluginRow = page.locator('tr.active[data-plugin*="nmkr-connect"]').filter({ hasText: /NMKR Connect/i });
     await expect(pluginRow, 'NMKR Connect should appear as an active plugin without exposing credentials.').toBeVisible();
   });
 
@@ -47,18 +58,23 @@ test.describe('NMKR Connect WordPress admin smoke tests', () => {
     const settingsPath = process.env.NMKR_SETTINGS_PATH || '/wp-admin/options-general.php?page=nmkr-connect-settings';
 
     await page.goto(siteUrl(dashboardPath));
+    await expect(page, 'NMKR dashboard should stay on the configured dashboard URL.').toHaveURL(pathExpectation(dashboardPath));
     await expectNoWordPressFatal(page);
-    await expect(page.getByRole('heading', { name: /NMKR|Dashboard/i }).or(page.locator('body', { hasText: /NMKR Connect|Dashboard/i }))).toBeVisible();
+    await expect(page.locator('body'), 'NMKR dashboard page should contain NMKR-specific page content.').toContainText(/NMKR/i);
 
     await page.goto(siteUrl(settingsPath));
+    await expect(page, 'NMKR settings should stay on the configured settings URL.').toHaveURL(pathExpectation(settingsPath));
     await expectNoWordPressFatal(page);
-    await expect(page.getByRole('heading', { name: /NMKR Connect Settings|Settings/i })).toBeVisible();
-    await expect(page.getByLabel(/API Key/i).or(page.locator('#nmkr_api_key'))).toBeVisible();
-    await expect(page.locator('#nmkr_sync_profile, select[name="nmkr_connect_options[sync_profile]"]')).toBeVisible();
-    await expect(page.getByRole('button', { name: /save settings/i })).toBeVisible();
+    await expect(page.locator('body'), 'NMKR settings page should contain NMKR-specific page content.').toContainText(/NMKR/i);
 
-    const apiKeyInput = page.locator('#nmkr_api_key');
-    await expect(apiKeyInput).toHaveCount(1);
+    const apiKeyInput = page.locator('#nmkr_api_key, input[name="nmkr_connect_options[api_key]"]').first();
+    await expect(apiKeyInput, 'NMKR API key input should be present; its value is never printed.').toBeVisible();
+
+    const syncProfileControl = page.locator('#nmkr_sync_profile, select[name="nmkr_connect_options[sync_profile]"]').first();
+    await expect(syncProfileControl, 'NMKR sync profile control should be present.').toBeVisible();
+
+    await expect(page.locator('#submit, input[type="submit"][name="submit"], button[type="submit"]').first()).toBeVisible();
+
     const hasApiKey = await apiKeyInput.evaluate((input) => (input as HTMLInputElement).value.length > 0);
     expect(hasApiKey, 'Configured NMKR API key field should be non-empty; the value is intentionally never logged.').toBe(true);
 


### PR DESCRIPTION
### Motivation

- Make Phase 1 smoke tests runnable and VM-friendly by using stable WordPress selectors and stronger URL assertions so the test cannot pass by landing on the generic dashboard.
- Keep the tests public-safe by never printing secrets, not saving artifacts by default, and not starting a real NMKR sync in Phase 1.
- Validate the WP-CLI smoke script and env example are syntactically correct and safe to source on a private VM.

### Description

- Update the Playwright admin smoke test to use stable login IDs `#user_login`, `#user_pass`, and `#wp-submit` and centralize login in `loginToWordPressAdmin`. (changed file: `tests/e2e/nmkr-admin.smoke.spec.ts`)
- Add `pathExpectation` and explicit `toHaveURL` checks for the NMKR dashboard and settings pages so assertions require the configured admin page slugs. (changed file: `tests/e2e/nmkr-admin.smoke.spec.ts`)
- Replace fragile `.or()` locators with readable, resilient locators for plugin row, API key input, sync profile control, and submit controls, and ensure the API key value is never logged. (changed file: `tests/e2e/nmkr-admin.smoke.spec.ts`)
- Preserve Phase 1 behavior: artifacts disabled by default, HTML report kept, and `RUN_REAL_SYNC=true` is reserved/skipped in tests; no plugin runtime code was changed and WP-CLI script remains read-only.

### Testing

- Ran `bash -n scripts/nmkr-wpcli-smoke.sh` which completed successfully and validated the shell script syntax.
- Validated `.env.tests.example` lines with `node -e` check which passed and confirmed each variable is on its own line and source-safe.
- Installed dev deps with `npm install` and confirmed Playwright test discovery with `npm run test:e2e -- --list` which listed the two smoke tests.
- Ran `git diff --check` and committed the change; all automated checks executed in the editing VM succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e776452388333a444ab599cdf23c9)