### PR TITLE
Add analytics page regression test

### DIFF
--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -123,6 +123,53 @@ The shortcodes regression is intentionally non-mutating:
 - It does not inspect customer project or token data.
 - It avoids plan-specific premium/free upsell copy assertions because rendered copy may differ by license state.
 
+## Analytics-page regression
+
+The analytics regression is implemented in `tests/e2e/nmkr-analytics.regression.spec.ts`. It logs in with the shared WordPress admin helpers, opens `NMKR_ANALYTICS_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-analytics`), and verifies the Analytics admin page shell plus the JavaScript-rendered analytics controls and containers.
+
+The test confirms focused structural coverage for:
+
+- Analytics admin page shell
+- `Analytics` page heading
+- Filter, KPI, chart, table, and export PHP shell containers
+- Runtime filter controls
+- Runtime KPI containers
+- Runtime chart containers
+- Runtime top projects and top tokens table roots
+- Runtime export selector/status containers
+
+Analytics menu registration is conditional because `NMKR_ANALYTICS_UI_ENABLED` can disable the menu. After login and WordPress admin shell validation, the regression checks for `.wrap.nmkr-analytics-wrap` with a short timeout. If the Analytics UI is unavailable in the environment, the spec skips with an explicit message instead of failing Phase 2 validation. When the Analytics wrapper is present, missing expected shell or runtime controls fail normally.
+
+### Analytics AJAX guard and safety guarantees
+
+The analytics regression installs an `admin-ajax.php` route guard before navigating to the page. Expected page-load Analytics AJAX actions are fulfilled locally with empty, public-safe JSON so real Analytics AJAX requests do not reach WordPress:
+
+- `nmkr_analytics_kpis`
+- `nmkr_analytics_timeseries`
+- `nmkr_analytics_top_projects`
+- `nmkr_analytics_top_tokens`
+
+The guard also records and locally fulfills unexpected sync, mutation, or export-oriented actions, then fails the test if any guarded action was attempted. Guarded actions include sync start/stop, active metric storage, sync statistics reads, log clearing, sync progress polling, Analytics export, and Analytics breakdown requests.
+
+The analytics regression is intentionally non-mutating:
+
+- It does not click **Apply**.
+- It does not change the date range.
+- It does not change the shortcode type.
+- It does not fill search inputs.
+- It does not click table sort headers.
+- It does not click pagination buttons.
+- It does not click export or download controls.
+- It does not trigger `nmkr_analytics_export`.
+- It does not read real analytics database data.
+- It does not inspect or assert customer project or token analytics values.
+- It does not read or assert `project_uid` or `token_uid` values.
+- It does not create posts or pages.
+- It does not save options.
+- It does not run sync.
+
+The Analytics regression is included by default in `npm run test:e2e` and therefore in Phase 2 validation. The spec may skip during those runs when the Analytics UI is disabled by environment configuration.
+
 ## Running Phase 3 locally
 
 The Phase 3 regressions are included in the default Playwright suite:
@@ -142,6 +189,8 @@ npm run test:e2e:projects -- --list
 npm run test:e2e:projects
 npm run test:e2e:shortcodes -- --list
 npm run test:e2e:shortcodes
+npm run test:e2e:analytics -- --list
+npm run test:e2e:analytics
 ```
 
 Direct targeted Playwright scripts do not automatically load `NMKR_PHASE2_ENV_FILE`. For direct targeted runs on the VM, source the private environment first, then run the targeted script:
@@ -151,7 +200,7 @@ set -a
 source "$HOME/.config/nmkr-connect/phase2.env"
 set +a
 
-npm run test:e2e:shortcodes
+npm run test:e2e:analytics
 ```
 
 Because the Phase 2 runner executes `npm run test:e2e`, the Phase 3 regressions are automatically included in Phase 2 VM validation. Full Phase 2 validation should continue to use:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts",
     "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts",
     "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts",
