### PR TITLE
Add settings page regression test

### DIFF
--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -1,0 +1,53 @@
+# Phase 3 settings-page regression coverage
+
+Phase 3 adds the first safe Playwright regression check for the NMKR Connect settings page. The goal is to verify the admin settings page structure and important controls without mutating WordPress options or exposing private configuration.
+
+## What the settings regression covers
+
+The settings regression is implemented in `tests/e2e/nmkr-settings.regression.spec.ts`. It logs in with the existing WordPress admin test environment variables, opens `NMKR_SETTINGS_PATH` (defaulting to `/wp-admin/options-general.php?page=nmkr-connect-settings`), and verifies that the WordPress admin shell, NMKR settings page, settings form, sections, and key controls are present.
+
+The test confirms broad coverage for:
+
+- API Settings
+- Synchronization Settings
+- Debug Settings
+- Analytics & Privacy
+- Save Settings and Reset to Defaults controls
+
+## Non-mutating safety guarantees
+
+The Phase 3 settings regression is intentionally non-mutating:
+
+- It does not click **Save Settings**.
+- It does not click **Reset to Defaults**.
+- It does not click the API key visibility toggle.
+- It does not change the synchronization profile.
+- It does not fill, clear, check, uncheck, or otherwise change settings controls.
+- It does not run real NMKR sync.
+- It does not read, print, snapshot, or assert raw API key values.
+- It does not read, print, snapshot, or assert raw GA4 API secret values.
+
+The test uses presence and basic attribute assertions for secret fields, such as checking that API key and GA4 API secret inputs exist and remain `type="password"`.
+
+## Running Phase 3 locally
+
+The settings regression is included in the default Playwright suite:
+
+```bash
+npm run test:e2e
+```
+
+It can also be listed or run directly with:
+
+```bash
+npm run test:e2e:settings -- --list
+npm run test:e2e:settings
+```
+
+Because the Phase 2 runner executes `npm run test:e2e`, the Phase 3 settings regression is automatically included in Phase 2 VM validation.
+
+## Artifacts and public safety
+
+Playwright screenshots, traces, and videos remain disabled by default. They are only enabled when `PW_SAVE_ARTIFACTS=true`, and Phase 2 stores reports and test output in the private run directory.
+
+Do not commit or publish secrets, API keys, WordPress admin passwords, Basic Auth credentials, private token URLs, private screenshots, traces, videos, `.env.tests`, private environment files, VM output, Playwright reports, or sensitive logs.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test:e2e": "playwright test",
     "test:e2e:report": "playwright show-report",
