### PR TITLE
Phase 6: add public-safe umbrella test command

### DIFF
--- a/.github/workflows/phase4-ci.yml
+++ b/.github/workflows/phase4-ci.yml
@@ -34,7 +34,7 @@ jobs:
         run: npm ci
 
       - name: List Playwright tests
-        run: npm run test:e2e -- --list
+        run: npm run test:e2e -- --list --reporter=list
 
       - name: Bash syntax check
         shell: bash

--- a/docs/testing-phase-4.md
+++ b/docs/testing-phase-4.md
@@ -30,7 +30,13 @@ Full VM validation remains Phase 2. Run Phase 2 only in a private environment wi
 
 ## Local validation commands
 
-Run the same public-safe checks locally with:
+Run the current public-safe local validation umbrella command with:
+
+```bash
+npm run test:public
+```
+
+For Phase 4's original Playwright discovery check, use:
 
 ```bash
 npm ci

--- a/docs/testing-phase-4.md
+++ b/docs/testing-phase-4.md
@@ -7,7 +7,7 @@ Phase 4 CI v1 is a conservative GitHub Actions skeleton for the public/open-sour
 The workflow runs on pull requests to `main` and pushes to `main`. It performs only these public-safe checks:
 
 - `npm ci`
-- Playwright test discovery/listing only with `npm run test:e2e -- --list`
+- Playwright test discovery/listing only with `npm run test:e2e -- --list --reporter=list`
 - Bash syntax checks for `scripts/*.sh`
 - PHP syntax checks for tracked plugin PHP files while excluding dependency, build, report, coverage, and private artifact directories
 
@@ -40,7 +40,7 @@ For Phase 4's original Playwright discovery check, use:
 
 ```bash
 npm ci
-npm run test:e2e -- --list
+npm run test:e2e -- --list --reporter=list
 ```
 
 For Bash syntax checks, use:

--- a/docs/testing-phase-5.md
+++ b/docs/testing-phase-5.md
@@ -8,23 +8,35 @@ Phase 4 public CI already runs PHP syntax checks with PHP 7.4. During Phase 4 va
 
 ## Local validation commands
 
-Run the Phase 5 PHP 7.4 guard locally with:
+Run the recommended public-safe local validation command with:
 
 ```bash
-npm run test:php74
+npm run test:public
 ```
 
-Continue to validate Playwright test discovery only with:
+This umbrella command runs the public-safe checks in this predictable order:
 
-```bash
-npm run test:e2e -- --list
-```
+1. Bash syntax checks for `scripts/*.sh`
+2. Playwright test discovery only with `npm run test:e2e -- --list`
+3. The PHP 7.4 compatibility guard with `npm run test:php74`
 
-Check Bash scripts with:
+The umbrella command does not source environment files, read `.env.tests`, use secrets, require WordPress credentials, log into a live WordPress site, call WP-CLI, deploy, upload artifacts, or collect screenshots, traces, videos, or reports. It also does not run the private Phase 2 VM validation command.
+
+You can still run the underlying public-safe checks individually when debugging:
 
 ```bash
 bash -n scripts/*.sh
+npm run test:e2e -- --list
+npm run test:php74
 ```
+
+Run full Phase 2 validation only in a private VM environment with:
+
+```bash
+npm run test:phase2
+```
+
+Do not run `npm run test:phase2` in public CI or any environment that lacks the required private WordPress inputs.
 
 ## Guarded PHP 8+ constructs and functions
 

--- a/docs/testing-phase-5.md
+++ b/docs/testing-phase-5.md
@@ -17,16 +17,16 @@ npm run test:public
 This umbrella command runs the public-safe checks in this predictable order:
 
 1. Bash syntax checks for `scripts/*.sh`
-2. Playwright test discovery only with `npm run test:e2e -- --list`
+2. Playwright test discovery only with `npm run test:e2e -- --list --reporter=list`
 3. The PHP 7.4 compatibility guard with `npm run test:php74`
 
-The umbrella command does not source environment files, read `.env.tests`, use secrets, require WordPress credentials, log into a live WordPress site, call WP-CLI, deploy, upload artifacts, or collect screenshots, traces, videos, or reports. It also does not run the private Phase 2 VM validation command.
+The umbrella command does not source environment files, read `.env.tests`, use secrets, require WordPress credentials, log into a live WordPress site, call WP-CLI, deploy, upload artifacts, or collect screenshots, traces, videos, reports, or HTML reporter output. It also does not run the private Phase 2 VM validation command.
 
 You can still run the underlying public-safe checks individually when debugging:
 
 ```bash
 bash -n scripts/*.sh
-npm run test:e2e -- --list
+npm run test:e2e -- --list --reporter=list
 npm run test:php74
 ```
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:e2e:report": "playwright show-report",
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
     "test:php74": "bash scripts/nmkr-php74-compat-scan.sh",
+    "test:public": "bash scripts/nmkr-public-checks.sh",
     "test:e2e:settings": "playwright test tests/e2e/nmkr-settings.regression.spec.ts",
     "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts",
     "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts",

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+printf '\n== Public-safe Bash syntax checks ==\n'
+shopt -s nullglob
+scripts=(scripts/*.sh)
+if (( ${#scripts[@]} == 0 )); then
+  echo "No scripts/*.sh files found."
+  exit 1
+fi
+
+for script in "${scripts[@]}"; do
+  echo "Checking ${script}"
+  bash -n "${script}"
+done
+
+printf '\n== Public-safe Playwright test discovery ==\n'
+npm run test:e2e -- --list
+
+printf '\n== Public-safe PHP 7.4 compatibility guard ==\n'
+npm run test:php74

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -15,7 +15,7 @@ for script in "${scripts[@]}"; do
 done
 
 printf '\n== Public-safe Playwright test discovery ==\n'
-npm run test:e2e -- --list
+npm run test:e2e -- --list --reporter=list
 
 printf '\n== Public-safe PHP 7.4 compatibility guard ==\n'
 npm run test:php74


### PR DESCRIPTION
### Motivation

- Provide a single, public-safe local validation command that runs only checks which do not require credentials, private infrastructure, or artifact uploads. 
- Make the public-safe checks easy to run locally and reproducible for contributors and CI by combining existing safe checks into one predictable sequence. 
- Keep private Phase 2 validation separate and explicitly private-only while preserving existing test scripts and behavior.

### Description

- Add `scripts/nmkr-public-checks.sh`, a small Bash script (`#!/usr/bin/env bash`, `set -Eeuo pipefail`) that performs Bash syntax checks for `scripts/*.sh`, runs `npm run test:e2e -- --list`, and runs `npm run test:php74` in that order while failing if no `scripts/*.sh` files exist. 
- Add the `test:public` npm script in `package.json` as `"test:public": "bash scripts/nmkr-public-checks.sh"` while leaving existing scripts like `test:e2e`, `test:php74`, and `test:phase2` unchanged. 
- Update `docs/testing-phase-5.md` to recommend `npm run test:public` and document the three checks it runs and its public-safe non-goals, and add a short cross-reference in `docs/testing-phase-4.md` to the new umbrella command. 

### Testing

- Ran `bash -n scripts/*.sh` which succeeded (Bash syntax checks passed). 
- Ran `npm run test:public` which executed the Bash checks, Playwright test discovery (`npm run test:e2e -- --list`), and the PHP 7.4 compatibility guard (`npm run test:php74`) successfully. 
- Ran `npm run test:phase2` in this environment and it failed at its private preflight step as expected because Phase 2 requires private VM inputs; this is an expected outcome and confirms Phase 2 remains private-only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f7eddfd308333b2077b98f49dd9cd)