### PR TITLE
Phase 7: add non-mutating sync-state regression test

### DIFF
--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -62,6 +62,8 @@ The dashboard regression is intentionally non-mutating:
 
 The test uses attachment, role, attribute, and element type assertions for controls that may be hidden by default or may not include explicit `type="button"` attributes.
 
+Phase 7 extends dashboard coverage with `tests/e2e/nmkr-sync-state.regression.spec.ts`, a separate non-mutating sync-state regression that locally stubs sync progress and completed statistics AJAX responses without clicking Start or Stop. See `docs/testing-phase-7.md` for the Phase 7 safety model and commands.
+
 ## Projects-page regression
 
 The projects regression is implemented in `tests/e2e/nmkr-projects.regression.spec.ts`. It logs in with the shared WordPress admin helpers, opens `NMKR_PROJECTS_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-projects`), and verifies the default **no project selected** state for the NMKR Projects and Tokens admin page.

--- a/docs/testing-phase-7.md
+++ b/docs/testing-phase-7.md
@@ -1,0 +1,62 @@
+# Phase 7 non-mutating sync-state regression coverage
+
+Phase 7 adds a targeted Playwright regression for the NMKR Connect dashboard synchronization state UI. The test is implemented in `tests/e2e/nmkr-sync-state.regression.spec.ts` and exercises the client-side dashboard behavior with local Playwright AJAX stubs instead of real synchronization.
+
+## Purpose
+
+The regression verifies that the dashboard can render a realistic sync lifecycle without changing WordPress state. It covers the deeper UI state that is not exercised by the structural dashboard regression:
+
+- Active sync progress.
+- Live active metrics updates.
+- Completion handling.
+- Past/completed synchronization statistics refresh.
+
+## What the test simulates
+
+The test logs in with the shared WordPress admin helpers, opens `NMKR_DASHBOARD_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-dashboard`), and routes dashboard AJAX calls to local JSON responses.
+
+Locally stubbed AJAX actions are:
+
+- `nmkr_check_api_status`, returning a connected, non-error dashboard status.
+- `nmkr_sync_progress`, returning an active 37% progress response followed by a completed 100% response.
+- `nmkr_get_sync_statistics`, returning fixed completed synchronization statistics for the past-statistics panel.
+
+The test calls the dashboard's public `window.NMKRProgress.startPolling()` hook to trigger client polling. It does not click synchronization controls.
+
+## Safety guarantees
+
+The Phase 7 regression is intentionally non-mutating:
+
+- It does not click **Start Synchronization**.
+- It does not click **Stop Synchronization**.
+- It does not allow real `nmkr_start_sync` requests to reach WordPress.
+- It does not allow real `nmkr_stop_sync` requests to reach WordPress.
+- It does not allow real `nmkr_store_active_metrics` requests to reach WordPress.
+- It does not clear logs or allow real log-clearing requests to reach WordPress.
+- It does not mutate options, transients, database rows, logs, API keys, or sync state.
+- It does not assert, print, snapshot, or expose nonce values.
+- It does not assert, print, snapshot, or expose API keys, credentials, private URLs, environment values, or logs.
+
+The Playwright route guard records blocked mutating actions and fulfills them locally with harmless JSON if they are attempted, then fails the test if any were observed. Sync/dashboard AJAX actions used by the regression are stubbed locally in Playwright and do not reach WordPress.
+
+## Commands
+
+Run the targeted Phase 7 regression locally with a private WordPress test environment loaded:
+
+```bash
+npm run test:e2e:sync-state
+```
+
+Run full private Phase 2 validation with the private VM environment:
+
+```bash
+npm run test:phase2
+```
+
+Run public-safe validation:
+
+```bash
+npm run test:public
+```
+
+Public CI should only list/discover the Playwright regression. It must not execute this sync-state regression against live WordPress credentials.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:e2e:dashboard": "playwright test tests/e2e/nmkr-dashboard.regression.spec.ts",
     "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts",
     "test:e2e:shortcodes": "playwright test tests/e2e/nmkr-shortcodes.regression.spec.ts",
