### PR TITLE
Add shortcodes page regression test

### DIFF
--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -94,6 +94,35 @@ The projects regression is intentionally non-mutating:
 - It does not click token images, Buy Now links, project website links, external links, or lightbox interactions.
 - It does not require selected-project or token-grid controls in this first default-state regression.
 
+## Shortcodes-page regression
+
+The shortcodes regression is implemented in `tests/e2e/nmkr-shortcodes.regression.spec.ts`. It logs in with the shared WordPress admin helpers, opens `NMKR_SHORTCODES_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-shortcodes`), and verifies the NMKR Connect Shortcodes admin page structure and shortcode reference headings.
+
+The test confirms focused structural coverage for:
+
+- NMKR Connect Shortcodes admin shell
+- Main `NMKR Connect - Shortcodes` page heading
+- `Available Shortcodes` panel heading
+- Informational box presence
+- Stable shortcode reference headings for `[nmkr-grid]`, `[nmkr-token-list]`, `[nmkr-carousel]`, `[nmkr-token]`, and `[nmkr-project]`
+
+### Shortcodes safety guarantees
+
+The shortcodes regression installs an `admin-ajax.php` route guard before navigating to the Shortcodes page. The guard records and locally fulfills unexpected sync or mutation-oriented actions so they do not reach WordPress, then fails the test if any guarded action was attempted during page load. Guarded actions include sync start/stop, active metric storage, sync statistics reads, log clearing, and sync progress polling.
+
+The shortcodes regression is intentionally non-mutating:
+
+- It performs structural-only shortcode reference checks.
+- It does not click Freemius upgrade links, internal links, or external links.
+- It does not inspect or assert upgrade URLs.
+- It does not navigate to external URLs.
+- It does not render shortcodes on the frontend.
+- It does not create posts or pages.
+- It does not save options or submit forms.
+- It does not run real NMKR sync.
+- It does not inspect customer project or token data.
+- It avoids plan-specific premium/free upsell copy assertions because rendered copy may differ by license state.
+
 ## Running Phase 3 locally
 
 The Phase 3 regressions are included in the default Playwright suite:
@@ -111,6 +140,8 @@ npm run test:e2e:dashboard -- --list
 npm run test:e2e:dashboard
 npm run test:e2e:projects -- --list
 npm run test:e2e:projects
+npm run test:e2e:shortcodes -- --list
+npm run test:e2e:shortcodes
 ```
 
 Direct targeted Playwright scripts do not automatically load `NMKR_PHASE2_ENV_FILE`. For direct targeted runs on the VM, source the private environment first, then run the targeted script:
@@ -120,7 +151,7 @@ set -a
 source "$HOME/.config/nmkr-connect/phase2.env"
 set +a
 
-npm run test:e2e:projects
+npm run test:e2e:shortcodes
 ```
 
 Because the Phase 2 runner executes `npm run test:e2e`, the Phase 3 regressions are automatically included in Phase 2 VM validation. Full Phase 2 validation should continue to use:

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
     "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts",
     "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts",
-    "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts"
+    "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts",
+    "test:e2e:shortcodes": "playwright test tests/e2e/nmkr-shortcodes.regression.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/tests/e2e/nmkr-shortcodes.regression.spec.ts
+++ b/tests/e2e/nmkr-shortcodes.regression.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
+
+const blockedShortcodesAjaxActions = new Set([
+  'nmkr_start_sync',
+  'nmkr_stop_sync',
+  'nmkr_store_active_metrics',
+  'nmkr_get_sync_statistics',
+  'nmkr_clear_all_logs',
+  'nmkr_clear_section_logs',
+  'nmkr_sync_progress',
+]);
+
+test.describe('NMKR Connect shortcodes page regression', () => {
+  test('loads shortcode reference structure without mutating state', async ({ page }) => {
+    const baseUrl = await loginToWpAdmin(page);
+    const shortcodesPath = env('NMKR_SHORTCODES_PATH', '/wp-admin/admin.php?page=nmkr-connect-shortcodes');
+    const unexpectedShortcodesAjaxActions: string[] = [];
+
+    await page.route('**/wp-admin/admin-ajax.php', async (route, request) => {
+      const postData = request.postData();
+      const action = postData ? new URLSearchParams(postData).get('action') : null;
+
+      if (action && blockedShortcodesAjaxActions.has(action)) {
+        unexpectedShortcodesAjaxActions.push(action);
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { message: 'Test stub: shortcodes AJAX action skipped.' } }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto(urlFor(baseUrl, shortcodesPath));
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-shortcodes/);
+
+    const shortcodesDashboard = page.locator('.wrap.nmkr-dashboard');
+    await expect(shortcodesDashboard).toBeAttached();
+    await expect(page.getByRole('heading', { name: 'NMKR Connect - Shortcodes' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Available Shortcodes' })).toBeVisible();
+    await expect(page.locator('.nmkr-info-box').first()).toBeAttached();
+
+    for (const shortcodeHeading of ['[nmkr-grid]', '[nmkr-token-list]', '[nmkr-carousel]', '[nmkr-token]', '[nmkr-project]']) {
+      await expect(page.getByRole('heading', { name: shortcodeHeading })).toBeVisible();
+    }
+
+    expect(unexpectedShortcodesAjaxActions).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation

- Implement a Phase 3 Playwright regression that verifies the NMKR Connect Shortcodes admin page structure and shortcode reference headings while guaranteeing no WordPress state changes. 

### Description

- Add a new spec `tests/e2e/nmkr-shortcodes.regression.spec.ts` that reuses `loginToWpAdmin`, `env`, `urlFor`, and `expectWpAdmin` from `tests/e2e/helpers/wp-admin.ts` and targets `NMKR_SHORTCODES_PATH` (default `/wp-admin/admin.php?page=nmkr-connect-shortcodes`).
- Install an `admin-ajax.php` route guard in the spec that inspects `action` from POST data, blocks and locally fulfills any of the guarded sync/mutation actions (`nmkr_start_sync`, `nmkr_stop_sync`, `nmkr_store_active_metrics`, `nmkr_get_sync_statistics`, `nmkr_clear_all_logs`, `nmkr_clear_section_logs`, `nmkr_sync_progress`), and records unexpected attempts so the test fails if any occur. 
- Assert non-mutating page structure including WordPress admin shell, URL contains `page=nmkr-connect-shortcodes`, `.wrap.nmkr-dashboard` attachment, page heading `NMKR Connect - Shortcodes`, panel heading `Available Shortcodes`, at least one `.nmkr-info-box`, and presence of shortcode reference headings `[nmkr-grid]`, `[nmkr-token-list]`, `[nmkr-carousel]`, `[nmkr-token]`, and `[nmkr-project]`. 
- Add `test:e2e:shortcodes` npm script and update `docs/testing-phase-3.md` with Shortcodes regression purpose, safety guarantees, admin-ajax guard details, and local/VM run commands including direct-env sourcing guidance. 

### Testing

- Ran `npm run test:e2e -- --list` and it listed 5 tests (smoke, dashboard, projects, settings, shortcodes) as expected. 
- Ran `npm run test:e2e:shortcodes -- --list` and it listed only the Shortcodes regression spec as expected. 
- Verified repository checks with `git diff --check` and `git status --short` which showed the new spec, `package.json`, and docs updates staged for inclusion. 
- Live Playwright execution was not run in this environment because required `WP_BASE_URL`, `WP_ADMIN_USER`, and `WP_ADMIN_PASSWORD` env vars were not available; complete live validation should be run on the GCP dev VM using the documented `set -a`/`source` workflow and `npm run test:e2e:shortcodes`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f61f45fb4833399ec1590de528265)