### PR TITLE
Add dashboard page regression test

### DIFF
--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -1,8 +1,8 @@
-# Phase 3 settings-page regression coverage
+# Phase 3 Playwright regression coverage
 
-Phase 3 adds the first safe Playwright regression check for the NMKR Connect settings page. The goal is to verify the admin settings page structure and important controls without mutating WordPress options or exposing private configuration.
+Phase 3 adds safe Playwright regression checks for the NMKR Connect WordPress admin pages. These tests verify page structure and important controls without mutating WordPress options, starting synchronization, clearing logs, or exposing private configuration.
 
-## What the settings regression covers
+## Settings-page regression
 
 The settings regression is implemented in `tests/e2e/nmkr-settings.regression.spec.ts`. It logs in with the existing WordPress admin test environment variables, opens `NMKR_SETTINGS_PATH` (defaulting to `/wp-admin/options-general.php?page=nmkr-connect-settings`), and verifies that the WordPress admin shell, NMKR settings page, settings form, sections, and key controls are present.
 
@@ -14,9 +14,9 @@ The test confirms broad coverage for:
 - Analytics & Privacy
 - Save Settings and Reset to Defaults controls
 
-## Non-mutating safety guarantees
+### Settings safety guarantees
 
-The Phase 3 settings regression is intentionally non-mutating:
+The settings regression is intentionally non-mutating:
 
 - It does not click **Save Settings**.
 - It does not click **Reset to Defaults**.
@@ -29,22 +29,55 @@ The Phase 3 settings regression is intentionally non-mutating:
 
 The test uses presence and basic attribute assertions for secret fields, such as checking that API key and GA4 API secret inputs exist and remain `type="password"`.
 
+## Dashboard-page regression
+
+The dashboard regression is implemented in `tests/e2e/nmkr-dashboard.regression.spec.ts`. It logs in with the same shared WordPress admin helpers, opens `NMKR_DASHBOARD_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-dashboard`), and verifies that the WordPress admin shell, NMKR dashboard shell, dashboard panels, status/progress structure, statistics structure, and key controls are present.
+
+The test confirms broad coverage for:
+
+- NMKR Connect Dashboard shell
+- API Connection Status panel
+- Data Synchronization panel
+- Hidden nonce input presence and type
+- Sync progress and active metric containers
+- Previous Synchronization Statistics panel
+- Optional Debug Logs panel structure when dashboard logging is enabled
+
+### Dashboard safety guarantees
+
+The dashboard regression is intentionally non-mutating:
+
+- It does not click **Start Synchronization**.
+- It does not click **Stop Synchronization**.
+- It does not click **Refresh Status**.
+- It does not click **Clear Logs**.
+- It does not click, fill, or change debug log search/filter controls.
+- It treats the Debug Logs panel as optional because it depends on `nmkr_connect_options['log_to_dashboard']`.
+- It does not require optional Debug Logs controls when dashboard logging is disabled.
+- It does not read, print, snapshot, or assert nonce values.
+- It does not inspect debug log entries, messages, payloads, timestamps, counts, or log text.
+- It does not assert exact sync metric or performance statistic values, which may vary by environment.
+
+The test uses attachment, role, attribute, and element type assertions for controls that may be hidden by default or may not include explicit `type="button"` attributes.
+
 ## Running Phase 3 locally
 
-The settings regression is included in the default Playwright suite:
+Both Phase 3 regressions are included in the default Playwright suite:
 
 ```bash
 npm run test:e2e
 ```
 
-It can also be listed or run directly with:
+They can also be listed or run directly with:
 
 ```bash
 npm run test:e2e:settings -- --list
 npm run test:e2e:settings
+npm run test:e2e:dashboard -- --list
+npm run test:e2e:dashboard
 ```
 
