### PR TITLE
Handle WordPress admin prompts in Playwright smoke test

### DIFF
--- a/tests/e2e/nmkr-admin.smoke.spec.ts
+++ b/tests/e2e/nmkr-admin.smoke.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 
 const requiredEnv = ['WP_BASE_URL', 'WP_ADMIN_USER', 'WP_ADMIN_PASSWORD'] as const;
 
@@ -20,6 +20,30 @@ function urlFor(baseUrl: string, path: string): string {
   return new URL(path, baseUrl).toString();
 }
 
+function cssAttrValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+async function handleAdminEmailVerification(page: Page): Promise<void> {
+  const emailVerificationHeading = page.getByRole('heading', {
+    name: /administration email verification/i,
+  });
+
+  if (await emailVerificationHeading.isVisible({ timeout: 3000 }).catch(() => false)) {
+    const confirmButton = page.getByRole('button', { name: /email is correct/i });
+
+    if (await confirmButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await confirmButton.click();
+      await page.waitForLoadState('domcontentloaded');
+    }
+  }
+}
+
+async function expectWpAdmin(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/wp-admin/);
+  await expect(page.locator('#wpadminbar, #adminmenu, #wpbody-content').first()).toBeVisible();
+}
+
 test.describe('NMKR Connect WordPress admin smoke test', () => {
   test('loads admin, plugin pages, and safe Phase 1 controls', async ({ page }) => {
     const baseUrl = requireEnv('WP_BASE_URL');
@@ -28,6 +52,7 @@ test.describe('NMKR Connect WordPress admin smoke test', () => {
     const adminPath = env('WP_ADMIN_PATH', '/wp-admin');
     const dashboardPath = env('NMKR_DASHBOARD_PATH', '/wp-admin/admin.php?page=nmkr-connect-dashboard');
     const settingsPath = env('NMKR_SETTINGS_PATH', '/wp-admin/options-general.php?page=nmkr-connect-settings');
+    const pluginSlug = env('NMKR_PLUGIN_SLUG', 'nmkr-connect/nmkr-connect.php');
     const runRealSync = env('RUN_REAL_SYNC', 'false') === 'true';
 
     await page.goto(urlFor(baseUrl, '/wp-login.php'));
@@ -36,44 +61,56 @@ test.describe('NMKR Connect WordPress admin smoke test', () => {
     await page.locator('#user_pass').fill(password);
     await page.locator('#wp-submit').click();
 
-    await page.waitForURL(/wp-admin/);
-    await expect(page.locator('body.wp-admin')).toBeVisible();
+    await page.waitForLoadState('domcontentloaded');
+    await handleAdminEmailVerification(page);
+    await page.goto(urlFor(baseUrl, adminPath));
+    await expectWpAdmin(page);
 
     await page.goto(urlFor(baseUrl, '/wp-admin/plugins.php'));
-    const pluginRow = page.locator('tr[data-slug="nmkr-connect"], tr:has-text("NMKR Connect")').first();
-    await expect(pluginRow).toBeVisible();
-    await expect(pluginRow).toContainText(/active|deactivate/i);
+    await expectWpAdmin(page);
 
-    await page.goto(urlFor(baseUrl, adminPath));
-    await expect(page.locator('body.wp-admin')).toBeVisible();
+    const pluginRow = page.locator(`tr[data-plugin="${cssAttrValue(pluginSlug)}"]`).first();
+    await expect(pluginRow).toBeVisible();
+    await expect(pluginRow).toContainText(/deactivate/i);
 
     await page.goto(urlFor(baseUrl, dashboardPath));
-    await expect(page.locator('body.wp-admin')).toBeVisible();
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-dashboard/);
     await expect(page.locator('body')).toContainText(/NMKR|Connect|Dashboard/i);
 
     await page.goto(urlFor(baseUrl, settingsPath));
-    await expect(page.locator('body.wp-admin')).toBeVisible();
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-settings/);
     await expect(page.locator('body')).toContainText(/NMKR|Connect|Settings/i);
 
     const apiKeyField = page
       .locator('input[type="password"], input[name*="api" i], input[id*="api" i]')
       .first();
+
     await expect(apiKeyField).toBeVisible();
 
     const apiKeyValue = await apiKeyField.inputValue();
-    if (apiKeyValue.length > 0) {
+
+    if (apiKeyValue) {
       expect(apiKeyValue.trim().length).toBeGreaterThan(0);
     }
 
     const syncProfileControl = page
       .locator('select[name*="profile" i], input[name*="profile" i], select[id*="profile" i], input[id*="profile" i]')
       .first();
+
     await expect(syncProfileControl).toBeVisible();
+    await expect(page.locator('body')).toContainText(/sync/i);
 
     if (!runRealSync) {
-      test.skip(true, 'Phase 1 proof-of-concept skips real NMKR sync behavior unless RUN_REAL_SYNC=true.');
+      test.info().annotations.push({
+        type: 'phase-1',
+        description: 'Real NMKR sync was intentionally not started because RUN_REAL_SYNC is not true.',
+      });
+
+      return;
     }
 
-    await expect(page.locator('body')).toContainText(/sync/i);
+    throw new Error('RUN_REAL_SYNC=true is reserved for a later phase and is not implemented in this smoke test.');
   });
 });


### PR DESCRIPTION
## Summary

- Handles the WordPress administration email verification interstitial after login.
- Replaces fragile `body.wp-admin` checks with stable wp-admin element assertions.
- Targets the exact active NMKR plugin row using `NMKR_PLUGIN_SLUG` so backup plugin directories are not matched first.
- Keeps Phase 1 safe by not starting a real NMKR sync unless a later phase implements `RUN_REAL_SYNC=true` behavior.

## Validation

Validated on the dev VM using a VM-local, uncommitted `.env.tests` file and a dedicated dev-only WordPress admin test user.

Result:

```text
1 passed (29.7s)
PLAYWRIGHT_EXIT_CODE=0
```

Public safety:

- No credentials committed.
- No `.env.tests` committed.
- No reports, screenshots, traces, videos, or private logs committed.
- Only `tests/e2e/nmkr-admin.smoke.spec.ts` changed.