-    "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh"
+    "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
+    "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/tests/e2e/helpers/wp-admin.ts
+++ b/tests/e2e/helpers/wp-admin.ts
@@ -1,0 +1,65 @@
+import { expect, Page } from '@playwright/test';
+
+export const requiredEnv = ['WP_BASE_URL', 'WP_ADMIN_USER', 'WP_ADMIN_PASSWORD'] as const;
+
+export function env(name: string, fallback = ''): string {
+  return process.env[name] || fallback;
+}
+
+export function requireEnv(name: (typeof requiredEnv)[number]): string {
+  const value = process.env[name];
+
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`);
+  }
+
+  return value;
+}
+
+export function urlFor(baseUrl: string, path: string): string {
+  return new URL(path, baseUrl).toString();
+}
+
+export function cssAttrValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+export async function handleAdminEmailVerification(page: Page): Promise<void> {
+  const emailVerificationHeading = page.getByRole('heading', {
+    name: /administration email verification/i,
+  });
+
+  if (await emailVerificationHeading.isVisible({ timeout: 3000 }).catch(() => false)) {
+    const confirmButton = page.getByRole('button', { name: /email is correct/i });
+
+    if (await confirmButton.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await confirmButton.click();
+      await page.waitForLoadState('domcontentloaded');
+    }
+  }
+}
+
+export async function expectWpAdmin(page: Page): Promise<void> {
+  await expect(page).toHaveURL(/wp-admin/);
+  await expect(page.locator('#wpadminbar, #adminmenu, #wpbody-content').first()).toBeVisible();
+}
+
+export async function loginToWpAdmin(page: Page): Promise<string> {
+  const baseUrl = requireEnv('WP_BASE_URL');
+  const username = requireEnv('WP_ADMIN_USER');
+  const password = requireEnv('WP_ADMIN_PASSWORD');
+  const adminPath = env('WP_ADMIN_PATH', '/wp-admin');
+
+  await page.goto(urlFor(baseUrl, '/wp-login.php'));
+  await expect(page.locator('#user_login')).toBeVisible();
+  await page.locator('#user_login').fill(username);
+  await page.locator('#user_pass').fill(password);
+  await page.locator('#wp-submit').click();
+
+  await page.waitForLoadState('domcontentloaded');
+  await handleAdminEmailVerification(page);
+  await page.goto(urlFor(baseUrl, adminPath));
+  await expectWpAdmin(page);
+
+  return baseUrl;
+}

--- a/tests/e2e/nmkr-admin.smoke.spec.ts
+++ b/tests/e2e/nmkr-admin.smoke.spec.ts
@@ -1,70 +1,13 @@
-import { expect, Page, test } from '@playwright/test';
-
-const requiredEnv = ['WP_BASE_URL', 'WP_ADMIN_USER', 'WP_ADMIN_PASSWORD'] as const;
-
-function env(name: string, fallback = ''): string {
-  return process.env[name] || fallback;
-}
-
-function requireEnv(name: (typeof requiredEnv)[number]): string {
-  const value = process.env[name];
-
-  if (!value) {
-    throw new Error(`Missing required environment variable: ${name}`);
-  }
-
-  return value;
-}
-
-function urlFor(baseUrl: string, path: string): string {
-  return new URL(path, baseUrl).toString();
-}
-
-function cssAttrValue(value: string): string {
-  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-}
-
-async function handleAdminEmailVerification(page: Page): Promise<void> {
-  const emailVerificationHeading = page.getByRole('heading', {
-    name: /administration email verification/i,
-  });
-
-  if (await emailVerificationHeading.isVisible({ timeout: 3000 }).catch(() => false)) {
-    const confirmButton = page.getByRole('button', { name: /email is correct/i });
-
-    if (await confirmButton.isVisible({ timeout: 3000 }).catch(() => false)) {
-      await confirmButton.click();
-      await page.waitForLoadState('domcontentloaded');
-    }
-  }
-}
-
-async function expectWpAdmin(page: Page): Promise<void> {
-  await expect(page).toHaveURL(/wp-admin/);
-  await expect(page.locator('#wpadminbar, #adminmenu, #wpbody-content').first()).toBeVisible();
-}
+import { expect, test } from '@playwright/test';
+import { cssAttrValue, env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
 
 test.describe('NMKR Connect WordPress admin smoke test', () => {
   test('loads admin, plugin pages, and safe Phase 1 controls', async ({ page }) => {
-    const baseUrl = requireEnv('WP_BASE_URL');
-    const username = requireEnv('WP_ADMIN_USER');
-    const password = requireEnv('WP_ADMIN_PASSWORD');
-    const adminPath = env('WP_ADMIN_PATH', '/wp-admin');
+    const baseUrl = await loginToWpAdmin(page);
     const dashboardPath = env('NMKR_DASHBOARD_PATH', '/wp-admin/admin.php?page=nmkr-connect-dashboard');
     const settingsPath = env('NMKR_SETTINGS_PATH', '/wp-admin/options-general.php?page=nmkr-connect-settings');
     const pluginSlug = env('NMKR_PLUGIN_SLUG', 'nmkr-connect/nmkr-connect.php');
     const runRealSync = env('RUN_REAL_SYNC', 'false') === 'true';
-
-    await page.goto(urlFor(baseUrl, '/wp-login.php'));
-    await expect(page.locator('#user_login')).toBeVisible();
-    await page.locator('#user_login').fill(username);
-    await page.locator('#user_pass').fill(password);
-    await page.locator('#wp-submit').click();
-
-    await page.waitForLoadState('domcontentloaded');
-    await handleAdminEmailVerification(page);
-    await page.goto(urlFor(baseUrl, adminPath));
-    await expectWpAdmin(page);
 
     await page.goto(urlFor(baseUrl, '/wp-admin/plugins.php'));
     await expectWpAdmin(page);
@@ -83,17 +26,9 @@ test.describe('NMKR Connect WordPress admin smoke test', () => {
     await expect(page).toHaveURL(/page=nmkr-connect-settings/);
     await expect(page.locator('body')).toContainText(/NMKR|Connect|Settings/i);
 
-    const apiKeyField = page
-      .locator('input[type="password"], input[name*="api" i], input[id*="api" i]')
-      .first();
-
+    const apiKeyField = page.locator('#nmkr_api_key');
     await expect(apiKeyField).toBeVisible();
-
-    const apiKeyValue = await apiKeyField.inputValue();
-
-    if (apiKeyValue) {
-      expect(apiKeyValue.trim().length).toBeGreaterThan(0);
-    }
+    await expect(apiKeyField).toHaveAttribute('type', 'password');
 
     const syncProfileControl = page
       .locator('select[name*="profile" i], input[name*="profile" i], select[id*="profile" i], input[id*="profile" i]')

--- a/tests/e2e/nmkr-settings.regression.spec.ts
+++ b/tests/e2e/nmkr-settings.regression.spec.ts
@@ -1,0 +1,71 @@
+import { expect, Locator, test } from '@playwright/test';
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
+
+async function expectType(locator: Locator, type: string): Promise<void> {
+  await expect(locator).toBeVisible();
+  await expect(locator).toHaveAttribute('type', type);
+}
+
+async function expectSelectOptions(select: Locator, values: string[]): Promise<void> {
+  await expect(select).toBeVisible();
+
+  for (const value of values) {
+    await expect(select.locator(`option[value="${value}"]`)).toHaveCount(1);
+  }
+}
+
+test.describe('NMKR Connect settings page regression', () => {
+  test('loads settings controls without changing persisted options', async ({ page }) => {
+    const baseUrl = await loginToWpAdmin(page);
+    const settingsPath = env('NMKR_SETTINGS_PATH', '/wp-admin/options-general.php?page=nmkr-connect-settings');
+
+    await page.goto(urlFor(baseUrl, settingsPath));
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-settings/);
+    await expect(page.locator('body')).toContainText(/NMKR|Connect|Settings/i);
+
+    await expect(page.locator('form[action="options.php"][method="post"]')).toBeVisible();
+
+    await expect(page.getByText('API Settings', { exact: true })).toBeVisible();
+    await expect(page.getByText('Synchronization Settings', { exact: true })).toBeVisible();
+    await expect(page.getByText('Debug Settings', { exact: true })).toBeVisible();
+    await expect(page.getByText('Analytics & Privacy', { exact: true })).toBeVisible();
+
+    await expectType(page.locator('#nmkr_api_key'), 'password');
+    await expectType(page.locator('#toggle_api_key_visibility'), 'button');
+
+    await expectSelectOptions(page.locator('#nmkr_sync_profile'), ['light', 'balanced', 'aggressive', 'custom']);
+    await expectType(page.locator('#nmkr_sync_batch_size'), 'number');
+    await expectType(page.locator('#nmkr_sync_batch_delay'), 'number');
+    await expectType(page.locator('input[name="nmkr_connect_options[sync_initial_interval]"]'), 'number');
+    await expectType(page.locator('input[name="nmkr_connect_options[sync_max_interval]"]'), 'number');
+    await expectType(page.locator('input[name="nmkr_connect_options[sync_interval_increase]"]'), 'number');
+    await expectType(page.locator('input[name="nmkr_connect_options[sync_interval_decrease]"]'), 'number');
+    await expectType(page.locator('input[name="nmkr_connect_options[sync_max_errors]"]'), 'number');
+
+    await expectType(page.locator('#nmkr_debug_enabled'), 'checkbox');
+    await expectType(page.locator('#nmkr_log_to_debug_file'), 'checkbox');
+    await expectType(page.locator('#nmkr_log_to_dashboard'), 'checkbox');
+    await expectType(page.locator('#nmkr_api_debug_enabled'), 'checkbox');
+    await expectType(page.locator('#nmkr_sync_debug_enabled'), 'checkbox');
+    await expectType(page.locator('#nmkr_ui_debug_enabled'), 'checkbox');
+    await expectType(page.locator('#nmkr_performance_debug_enabled'), 'checkbox');
+    await expectType(page.locator('#nmkr_log_throttle_enabled'), 'checkbox');
+    await expectType(page.locator('#nmkr_log_retention_limit'), 'number');
+    await expect(page.locator('#nmkr-dashboard-sync-logging-status')).toBeVisible();
+    await expect(page.locator('#nmkr-dashboard-sync-logging-status-text')).toBeVisible();
+
+    await expectSelectOptions(page.locator('#nmkr_analytics_mode'), ['off', 'custom', 'ga4', 'both']);
+    await expectType(page.locator('#nmkr_ga4_measurement_id'), 'text');
+    await expectType(page.locator('#nmkr_ga4_api_secret'), 'password');
+    await expectType(page.locator('#nmkr_analytics_retention_days'), 'number');
+    await expectType(page.locator('#nmkr_analytics_sample_rate'), 'number');
+    await expectType(page.locator('#nmkr_analytics_track_logged_in'), 'checkbox');
+    await expectType(page.locator('#nmkr_analytics_require_consent'), 'checkbox');
+    await expectType(page.locator('#nmkr_analytics_remove_on_uninstall'), 'checkbox');
+    await expectType(page.locator('#nmkr_analytics_debug'), 'checkbox');
+
+    await expect(page.getByRole('button', { name: 'Save Settings' })).toBeVisible();
+    await expectType(page.locator('#nmkr-reset-defaults'), 'button');
+  });
+});


### PR DESCRIPTION
### Motivation

- Add Phase 3 safe, non-mutating Playwright coverage for the NMKR Connect settings page to detect regressions in admin UI without changing persisted options or exposing secrets.
- Reduce duplication by extracting reusable admin helpers for login, env handling, URL/CSS utilities, and admin-shell assertions.

### Description

- Added shared helper module `tests/e2e/helpers/wp-admin.ts` that exports `env`, `requireEnv`, `urlFor`, `cssAttrValue`, `handleAdminEmailVerification`, `expectWpAdmin`, and `loginToWpAdmin` for reuse across Playwright specs.
- Updated `tests/e2e/nmkr-admin.smoke.spec.ts` to use the shared helpers and hardened the API key assertion to check presence and `type=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f441fe0208333bce05a436b9a9c0f)