### PR TITLE
Phase 5: add PHP 7.4 compatibility guardrails to public CI

### DIFF
--- a/.github/workflows/phase4-ci.yml
+++ b/.github/workflows/phase4-ci.yml
@@ -56,24 +56,5 @@ jobs:
           coverage: none
           tools: none
 
-      - name: PHP syntax check
-        shell: bash
-        run: |
-          set -euo pipefail
-          mapfile -d '' php_files < <(git ls-files -z -- '*.php' \
-            ':(exclude)vendor/**' \
-            ':(exclude)node_modules/**' \
-            ':(exclude)build/**' \
-            ':(exclude)dist/**' \
-            ':(exclude)playwright-report/**' \
-            ':(exclude)test-results/**' \
-            ':(exclude).phase2-private/**' \
-            ':(exclude)coverage/**' \
-            ':(exclude)reports/**')
-          if (( ${#php_files[@]} == 0 )); then
-            echo "No tracked PHP files found."
-            exit 1
-          fi
-          for file in "${php_files[@]}"; do
-            php -l "$file"
-          done
+      - name: PHP 7.4 syntax and compatibility guard
+        run: npm run test:php74

--- a/docs/testing-phase-4.md
+++ b/docs/testing-phase-4.md
@@ -76,6 +76,8 @@ done
 
 The workflow uses PHP 7.4 for this syntax smoke check because `composer.json` declares PHP `>=7.4`. This is not a full PHP-version compatibility matrix.
 
+Phase 5 extends this public-safe PHP floor check with a reusable lightweight compatibility guard documented in `docs/testing-phase-5.md`.
+
 ## Public-safety rules
 
 - Never commit `.env.tests` or any populated environment file.

--- a/docs/testing-phase-5.md
+++ b/docs/testing-phase-5.md
@@ -1,0 +1,67 @@
+# Phase 5 PHP 7.4 compatibility guardrails
+
+Phase 5 adds lightweight PHP 7.4 compatibility guardrails for public CI and local validation. The guard keeps the repository aligned with the declared Composer PHP floor of `>=7.4` without introducing broad coding-standard or static-analysis tooling.
+
+## Why this exists
+
+Phase 4 public CI already runs PHP syntax checks with PHP 7.4. During Phase 4 validation, that check surfaced a real PHP 8-only syntax issue: a `match` expression in code that should support the repository's declared PHP `>=7.4` floor. Phase 5 preserves that syntax check and hardens it with a narrow compatibility scan for common PHP 8+ constructs and helper functions.
+
+## Local validation commands
+
+Run the Phase 5 PHP 7.4 guard locally with:
+
+```bash
+npm run test:php74
+```
+
+Continue to validate Playwright test discovery only with:
+
+```bash
+npm run test:e2e -- --list
+```
+
+Check Bash scripts with:
+
+```bash
+bash -n scripts/*.sh
+```
+
+## Guarded PHP 8+ constructs and functions
+
+The guard scans tracked PHP files in the same scope used by public CI, excluding dependency, build, report, coverage, and private artifact directories. It runs `php -l` for each discovered PHP file and then checks for these PHP 8+ patterns:
+
+- `match (` expressions
+- nullsafe operator usage with `?->`
+- PHP attributes at the start of a line with `#[`
+- `readonly`
+- enum declarations such as `enum Name`
+- PHP 8 string helpers:
+  - `str_contains(`
+  - `str_starts_with(`
+  - `str_ends_with(`
+- PHP 8 runtime helpers:
+  - `fdiv(`
+  - `get_debug_type(`
+  - `get_resource_id(`
+
+This is a lightweight guardrail, not a complete PHPCompatibility, PHPCS, PHPStan, or Psalm replacement. It is intentionally narrow so public CI remains fast, dependency-light, and low-noise.
+
+## False-positive handling
+
+If the scan reports a false positive, adjust `scripts/nmkr-php74-compat-scan.sh` carefully and keep the affected pattern as narrow as possible. Do not broaden the scan into a general coding-standard or static-analysis replacement in this phase.
+
+## Public-safety non-goals
+
+Phase 5 public CI intentionally does not add or publish:
+
+- WordPress credentials
+- Basic Auth credentials
+- API keys
+- private URLs
+- VM paths
+- WP-CLI commands against live sites
+- deployment commands
+- screenshots, traces, or videos
+- artifact uploads
+
+Phase 2 remains private-only and must not run in public CI.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "test:e2e": "playwright test",
     "test:e2e:report": "playwright show-report",
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
+    "test:php74": "bash scripts/nmkr-php74-compat-scan.sh",
     "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts",
     "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts",
     "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts",

--- a/scripts/nmkr-php74-compat-scan.sh
+++ b/scripts/nmkr-php74-compat-scan.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Lightweight PHP 7.4 guardrail for public CI.
+# This intentionally combines PHP 7.4 syntax linting with a narrow grep scan for
+# common PHP 8+ constructs/functions. It is not a full PHPCompatibility, PHPCS,
+# PHPStan, or Psalm replacement.
+
+mapfile -d '' php_files < <(git ls-files -z -- '*.php' \
+  ':(exclude)vendor/**' \
+  ':(exclude)node_modules/**' \
+  ':(exclude)build/**' \
+  ':(exclude)dist/**' \
+  ':(exclude)playwright-report/**' \
+  ':(exclude)test-results/**' \
+  ':(exclude).phase2-private/**' \
+  ':(exclude)coverage/**' \
+  ':(exclude)reports/**')
+
+if (( ${#php_files[@]} == 0 )); then
+  echo "No tracked PHP files found."
+  exit 1
+fi
+
+echo "Running PHP 7.4 syntax checks for ${#php_files[@]} tracked PHP files."
+for file in "${php_files[@]}"; do
+  php -l "$file"
+done
+
+echo "Scanning for narrow PHP 8+ compatibility patterns."
+compat_failed=0
+
+# Keep patterns narrow to reduce false positives in public CI output. Matches
+# report only repository-relative paths, line numbers, and matching source lines.
+if grep -EnH \
+  -e '\bmatch[[:space:]]*\(' \
+  -e '\?->' \
+  -e '^[[:space:]]*#\[' \
+  -e '\breadonly\b' \
+  -e '\benum[[:space:]]+[A-Za-z_][A-Za-z0-9_]*' \
+  -e '\bstr_contains[[:space:]]*\(' \
+  -e '\bstr_starts_with[[:space:]]*\(' \
+  -e '\bstr_ends_with[[:space:]]*\(' \
+  -e '\bfdiv[[:space:]]*\(' \
+  -e '\bget_debug_type[[:space:]]*\(' \
+  -e '\bget_resource_id[[:space:]]*\(' \
+  -- "${php_files[@]}"; then
+  compat_failed=1
+fi
+
+if (( compat_failed != 0 )); then
+  echo "PHP 8+ compatibility patterns were found. Keep runtime-compatible code for the declared PHP >=7.4 floor."
+  exit 1
+fi
+
+echo "No guarded PHP 8+ compatibility patterns found."


### PR DESCRIPTION
### Motivation
- Preserve and harden the repository PHP `>=7.4` floor by adding a lightweight, public-safe compatibility guard that complements the existing PHP 7.4 syntax checks. 
- Provide a reusable local and CI-friendly check that detects common PHP 8+ constructs that would break on PHP 7.4 without adding dev dependencies or heavy static-analysis tools.

### Description
- Add `scripts/nmkr-php74-compat-scan.sh`, a Bash script that discovers tracked PHP files using `git ls-files -z -- '*.php'` with the same exclusions as the current CI, fails if no PHP files are found, runs `php -l` on each file, and performs a narrow `grep` scan for PHP 8+ patterns. 
- The scan guards for `match(`, the nullsafe operator `?->`, line-start attributes `#[`, `readonly`, `enum` declarations, `str_contains(`, `str_starts_with(`, `str_ends_with(`, `fdiv(`, `get_debug_type(`, and `get_resource_id(`, and prints file paths and line numbers for matches. 
- Wire the guard into public CI by replacing the inline PHP lint block in `.github/workflows/phase4-ci.yml` with a `PHP 7.4 syntax and compatibility guard` step that runs `npm run test:php74` while preserving `shivammathur/setup-php@v2` with `php-version: "7.4"`. 
- Add `test:php74` to `package.json` and create `docs/testing-phase-5.md` (with a one-line cross-reference added to `docs/testing-phase-4.md`) documenting purpose, guarded constructs, local commands, false-positive handling, and public-safety non-goals.

### Testing
- Ran Bash syntax checks with `bash -n scripts/*.sh`, which passed. 
- Installed Node deps with `npm ci` and listed Playwright tests using `npm run test:e2e -- --list`, which succeeded. 
- Executed the new guard locally with `npm run test:php74`, which ran `php -l` over tracked files and the grep-based compatibility scan and reported no guarded PHP 8+ patterns. 
- Ran `git diff --check` to ensure no whitespace or index issues, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f7999a1cc83338dc40d813e41915e)