### PR TITLE
Add projects page regression test

### DIFF
--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -62,9 +62,41 @@ The dashboard regression is intentionally non-mutating:
 
 The test uses attachment, role, attribute, and element type assertions for controls that may be hidden by default or may not include explicit `type="button"` attributes.
 
+## Projects-page regression
+
+The projects regression is implemented in `tests/e2e/nmkr-projects.regression.spec.ts`. It logs in with the shared WordPress admin helpers, opens `NMKR_PROJECTS_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-projects`), and verifies the default **no project selected** state for the NMKR Projects and Tokens admin page.
+
+The test confirms focused coverage for:
+
+- NMKR Projects and Tokens admin shell
+- Your Projects panel heading
+- Informational box presence
+- Project selector form structure
+- Project selector `method="post"` form attribute
+- `select#project_uid[name="project_uid"]` presence
+- Project selector `onchange="this.form.submit()"` attribute
+- Exactly one empty placeholder option with `-- Select a Project --` text
+- Empty selected value remaining selected by default
+
+### Projects safety guarantees
+
+The projects regression installs an `admin-ajax.php` route guard before navigating to the Projects page. The guard records and locally fulfills unexpected sync or mutation-oriented actions so they do not reach WordPress, then fails the test if any of those actions were attempted during page load. Guarded actions include sync start/stop, active metric storage, sync statistics reads, log clearing, and sync progress polling.
+
+The projects regression is intentionally non-mutating:
+
+- It checks only the default no-project-selected state.
+- It does not select a project.
+- It does not submit the project selector form.
+- It does not fill, change, or submit token search or filter controls.
+- It does not run real NMKR sync.
+- It does not inspect project descriptions, synchronized project option names, token names, token metadata, image URLs, payment gateway links, or project URLs.
+- It does not count synchronized project options.
+- It does not click token images, Buy Now links, project website links, external links, or lightbox interactions.
+- It does not require selected-project or token-grid controls in this first default-state regression.
+
 ## Running Phase 3 locally
 
-Both Phase 3 regressions are included in the default Playwright suite:
+The Phase 3 regressions are included in the default Playwright suite:
 
 ```bash
 npm run test:e2e
@@ -77,9 +109,27 @@ npm run test:e2e:settings -- --list
 npm run test:e2e:settings
 npm run test:e2e:dashboard -- --list
 npm run test:e2e:dashboard
+npm run test:e2e:projects -- --list
+npm run test:e2e:projects
 ```
 
-Because the Phase 2 runner executes `npm run test:e2e`, both Phase 3 regressions are automatically included in Phase 2 VM validation.
+Direct targeted Playwright scripts do not automatically load `NMKR_PHASE2_ENV_FILE`. For direct targeted runs on the VM, source the private environment first, then run the targeted script:
+
+```bash
+set -a
+source "$HOME/.config/nmkr-connect/phase2.env"
+set +a
+
+npm run test:e2e:projects
+```
+
+Because the Phase 2 runner executes `npm run test:e2e`, the Phase 3 regressions are automatically included in Phase 2 VM validation. Full Phase 2 validation should continue to use:
+
+```bash
+NMKR_PHASE2_ENV_FILE="$HOME/.config/nmkr-connect/phase2.env" \
+NMKR_PHASE2_LOG_DIR="$HOME/.local/state/nmkr-connect-phase2" \
+npm run test:phase2
+```
 
 ## Artifacts and public safety
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "test:e2e:report": "playwright show-report",
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
     "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts",
-    "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts"
+    "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts",
+    "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/tests/e2e/nmkr-projects.regression.spec.ts
+++ b/tests/e2e/nmkr-projects.regression.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
+
+const blockedProjectsAjaxActions = new Set([
+  'nmkr_start_sync',
+  'nmkr_stop_sync',
+  'nmkr_store_active_metrics',
+  'nmkr_get_sync_statistics',
+  'nmkr_clear_all_logs',
+  'nmkr_clear_section_logs',
+  'nmkr_sync_progress',
+]);
+
+test.describe('NMKR Connect projects page regression', () => {
+  test('loads default project selector state without selecting a project', async ({ page }) => {
+    const baseUrl = await loginToWpAdmin(page);
+    const projectsPath = env('NMKR_PROJECTS_PATH', '/wp-admin/admin.php?page=nmkr-connect-projects');
+    const unexpectedProjectsAjaxActions: string[] = [];
+
+    await page.route('**/wp-admin/admin-ajax.php', async (route, request) => {
+      const postData = request.postData();
+      const action = postData ? new URLSearchParams(postData).get('action') : null;
+
+      if (action && blockedProjectsAjaxActions.has(action)) {
+        unexpectedProjectsAjaxActions.push(action);
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { message: 'Test stub: projects AJAX action skipped.' } }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto(urlFor(baseUrl, projectsPath));
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-projects/);
+
+    const projectsDashboard = page.locator('.wrap.nmkr-dashboard');
+    await expect(projectsDashboard).toBeAttached();
+    await expect(page.getByRole('heading', { name: 'NMKR Projects and Tokens' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Your Projects' })).toBeVisible();
+    await expect(page.locator('.nmkr-info-box')).toBeAttached();
+
+    const projectSelectorForm = page.locator('form.project-selector-form');
+    await expect(projectSelectorForm).toBeAttached();
+    await expect(projectSelectorForm).toHaveAttribute('method', 'post');
+
+    const projectSelect = projectSelectorForm.locator('select#project_uid[name="project_uid"]');
+    await expect(projectSelect).toBeAttached();
+    await expect(projectSelect).toHaveAttribute('onchange', 'this.form.submit()');
+
+    const placeholderOption = projectSelect.locator('option[value=""]');
+    await expect(placeholderOption).toHaveCount(1);
+    await expect(placeholderOption).toHaveText('-- Select a Project --');
+    await expect(projectSelect).toHaveValue('');
+
+    expect(unexpectedProjectsAjaxActions).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation

- Add a safe Phase 3 Playwright regression that validates the NMKR Projects admin page in the default no-project-selected state without mutating WordPress state.
- Prevent page-load side-effects from background sync/polling by guarding `admin-ajax.php` and failing the test if mutation-oriented actions are attempted. 
- Make the Projects regression available as a targeted npm script and document running guidance for direct VM runs that require private env sourcing.

### Description

- Add `tests/e2e/nmkr-projects.regression.spec.ts` which reuses shared helpers (`loginToWpAdmin`, `env`, `urlFor`, `expectWpAdmin`), installs a route guard for `**/wp-admin/admin-ajax.php`, records and locally-fulfills blocked sync/mutation actions, and asserts the default project selector structure and page shell without selecting or submitting anything. 
- Update `package.json` to add the `test:e2e:projects` script as `playwright test tests/e2e/nmkr-projects.regression.spec.ts` while preserving existing scripts. 
- Update `docs/testing-phase-3.md` to add a Projects-page regression section describing purpose, non-mutating guarantees, AJAX guard behavior, selector structure checks, and direct-target run instructions including example private env sourcing and inclusion in Phase 2 validation. 

### Testing

- Ran `npm run test:e2e -- --list` which listed four tests (smoke, dashboard, projects, settings) as expected. 
- Ran `npm run test:e2e:projects -- --list` which listed only the new Projects regression test as expected. 
- Live execution of `npm run test:e2e:projects` was skipped because `WP_BASE_URL`, `WP_ADMIN_USER`, and `WP_ADMIN_PASSWORD` were not present in the environment; live validation should be performed on the GCP dev VM after sourcing the private Phase 2 env using the documented `set -a`/`source`/`set +a` commands.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5d60f180833397c3c1fadf424221)