-Because the Phase 2 runner executes `npm run test:e2e`, the Phase 3 settings regression is automatically included in Phase 2 VM validation.
+Because the Phase 2 runner executes `npm run test:e2e`, both Phase 3 regressions are automatically included in Phase 2 VM validation.
 
 ## Artifacts and public safety
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test:e2e": "playwright test",
     "test:e2e:report": "playwright show-report",
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
-    "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts"
+    "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts",
+    "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/tests/e2e/nmkr-dashboard.regression.spec.ts
+++ b/tests/e2e/nmkr-dashboard.regression.spec.ts
@@ -1,0 +1,100 @@
+import { expect, Locator, test } from '@playwright/test';
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
+
+async function expectButtonElement(locator: Locator): Promise<void> {
+  await expect(locator).toBeAttached();
+  await expect(locator).toHaveJSProperty('tagName', 'BUTTON');
+}
+
+async function expectHiddenInput(locator: Locator): Promise<void> {
+  await expect(locator).toBeAttached();
+  await expect(locator).toHaveJSProperty('tagName', 'INPUT');
+  await expect(locator).toHaveAttribute('type', 'hidden');
+}
+
+test.describe('NMKR Connect dashboard page regression', () => {
+  test('loads dashboard structure and safe controls without mutating state', async ({ page }) => {
+    const baseUrl = await loginToWpAdmin(page);
+    const dashboardPath = env('NMKR_DASHBOARD_PATH', '/wp-admin/admin.php?page=nmkr-connect-dashboard');
+
+    await page.goto(urlFor(baseUrl, dashboardPath));
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-dashboard/);
+
+    const dashboard = page.locator('.wrap.nmkr-dashboard');
+    await expect(dashboard).toBeAttached();
+    await expect(page.locator('body')).toContainText(/NMKR Connect Dashboard/i);
+
+    const apiPanel = page.locator('.api-status-panel');
+    await expect(apiPanel).toBeAttached();
+    await expect(apiPanel).toContainText('API Connection Status');
+    await expect(apiPanel.locator('#api-status')).toBeAttached();
+    await expectButtonElement(apiPanel.locator('#refresh-api-status'));
+
+    const syncPanel = page.locator('.sync-data');
+    await expect(syncPanel).toBeAttached();
+    await expect(syncPanel).toContainText('Data Synchronization');
+    await expectButtonElement(syncPanel.locator('#nmkr-sync-button'));
+    await expectButtonElement(syncPanel.locator('#nmkr-stop-sync-button'));
+
+    await expectHiddenInput(page.locator('#nmkr-sync-nonce'));
+    await expectHiddenInput(page.locator('#nmkr-dashboard-nonce'));
+
+    const progressContainer = page.locator('#nmkr-sync-progress-container');
+    await expect(progressContainer).toBeAttached();
+    await expect(progressContainer).toHaveAttribute('role', 'progressbar');
+    await expect(page.locator('#nmkr-sync-progress-bar')).toBeAttached();
+    await expect(page.locator('#status-message')).toHaveAttribute('aria-live', 'polite');
+    await expect(page.locator('#nmkr-sync-phase-label')).toBeAttached();
+    await expect(page.locator('#active-sync-metrics')).toBeAttached();
+
+    for (const selector of [
+      '.total-projects-active',
+      '.total-tokens-active',
+      '.total-sync-duration-active',
+      '.total-api-time-active',
+      '.avg-response-time',
+      '.api-requests',
+      '.memory-usage',
+    ]) {
+      await expect(page.locator(selector).first()).toBeAttached();
+    }
+
+    const statisticsPanel = page.locator('.sync-statistics');
+    await expect(statisticsPanel).toBeAttached();
+    await expect(statisticsPanel).toContainText('Previous Synchronization Statistics');
+
+    for (const selector of [
+      '#last-synced',
+      '#performance-stats',
+      '#total-projects',
+      '#total-tokens',
+      '#total-sync-time',
+      '#total-api-time',
+      '#avg-response-time',
+      '#request-count',
+      '#memory-usage',
+      '#performance-legend',
+    ]) {
+      await expect(statisticsPanel.locator(selector)).toBeAttached();
+    }
+
+    const debugLogsPanel = page.locator('.debug-logs-panel');
+
+    if (await debugLogsPanel.isVisible().catch(() => false)) {
+      for (const selector of [
+        '#nmkr-debug-logs',
+        '.debug-logs-panel',
+        '#nmkr-log-search',
+        '#nmkr-log-type-filter',
+        '#nmkr-log-category-filter',
+        '#nmkr-clear-filters',
+        '#nmkr-clear-all-logs',
+        '.clear-section-logs-btn',
+        '.log-section',
+      ]) {
+        await expect(page.locator(selector).first()).toBeAttached();
+      }
+    }
+  });
+});


### PR DESCRIPTION
### Motivation
- Add a safe, non-mutating Phase 3 Playwright regression that verifies the NMKR Connect dashboard structure and key controls without changing runtime state or exposing secrets.
- Follow the existing settings-regression pattern and reuse shared admin helpers to minimize duplication and keep tests focused on structure-only checks.

### Description
- Add `tests/e2e/nmkr-dashboard.regression.spec.ts` which reuses `loginToWpAdmin`, `env`, `urlFor`, and `expectWpAdmin` and asserts dashboard shell, API panel, sync panel, nonce inputs, sync progress structure, active metrics, previous statistics, and optional debug-logs structure without clicking or reading secrets.
- Add `test:e2e:dashboard` npm script to `package.json` while preserving existing `test:e2e`, `test:e2e:settings`, and `test:phase2` scripts.
- Update `docs/testing-phase-3.md` to document the dashboard regression purpose, its non-mutating guarantees (no Start/Stop/Refresh/Clear, no nonce/log reads), optional Debug Logs behavior, and how to run the new regression.

### Testing
- Ran `npm run test:e2e -- --list` which listed three tests total: the smoke test, the new dashboard regression, and the settings regression, as expected.
- Ran `npm run test:e2e:dashboard -- --list` which listed only the dashboard regression spec, confirming the script targets the single test file.
- Verified environment limitation with a check for `WP_BASE_URL`, `WP_ADMIN_USER`, and `WP_ADMIN_PASSWORD` which are not present in this execution environment, so full live `playwright` runs were not executed here and should be validated on the GCP dev VM.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4a7910c08333a3a71f8498475031)