### PR TITLE
Simplify `.env.tests.example` by removing comments and blank lines

### DIFF
--- a/.env.tests.example
+++ b/.env.tests.example
@@ -1,6 +1,3 @@
-# Copy to a VM-local file such as .env.tests and fill in values there.
-# Never commit real secrets, private domains, tokens, screenshots, traces, videos, or logs.
-
 WP_BASE_URL=
 WP_ADMIN_USER=
 WP_ADMIN_PASSWORD=
@@ -9,7 +6,6 @@ NMKR_DASHBOARD_PATH=/wp-admin/admin.php?page=nmkr-connect-dashboard
 NMKR_SETTINGS_PATH=/wp-admin/options-general.php?page=nmkr-connect-settings
 RUN_REAL_SYNC=false
 PW_SAVE_ARTIFACTS=false
-
 WP_PATH=
 WP_CLI_BIN=wp
 NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php


### PR DESCRIPTION
### Motivation
- Reduce clutter in the example test environment file and keep only the required variable placeholders by removing top-line explanatory comments and an extra blank line.  

### Description
- Deleted the initial explanatory comment lines and an unnecessary blank line from `/.env.tests.example` so the file only contains the environment variable placeholders.  

### Testing
- No automated tests were run for this documentation/example-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e7ac5cdbc83338d4c8b6c2d81234e)