-    "test:e2e:analytics": "playwright test tests/e2e/nmkr-analytics.regression.spec.ts"
+    "test:e2e:analytics": "playwright test tests/e2e/nmkr-analytics.regression.spec.ts",
+    "test:e2e:sync-state": "playwright test tests/e2e/nmkr-sync-state.regression.spec.ts"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/tests/e2e/nmkr-sync-state.regression.spec.ts
+++ b/tests/e2e/nmkr-sync-state.regression.spec.ts
@@ -1,0 +1,208 @@
+import { expect, test } from '@playwright/test';
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
+
+const allowedStubbedActions = new Set([
+  'nmkr_check_api_status',
+  'nmkr_sync_progress',
+  'nmkr_get_sync_statistics',
+]);
+
+const blockedMutatingActions = new Set([
+  'nmkr_start_sync',
+  'nmkr_stop_sync',
+  'nmkr_force_stop_sync',
+  'nmkr_restart_sync_batch',
+  'nmkr_cleanup_sync_jobs',
+  'nmkr_store_active_metrics',
+  'nmkr_clear_all_logs',
+  'nmkr_clear_section_logs',
+]);
+
+const fixedUpdatedAt = 1783596000;
+
+function progressPayload(progressCallCount: number) {
+  if (progressCallCount === 1) {
+    return {
+      success: true,
+      data: {
+        progress: 37,
+        current_item: 'Processing test project',
+        in_progress: true,
+        finished: false,
+        aborted: false,
+        error: '',
+        total_items: 100,
+        live_metrics: {
+          total_projects: 3,
+          total_tokens: 14,
+          total_sync_duration: 12.5,
+          total_api_time: 1.25,
+          average_response_time: 0.31,
+          api_requests: 4,
+          memory_usage: 24.5,
+          updated_at: fixedUpdatedAt,
+        },
+      },
+    };
+  }
+
+  return {
+    success: true,
+    data: {
+      progress: 100,
+      current_item: 'All data synchronized',
+      in_progress: false,
+      finished: true,
+      aborted: false,
+      error: '',
+      total_items: 100,
+      live_metrics: {
+        total_projects: 3,
+        total_tokens: 14,
+        total_sync_duration: 12.5,
+        total_api_time: 1.25,
+        average_response_time: 0.31,
+        api_requests: 4,
+        memory_usage: 24.5,
+        updated_at: fixedUpdatedAt + 30,
+      },
+    },
+  };
+}
+
+test.describe('NMKR Connect sync-state regression', () => {
+  test('simulates active sync progress and completion without mutating WordPress state', async ({ page }) => {
+    const dashboardPath = env('NMKR_DASHBOARD_PATH', '/wp-admin/admin.php?page=nmkr-connect-dashboard');
+    const unexpectedMutatingActions: string[] = [];
+    let progressCallCount = 0;
+    let statisticsCallCount = 0;
+    let statisticsCallsAfterCompletion = 0;
+    let completionSeen = false;
+
+    await page.route('**/wp-admin/admin-ajax.php', async (route, request) => {
+      const params = new URLSearchParams(request.postData() || '');
+      const action = params.get('action');
+
+      if (action === 'nmkr_check_api_status') {
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              message: 'Test stub: API status check skipped.',
+              connected: true,
+              sync_in_progress: false,
+              progress: 0,
+              heartbeat_age: -1,
+              last_update: 0,
+              grace: 0,
+              last_result: '',
+              last_recovery_at: 0,
+            },
+          }),
+        });
+        return;
+      }
+
+      if (action === 'nmkr_sync_progress') {
+        progressCallCount += 1;
+        const payload = progressPayload(progressCallCount);
+        completionSeen = completionSeen || payload.data.finished === true;
+        await route.fulfill({ contentType: 'application/json', body: JSON.stringify(payload) });
+        return;
+      }
+
+      if (action === 'nmkr_get_sync_statistics') {
+        statisticsCallCount += 1;
+        if (completionSeen) {
+          statisticsCallsAfterCompletion += 1;
+        }
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({
+            success: true,
+            data: {
+              last_sync_time: '2026-07-09 11:20 UTC',
+              total_projects: 3,
+              total_tokens: 14,
+              total_sync_duration: '12.5s',
+              total_api_time: '1.25s',
+              average_response_time: '310.00ms',
+              average_response_time_raw: 0.31,
+              api_requests: 4,
+              memory_usage: '24.5 MB',
+              memory_usage_raw: 24.5,
+              response_time_class: 'status-excellent',
+              memory_class: 'status-excellent',
+            },
+          }),
+        });
+        return;
+      }
+
+      if (action && blockedMutatingActions.has(action)) {
+        unexpectedMutatingActions.push(action);
+        await route.fulfill({
+          contentType: 'application/json',
+          body: JSON.stringify({ success: true, data: { message: 'Test stub: mutating sync action skipped.' } }),
+        });
+        return;
+      }
+
+      if (action && allowedStubbedActions.has(action)) {
+        throw new Error(`Unhandled allowed stubbed action: ${action}`);
+      }
+
+      await route.continue();
+    });
+
+    const baseUrl = await loginToWpAdmin(page);
+    await page.goto(urlFor(baseUrl, dashboardPath));
+    await expectWpAdmin(page);
+    await expect(page).toHaveURL(/page=nmkr-connect-dashboard/);
+
+    await expect(page.locator('.sync-data')).toBeAttached();
+    await expect(page.locator('#nmkr-sync-progress-container')).toBeAttached();
+    await expect(page.locator('#nmkr-sync-progress-bar')).toBeAttached();
+    await expect(page.locator('#status-message')).toBeAttached();
+    await expect(page.locator('#active-sync-metrics')).toBeAttached();
+    await expect(page.locator('.sync-statistics')).toBeAttached();
+
+    const startButton = page.locator('#nmkr-sync-button');
+    const stopButton = page.locator('#nmkr-stop-sync-button');
+    await expect(startButton).toBeAttached();
+    await expect(stopButton).toBeAttached();
+
+    await page.evaluate(() => {
+      const progress = (window as Window & { NMKRProgress?: { startPolling?: () => void } }).NMKRProgress;
+      if (!progress || typeof progress.startPolling !== 'function') {
+        throw new Error('NMKRProgress.startPolling is not available.');
+      }
+      progress.startPolling();
+    });
+
+    await expect(page.locator('#nmkr-sync-progress-bar')).toContainText('37%');
+    await expect(page.locator('#status-message')).toContainText('Processing test project');
+    await expect(page.locator('#active-sync-metrics')).toBeVisible();
+    await expect(page.locator('.total-projects-active')).toContainText('3');
+    await expect(page.locator('.total-tokens-active')).toContainText('14');
+    await expect(page.locator('.api-requests')).toContainText('4');
+    await expect(page.locator('.memory-usage')).toContainText(/\S+/);
+
+    await expect(page.locator('#nmkr-sync-progress-bar')).toContainText('100%', { timeout: 7000 });
+    await expect(page.locator('#status-message')).toContainText(/Synchronization completed successfully|All data synchronized/);
+    await expect(startButton).toBeVisible();
+    await expect(startButton).toBeEnabled();
+    await expect(stopButton).toBeHidden();
+
+    await expect(page.locator('#last-synced')).toContainText('2026-07-09 11:20 UTC', { timeout: 3000 });
+    await expect(page.locator('#total-projects')).toContainText('3');
+    await expect(page.locator('#total-tokens')).toContainText('14');
+    await expect(page.locator('#request-count')).toContainText('4');
+
+    expect(unexpectedMutatingActions).toEqual([]);
+    expect(progressCallCount).toBeGreaterThanOrEqual(2);
+    expect(statisticsCallCount).toBeGreaterThanOrEqual(1);
+    expect(statisticsCallsAfterCompletion).toBeGreaterThanOrEqual(1);
+  });
+});