-    "test:e2e:shortcodes": "playwright test tests/e2e/nmkr-shortcodes.regression.spec.ts"
+    "test:e2e:shortcodes": "playwright test tests/e2e/nmkr-shortcodes.regression.spec.ts",
+    "test:e2e:analytics": "playwright test tests/e2e/nmkr-analytics.regression.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/tests/e2e/nmkr-analytics.regression.spec.ts
+++ b/tests/e2e/nmkr-analytics.regression.spec.ts
@@ -1,0 +1,160 @@
+import { expect, Locator, test } from '@playwright/test';
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
+
+async function expectButtonElement(locator: Locator): Promise<void> {
+  await expect(locator).toBeAttached();
+  await expect(locator).toHaveJSProperty('tagName', 'BUTTON');
+}
+
+const analyticsPageLoadAjaxResponses = new Map<string, object>([
+  [
+    'nmkr_analytics_kpis',
+    {
+      success: true,
+      data: {
+        views: 0,
+        clicks: 0,
+        ctr: 0,
+        range: {
+          from: '',
+          to: '',
+          label: '7d',
+        },
+      },
+    },
+  ],
+  [
+    'nmkr_analytics_timeseries',
+    {
+      success: true,
+      data: {
+        series: [],
+        from: '',
+        to: '',
+        bucket: 'day',
+      },
+    },
+  ],
+  [
+    'nmkr_analytics_top_projects',
+    {
+      success: true,
+      data: {
+        rows: [],
+        total: 0,
+        page: 1,
+        per_page: 10,
+        sort: 'views',
+        order: 'desc',
+        range: {
+          from: '',
+          to: '',
+        },
+      },
+    },
+  ],
+  [
+    'nmkr_analytics_top_tokens',
+    {
+      success: true,
+      data: {
+        rows: [],
+        total: 0,
+        page: 1,
+        per_page: 10,
+        sort: 'views',
+        order: 'desc',
+        range: {
+          from: '',
+          to: '',
+        },
+      },
+    },
+  ],
+]);
+
+const blockedAnalyticsAjaxActions = new Set([
+  'nmkr_start_sync',
+  'nmkr_stop_sync',
+  'nmkr_store_active_metrics',
+  'nmkr_get_sync_statistics',
+  'nmkr_clear_all_logs',
+  'nmkr_clear_section_logs',
+  'nmkr_sync_progress',
+  'nmkr_analytics_export',
+  'nmkr_analytics_breakdown',
+]);
+
+test.describe('NMKR Connect analytics page regression', () => {
+  test('loads analytics shell and safe runtime controls without reading analytics data', async ({ page }) => {
+    const baseUrl = await loginToWpAdmin(page);
+    const analyticsPath = env('NMKR_ANALYTICS_PATH', '/wp-admin/admin.php?page=nmkr-connect-analytics');
+    const unexpectedAnalyticsAjaxActions: string[] = [];
+
+    await page.route('**/wp-admin/admin-ajax.php', async (route, request) => {
+      const postData = request.postData();
+      const action = postData ? new URLSearchParams(postData).get('action') : null;
+
+      if (action && analyticsPageLoadAjaxResponses.has(action)) {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify(analyticsPageLoadAjaxResponses.get(action)),
+        });
+        return;
+      }
+
+      if (action && blockedAnalyticsAjaxActions.has(action)) {
+        unexpectedAnalyticsAjaxActions.push(action);
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { message: 'Test stub: analytics AJAX action skipped.' } }),
+        });
+        return;
+      }
+
+      await route.continue();
+    });
+
+    await page.goto(urlFor(baseUrl, analyticsPath));
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-analytics/);
+
+    const analyticsWrap = page.locator('.wrap.nmkr-analytics-wrap');
+    const analyticsAvailable = await analyticsWrap.isVisible({ timeout: 3000 }).catch(() => false);
+
+    test.skip(!analyticsAvailable, 'Analytics UI is not available in this environment.');
+
+    await expect(analyticsWrap).toBeAttached();
+    await expect(page.getByRole('heading', { name: 'Analytics' })).toBeVisible();
+
+    for (const selector of [
+      '#nmkr-analytics-filters',
+      '#nmkr-analytics-kpis',
+      '#nmkr-analytics-charts',
+      '#nmkr-analytics-tables',
+      '#nmkr-analytics-exports',
+    ]) {
+      await expect(page.locator(selector)).toBeAttached();
+    }
+
+    for (const selector of [
+      '#nmkr-f-range',
+      '#nmkr-f-type',
+      '#nmkr-kpi-views',
+      '#nmkr-kpi-clicks',
+      '#nmkr-kpi-ctr',
+      '#nmkr-chart-views-cv',
+      '#nmkr-chart-clicks-cv',
+      '#nmkr-top-projects-root',
+      '#nmkr-top-tokens-root',
+      '#nmkr-exp-what',
+      '#nmkr-exp-fmt',
+      '#nmkr-exp-status',
+    ]) {
+      await expect(page.locator(selector)).toBeAttached();
+    }
+
+    await expectButtonElement(page.locator('#nmkr-f-apply'));
+    expect(unexpectedAnalyticsAjaxActions).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation

- Add a safe Phase 3 Playwright regression to verify the NMKR Connect Analytics admin page shell and JS-rendered UI without reading real analytics data or mutating WordPress state.

### Description

- Add `tests/e2e/nmkr-analytics.regression.spec.ts` which uses shared helpers (`loginToWpAdmin`, `env`, `urlFor`, `expectWpAdmin`) to navigate to `NMKR_ANALYTICS_PATH`, installs a `**/wp-admin/admin-ajax.php` route guard, stubs page-load actions (`nmkr_analytics_kpis`, `nmkr_analytics_timeseries`, `nmkr_analytics_top_projects`, `nmkr_analytics_top_tokens`) with public-safe empty payloads, and blocks/records unexpected sync/mutation/export actions (listed in the spec) so they never reach WordPress while asserting the Analytics shell and runtime controls; the spec is skip-safe when `.wrap.nmkr-analytics-wrap` is not present.
- Add an npm script `test:e2e:analytics` that runs the new spec with `playwright test tests/e2e/nmkr-analytics.regression.spec.ts` in `package.json` and leave existing scripts unchanged.
- Document the Analytics regression, its conditional availability (`NMKR_ANALYTICS_UI_ENABLED`), AJAX stubbing/guard behavior, non-mutating guarantees, and local run instructions in `docs/testing-phase-3.md` (including `npm run test:e2e:analytics` / `-- --list` and direct-env sourcing guidance).

### Testing

- Ran `npm run test:e2e -- --list` and it listed 6 tests including the new `nmkr-analytics.regression.spec.ts` (success).
- Ran `npm run test:e2e:analytics -- --list` and it listed only the Analytics regression (success).
- Live Playwright runs (`npm run test:e2e:analytics` / `npm run test:e2e`) were not executed in this environment because required environment variables (`WP_BASE_URL`, `WP_ADMIN_USER`, `WP_ADMIN_PASSWORD`) are missing; complete live validation on the GCP dev VM after sourcing the private Phase 2 env file as documented.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f6643776c83338ae91b00a1a32057)