### PR DESCRIPTION
### Motivation

- Add Phase 7 coverage for the dashboard sync-state UI by simulating a realistic sync lifecycle in the browser without touching WordPress state or starting real synchronization.
- Provide a focused, public-safe Playwright regression that exercises active progress, live metrics, completion handling, and completed-statistics refresh via local AJAX stubs.

### Description

- Add `tests/e2e/nmkr-sync-state.regression.spec.ts`, a Playwright spec that routes `**/wp-admin/admin-ajax.php` and locally stubs `nmkr_check_api_status`, `nmkr_sync_progress` (two-step 37% then 100%), and `nmkr_get_sync_statistics` while recording and failing on any blocked mutating actions. 
- The spec triggers the dashboard client polling via `window.NMKRProgress.startPolling()` and asserts active metrics, progress bar states, completion UI, and refreshed completed statistics without clicking Start/Stop or calling real sync actions.
- Add a targeted npm script `test:e2e:sync-state` to `package.json` to run the new spec directly and leave all existing scripts unchanged. 
- Add `docs/testing-phase-7.md` documenting purpose, test simulation details, safety guarantees, and local/private/public validation commands, and add a short cross-reference to `docs/testing-phase-3.md`.

### Testing

- Ran Playwright discovery for the new spec with `npm run test:e2e:sync-state -- --list`, which successfully listed the new test. 
- Ran public-safe checks with `npm run test:public`, which completed Playwright test discovery and PHP 7.4 syntax checks without errors. 
- Ran `git diff --check` as part of validation with no whitespace or format errors found. 
- Note: a full private targeted run of the test (`npm run test:e2e:sync-state`) in the private Phase 2 VM was not executed here because the private environment file `$HOME/.config/nmkr-connect/phase2.env` was not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f870403608333a05e94d717d217bf)