### PR TITLE
Phase 8: add WP-CLI database-state validation

### DIFF
--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -2,7 +2,7 @@
 
 Phase 2 adds a VM-local orchestration runner around the existing Phase 1 automated checks. It is intended for maintainers who validate a deployed WordPress NMKR Connect installation from a private, user-owned checkout.
 
-The runner does not change plugin runtime behavior. It coordinates deployment, Playwright admin smoke checks, and WP-CLI smoke checks, then writes detailed output to private local files while printing only a concise public-safe summary.
+The runner does not change plugin runtime behavior. It coordinates deployment, Playwright admin smoke checks, WP-CLI smoke checks, and WP-CLI database-state validation, then writes detailed output to private local files while printing only a concise public-safe summary.
 
 ## Public-safety rules
 
@@ -81,6 +81,13 @@ The npm script runs:
 bash scripts/nmkr-phase2-test-runner.sh
 ```
 
+The runner performs these validation stages in order:
+
+1. Deployment, unless `NMKR_PHASE2_SKIP_DEPLOY=true`.
+2. Playwright admin smoke checks.
+3. WP-CLI smoke checks.
+4. WP-CLI database-state validation via `scripts/nmkr-wpcli-db-state.sh`.
+
 ## Deployment wiring
 
 When `NMKR_PHASE2_SKIP_DEPLOY` is not `true`, the runner requires `NMKR_DEPLOY_COMMAND` and runs it with:
@@ -121,6 +128,7 @@ Phase 2 summary
   browser: SKIPPED
   playwright: PASS
   wpcli: PASS
+  db-state: PASS
   result: PASS
   commit: abc1234
   private run dir: /path/to/checkout/.phase2-private/runs/20260708T120000Z-12345

--- a/docs/testing-phase-8.md
+++ b/docs/testing-phase-8.md
@@ -1,0 +1,73 @@
+# Phase 8 WP-CLI database-state validation
+
+Phase 8 adds a read-only WP-CLI database-state validation layer for deployed NMKR Connect test environments. It is intended to run after deployment and browser smoke coverage, when no NMKR sync is active.
+
+## Script
+
+```bash
+scripts/nmkr-wpcli-db-state.sh
+```
+
+The script follows the same WP-CLI environment conventions as the existing smoke script:
+
+- `WP_PATH` optionally points WP-CLI at the WordPress installation.
+- `WP_CLI_BIN` defaults to `wp`.
+- `NMKR_PLUGIN_SLUG` defaults to `nmkr-connect/nmkr-connect.php`.
+
+## Targeted command
+
+Run only the Phase 8 database-state validation with:
+
+```bash
+npm run test:wpcli:db-state
+```
+
+## Full validation
+
+Phase 2 runs Phase 8 automatically after the WP-CLI smoke checks pass:
+
+```bash
+npm run test:phase2
+```
+
+## What Phase 8 validates
+
+The validation checks only public-safe invariants and aggregate counts:
+
+- NMKR Connect plugin activation state.
+- Expected NMKR database tables.
+- Expected schema columns.
+- Expected indexes and unique keys.
+- Expected activation/default option keys.
+- API key presence without printing the API key.
+- No active sync state by default.
+- Basic data-integrity counts, including duplicate and relationship checks.
+- Sync metrics and sync stats rows for impossible values.
+- Latest sync timestamp consistency between sync metrics and the stored option when both values exist.
+
+## Active sync-state handling
+
+By default, Phase 8 fails when it detects active or partial sync state. This keeps normal validation deterministic and avoids treating an in-progress sync as a database invariant failure.
+
+If you intentionally need to inspect a database while sync state may be active, set:
+
+```bash
+NMKR_DB_STATE_ALLOW_ACTIVE_SYNC=true npm run test:wpcli:db-state
+```
+
+Use the default `false` behavior for normal Phase 2 validation. Do not run the script during an active sync unless the skip is explicitly allowed and understood.
+
+## Read-only and public-safety guarantees
+
+The script is designed to use only read-only WP-CLI and SQL operations, such as `wp core is-installed`, `wp plugin is-active`, `wp db prefix`, `wp db query` with `SHOW`/`SELECT`, `wp option get`, and `wp transient get`.
+
+It must not activate, deactivate, uninstall, delete, reinstall, or run NMKR sync. It must not write options, transients, database rows, logs, files, or plugin settings.
+
+Console output is intentionally concise and public-safe:
+
+- No secrets.
+- No API keys.
+- No credential, URL, nonce, or environment printing.
+- No row dumps.
+- No debug log output.
+- No database writes.

--- a/docs/testing-phase-8.md
+++ b/docs/testing-phase-8.md
@@ -32,7 +32,7 @@ npm run test:phase2
 
 ## What Phase 8 validates
 
-The validation checks only public-safe invariants and aggregate counts:
+The validation checks only public-safe invariants and aggregate counts. Invariant SQL query failures are fatal and are not treated as zero-count passes:
 
 - NMKR Connect plugin activation state.
 - Expected NMKR database tables.
@@ -47,7 +47,7 @@ The validation checks only public-safe invariants and aggregate counts:
 
 ## Active sync-state handling
 
-By default, Phase 8 fails when it detects active or partial sync state. This keeps normal validation deterministic and avoids treating an in-progress sync as a database invariant failure.
+By default, Phase 8 fails when it detects active or partial sync state. This keeps normal validation deterministic and avoids treating an in-progress sync as a database invariant failure. Transient sync-state rows are inspected through direct read-only option-table `SELECT` queries rather than `wp transient get`, so expired DB-backed transients are not cleaned up or mutated by validation.
 
 If you intentionally need to inspect a database while sync state may be active, set:
 
@@ -59,7 +59,7 @@ Use the default `false` behavior for normal Phase 2 validation. Do not run the s
 
 ## Read-only and public-safety guarantees
 
-The script is designed to use only read-only WP-CLI and SQL operations, such as `wp core is-installed`, `wp plugin is-active`, `wp db prefix`, `wp db query` with `SHOW`/`SELECT`, `wp option get`, and `wp transient get`.
+The script is designed to use only read-only WP-CLI and SQL operations, such as `wp core is-installed`, `wp plugin is-active`, `wp db prefix`, `wp db query` with `SHOW`/`SELECT`, `wp option get`, and direct read-only option-row `SELECT` queries for transient state.
 
 It must not activate, deactivate, uninstall, delete, reinstall, or run NMKR sync. It must not write options, transients, database rows, logs, files, or plugin settings.
 

--- a/docs/testing-phase-8.md
+++ b/docs/testing-phase-8.md
@@ -32,7 +32,7 @@ npm run test:phase2
 
 ## What Phase 8 validates
 
-The validation checks only public-safe invariants and aggregate counts. Invariant SQL query failures are fatal and are not treated as zero-count passes:
+The validation checks only public-safe invariants and aggregate counts. Invariant SQL query failures are fatal, include public-safe invariant labels, and are not treated as zero-count passes:
 
 - NMKR Connect plugin activation state.
 - Expected NMKR database tables.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "test:e2e:projects": "playwright test tests/e2e/nmkr-projects.regression.spec.ts",
     "test:e2e:shortcodes": "playwright test tests/e2e/nmkr-shortcodes.regression.spec.ts",
     "test:e2e:analytics": "playwright test tests/e2e/nmkr-analytics.regression.spec.ts",
-    "test:e2e:sync-state": "playwright test tests/e2e/nmkr-sync-state.regression.spec.ts"
+    "test:e2e:sync-state": "playwright test tests/e2e/nmkr-sync-state.regression.spec.ts",
+    "test:wpcli:db-state": "bash scripts/nmkr-wpcli-db-state.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -60,6 +60,7 @@ DEPS_STATUS="SKIPPED"
 BROWSER_STATUS="SKIPPED"
 PLAYWRIGHT_STATUS="SKIPPED"
 WPCLI_STATUS="SKIPPED"
+DBSTATE_STATUS="SKIPPED"
 FAILED_STEP=""
 FAILED_LOG=""
 EXIT_CODE=0
@@ -77,6 +78,7 @@ print_summary() {
   printf '  browser: %s\n' "$BROWSER_STATUS"
   printf '  playwright: %s\n' "$PLAYWRIGHT_STATUS"
   printf '  wpcli: %s\n' "$WPCLI_STATUS"
+  printf '  db-state: %s\n' "$DBSTATE_STATUS"
   printf '  result: %s\n' "$result"
   printf '  commit: %s\n' "$commit"
   printf '  private run dir: %s\n' "$RUN_DIR"
@@ -200,6 +202,13 @@ if bash scripts/nmkr-wpcli-smoke.sh >"$RUN_DIR/wpcli.log" 2>&1; then
   WPCLI_STATUS="PASS"
 else
   fail_step "wpcli" "$RUN_DIR/wpcli.log" 5
+fi
+
+DBSTATE_STATUS="FAIL"
+if bash scripts/nmkr-wpcli-db-state.sh >"$RUN_DIR/wpcli-db-state.log" 2>&1; then
+  DBSTATE_STATUS="PASS"
+else
+  fail_step "wpcli-db-state" "$RUN_DIR/wpcli-db-state.log" 6
 fi
 
 EXIT_CODE=0

--- a/scripts/nmkr-wpcli-db-state.sh
+++ b/scripts/nmkr-wpcli-db-state.sh
@@ -34,48 +34,56 @@ sql_ident() {
   printf '`%s`' "$(printf "%s" "$1" | sed 's/`/``/g')"
 }
 
+normalize_scalar_output() {
+  tr -d '\r' | sed '/^[[:space:]]*$/d' | tail -n 1 | sed 's/^[[:space:]]*//; s/[[:space:]]*$//'
+}
+
 query_scalar() {
-  local sql="$1"
+  local label="$1"
+  local sql="$2"
   local value
 
-  if ! value="$(wp_cli db query "$sql" --skip-column-names 2>/dev/null | tr -d '\r' | tail -n 1)"; then
-    fail "Database invariant query failed."
+  if ! value="$(wp_cli db query "$sql" --skip-column-names --silent --raw 2>/dev/null | normalize_scalar_output)"; then
+    fail "${label} database read failed."
   fi
 
   printf '%s' "$value"
 }
 
 query_optional_scalar() {
-  local sql="$1"
+  local label="$1"
+  local sql="$2"
   local value
 
-  if ! value="$(wp_cli db query "$sql" --skip-column-names 2>/dev/null | tr -d '\r' | tail -n 1)"; then
-    fail "Optional database read failed."
+  if ! value="$(wp_cli db query "$sql" --skip-column-names --silent --raw 2>/dev/null | normalize_scalar_output)"; then
+    fail "${label} optional database read failed."
   fi
 
   printf '%s' "$value"
 }
 
 query_count() {
-  local sql="$1"
+  local label="$1"
+  local sql="$2"
   local value
-  value="$(query_scalar "$sql")"
-  [[ "$value" =~ ^[0-9]+$ ]] || fail "Could not inspect database invariant count."
+  value="$(query_scalar "$label" "$sql")"
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "${label} invariant returned a non-numeric count."
   printf '%s' "$value"
 }
 
 read_option_value() {
-  local option_name="$1"
+  local label="$1"
+  local option_name="$2"
   local escaped_option
   escaped_option="$(sql_escape "$option_name")"
-  query_optional_scalar "SELECT option_value FROM ${options_ident} WHERE option_name = '${escaped_option}' LIMIT 1;"
+  query_optional_scalar "$label" "SELECT option_value FROM ${options_ident} WHERE option_name = '${escaped_option}' LIMIT 1;"
 }
 
 assert_zero_count() {
   local label="$1"
   local sql="$2"
   local count
-  count="$(query_count "$sql")"
+  count="$(query_count "$label" "$sql")"
   (( count == 0 )) || fail "${label} invariant failed with ${count} offending aggregate row(s)."
   info "${label} invariant passed."
 }
@@ -179,15 +187,15 @@ if [[ "$NMKR_DB_STATE_ALLOW_ACTIVE_SYNC" == "true" ]]; then
   info "Active sync-state failure checks were skipped by configuration."
 else
   sync_option="$(wp_cli option get nmkr_sync_in_progress 2>/dev/null || true)"
-  sync_transient="$(read_option_value _transient_nmkr_sync_in_progress)"
-  progress_transient="$(read_option_value _transient_nmkr_sync_progress)"
+  sync_transient="$(read_option_value "Sync in-progress transient" _transient_nmkr_sync_in_progress)"
+  progress_transient="$(read_option_value "Sync progress transient" _transient_nmkr_sync_progress)"
   if is_truthy "$sync_option" || is_truthy "$sync_transient"; then
     fail "Active sync state detected; run Phase 8 validation only when no sync is active."
   fi
   if [[ "$progress_transient" =~ ^[0-9]+$ ]] && (( progress_transient >= 1 && progress_transient <= 99 )); then
     fail "Active sync state detected; run Phase 8 validation only when no sync is active."
   fi
-  active_stats="$(query_count "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('initializing','processing_projects','processing_tokens','in_progress','running','pending') AND (end_time IS NULL OR end_time = '');")"
+  active_stats="$(query_count "Active sync stats" "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('initializing','processing_projects','processing_tokens','in_progress','running','pending') AND (end_time IS NULL OR end_time = '');")"
   (( active_stats == 0 )) || fail "Active sync state detected; run Phase 8 validation only when no sync is active."
   info "No active sync state detected."
 fi
@@ -205,7 +213,7 @@ assert_zero_count "Sync stats impossible values" "SELECT COUNT(*) FROM ${sync_st
 assert_zero_count "Completed sync stats end_time" "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('completed','success') AND (end_time IS NULL OR end_time = '');"
 assert_zero_count "Completed sync stats item totals" "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('completed','success') AND items_processed > 0 AND (items_successful + items_failed) > items_processed;"
 
-latest_metric_time="$(query_scalar "SELECT last_sync_time FROM ${metrics_ident} ORDER BY last_sync_time DESC, id DESC LIMIT 1;" || true)"
+latest_metric_time="$(query_scalar "Latest sync metrics timestamp" "SELECT last_sync_time FROM ${metrics_ident} ORDER BY last_sync_time DESC, id DESC LIMIT 1;")"
 option_time="$(wp_cli option get "$last_sync_option" 2>/dev/null || true)"
 if [[ -n "$latest_metric_time" && -n "$option_time" && "$latest_metric_time" != "$option_time" ]]; then
   fail "Latest sync timestamp option does not match latest metrics timestamp."

--- a/scripts/nmkr-wpcli-db-state.sh
+++ b/scripts/nmkr-wpcli-db-state.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+WP_PATH="${WP_PATH:-}"
+WP_CLI_BIN="${WP_CLI_BIN:-wp}"
+NMKR_PLUGIN_SLUG="${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}"
+NMKR_DB_STATE_ALLOW_ACTIVE_SYNC="${NMKR_DB_STATE_ALLOW_ACTIVE_SYNC:-false}"
+
+info() {
+  printf 'INFO: %s\n' "$*"
+}
+
+fail() {
+  printf 'ERROR: %s\n' "$*" >&2
+  exit 1
+}
+
+wp_cli() {
+  local args=("$WP_CLI_BIN")
+
+  if [[ -n "$WP_PATH" ]]; then
+    args+=("--path=$WP_PATH")
+  fi
+
+  args+=("$@")
+  "${args[@]}"
+}
+
+sql_escape() {
+  printf "%s" "$1" | sed "s/'/''/g"
+}
+
+sql_ident() {
+  printf '`%s`' "$(printf "%s" "$1" | sed 's/`/``/g')"
+}
+
+query_scalar() {
+  local sql="$1"
+  wp_cli db query "$sql" --skip-column-names 2>/dev/null | tr -d '\r' | tail -n 1
+}
+
+query_count() {
+  local sql="$1"
+  local value
+  value="$(query_scalar "$sql" || printf '0')"
+  [[ "$value" =~ ^[0-9]+$ ]] || fail "Could not inspect database invariant count."
+  printf '%s' "$value"
+}
+
+assert_zero_count() {
+  local label="$1"
+  local sql="$2"
+  local count
+  count="$(query_count "$sql")"
+  (( count == 0 )) || fail "${label} invariant failed with ${count} offending aggregate row(s)."
+  info "${label} invariant passed."
+}
+
+is_truthy() {
+  local value
+  value="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' | xargs)"
+  case "$value" in
+    1|true|yes|on|running|in_progress|processing|processing_projects|processing_tokens|initializing|pending)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+info "Checking WordPress installation."
+wp_cli core is-installed >/dev/null
+
+info "Checking NMKR Connect plugin activation state."
+wp_cli plugin is-active "$NMKR_PLUGIN_SLUG" >/dev/null
+
+prefix="$(wp_cli db prefix)"
+projects_table="${prefix}nmkr_projects"
+tokens_table="${prefix}nmkr_tokens"
+token_details_table="${prefix}nmkr_token_details"
+sync_stats_table="${prefix}nmkr_sync_stats"
+metrics_table="${prefix}nmkr_sync_metrics"
+analytics_table="${prefix}nmkr_analytics"
+connect_options="nmkr_connect_options"
+last_sync_option="nmkr_last_sync_time"
+
+projects_ident="$(sql_ident "$projects_table")"
+tokens_ident="$(sql_ident "$tokens_table")"
+token_details_ident="$(sql_ident "$token_details_table")"
+sync_stats_ident="$(sql_ident "$sync_stats_table")"
+metrics_ident="$(sql_ident "$metrics_table")"
+analytics_ident="$(sql_ident "$analytics_table")"
+
+info "Checking required NMKR database tables."
+required_tables=("$projects_table" "$tokens_table" "$token_details_table" "$sync_stats_table" "$metrics_table" "$analytics_table")
+for table in "${required_tables[@]}"; do
+  escaped_table="$(sql_escape "$table")"
+  exists="$(wp_cli db query "SHOW TABLES LIKE '${escaped_table}';" --skip-column-names 2>/dev/null || true)"
+  [[ "$exists" == "$table" ]] || fail "Required NMKR table is missing."
+done
+info "Required NMKR database tables exist."
+
+info "Checking required schema columns."
+check_column() {
+  local table="$1"
+  local column="$2"
+  local escaped_column
+  escaped_column="$(sql_escape "$column")"
+  local exists
+  exists="$(wp_cli db query "SHOW COLUMNS FROM $(sql_ident "$table") LIKE '${escaped_column}';" --skip-column-names 2>/dev/null || true)"
+  [[ -n "$exists" ]] || fail "Required schema column is missing."
+}
+
+for column in id project_uid project_name state synced_at hash; do check_column "$projects_table" "$column"; done
+for column in id token_uid project_uid token_name state synced_at hash; do check_column "$tokens_table" "$column"; done
+for column in id token_uid receiver_address sell_date synced_at hash; do check_column "$token_details_table" "$column"; done
+for column in id sync_type start_time end_time status items_processed items_successful items_failed failure_breakdown; do check_column "$sync_stats_table" "$column"; done
+for column in id last_sync_time total_projects total_tokens total_sync_duration total_api_time average_response_time api_requests memory_usage created_at; do check_column "$metrics_table" "$column"; done
+for column in id event_ts event_type shortcode_type site_id meta_json created_at; do check_column "$analytics_table" "$column"; done
+info "Required schema columns exist."
+
+info "Checking required indexes and unique keys."
+check_index() {
+  local table="$1"
+  local key="$2"
+  local escaped_key
+  escaped_key="$(sql_escape "$key")"
+  local exists
+  exists="$(wp_cli db query "SHOW INDEX FROM $(sql_ident "$table") WHERE Key_name = '${escaped_key}';" --skip-column-names 2>/dev/null || true)"
+  [[ -n "$exists" ]] || fail "Required index or key is missing."
+}
+check_index "$projects_table" project_uid
+check_index "$tokens_table" token_uid
+check_index "$tokens_table" project_uid
+check_index "$token_details_table" token_uid
+check_index "$sync_stats_table" status
+check_index "$analytics_table" ix_site_ts
+check_index "$analytics_table" ix_event_ts
+info "Required indexes and unique keys exist."
+
+info "Checking activation/default options without printing values."
+options_json="$(wp_cli option get "$connect_options" --format=json 2>/dev/null)" || fail "Required NMKR options object is missing or unreadable."
+printf '%s' "$options_json" | python3 -c 'import json,sys; v=json.load(sys.stdin); required={"sync_profile","sync_batch_size","sync_batch_delay","sync_initial_interval","sync_max_interval","sync_interval_increase","sync_interval_decrease","sync_max_errors"}; assert isinstance(v, dict); missing=required-set(v); sys.exit(0 if not missing else 1)' || fail "Required NMKR option keys are missing."
+api_present="$(wp_cli option get nmkr_api_key --format=json 2>/dev/null | python3 -c 'import json,sys; print(1 if str(json.load(sys.stdin)).strip() else 0)' 2>/dev/null || printf '0')"
+if [[ "$api_present" != "1" ]]; then
+  api_present="$(printf '%s' "$options_json" | python3 -c 'import json,sys; v=json.load(sys.stdin); print(1 if isinstance(v, dict) and str(v.get("api_key", "")).strip() else 0)' 2>/dev/null || printf '0')"
+fi
+[[ "$api_present" == "1" ]] || fail "API key is missing or empty."
+info "API key is present and non-empty; value was not printed."
+
+if [[ "$NMKR_DB_STATE_ALLOW_ACTIVE_SYNC" == "true" ]]; then
+  info "Active sync-state failure checks were skipped by configuration."
+else
+  sync_option="$(wp_cli option get nmkr_sync_in_progress 2>/dev/null || true)"
+  sync_transient="$(wp_cli transient get nmkr_sync_in_progress 2>/dev/null || true)"
+  progress_transient="$(wp_cli transient get nmkr_sync_progress 2>/dev/null || true)"
+  if is_truthy "$sync_option" || is_truthy "$sync_transient"; then
+    fail "Active sync state detected; run Phase 8 validation only when no sync is active."
+  fi
+  if [[ "$progress_transient" =~ ^[0-9]+$ ]] && (( progress_transient >= 1 && progress_transient <= 99 )); then
+    fail "Active sync state detected; run Phase 8 validation only when no sync is active."
+  fi
+  active_stats="$(query_count "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('initializing','processing_projects','processing_tokens','in_progress','running','pending') AND (end_time IS NULL OR end_time = '');")"
+  (( active_stats == 0 )) || fail "Active sync state detected; run Phase 8 validation only when no sync is active."
+  info "No active sync state detected."
+fi
+
+info "Checking database integrity invariants using aggregate counts only."
+assert_zero_count "Duplicate project_uid" "SELECT COUNT(*) FROM (SELECT project_uid FROM ${projects_ident} GROUP BY project_uid HAVING COUNT(*) > 1) duplicates;"
+assert_zero_count "Duplicate token_uid" "SELECT COUNT(*) FROM (SELECT token_uid FROM ${tokens_ident} GROUP BY token_uid HAVING COUNT(*) > 1) duplicates;"
+assert_zero_count "Duplicate token detail token_uid" "SELECT COUNT(*) FROM (SELECT token_uid FROM ${token_details_ident} GROUP BY token_uid HAVING COUNT(*) > 1) duplicates;"
+assert_zero_count "Token project relationship" "SELECT COUNT(*) FROM ${tokens_ident} t LEFT JOIN ${projects_ident} p ON p.project_uid = t.project_uid WHERE t.project_uid IS NOT NULL AND t.project_uid <> '' AND p.id IS NULL;"
+assert_zero_count "Token detail relationship" "SELECT COUNT(*) FROM ${token_details_ident} d LEFT JOIN ${tokens_ident} t ON t.token_uid = d.token_uid WHERE d.token_uid IS NOT NULL AND d.token_uid <> '' AND t.id IS NULL;"
+assert_zero_count "Project negative counts" "SELECT COUNT(*) FROM ${projects_ident} WHERE free < 0 OR sold < 0 OR reserved < 0 OR total < 0 OR blocked < 0 OR total_blocked < 0 OR total_tokens < 0;"
+assert_zero_count "Token negative numeric values" "SELECT COUNT(*) FROM ${tokens_ident} WHERE token_amount < 0 OR price < 0;"
+assert_zero_count "Sync metrics impossible values" "SELECT COUNT(*) FROM ${metrics_ident} WHERE total_projects < 0 OR total_tokens < 0 OR total_sync_duration < 0 OR total_api_time < 0 OR average_response_time < 0 OR api_requests < 0 OR memory_usage < 0 OR last_sync_time IS NULL;"
+assert_zero_count "Sync stats impossible values" "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE start_time IS NULL OR items_processed < 0 OR items_successful < 0 OR items_failed < 0 OR (end_time IS NOT NULL AND end_time < start_time);"
+assert_zero_count "Completed sync stats end_time" "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('completed','success') AND (end_time IS NULL OR end_time = '');"
+assert_zero_count "Completed sync stats item totals" "SELECT COUNT(*) FROM ${sync_stats_ident} WHERE status IN ('completed','success') AND items_processed > 0 AND (items_successful + items_failed) > items_processed;"
+
+latest_metric_time="$(query_scalar "SELECT last_sync_time FROM ${metrics_ident} ORDER BY last_sync_time DESC, id DESC LIMIT 1;" || true)"
+option_time="$(wp_cli option get "$last_sync_option" 2>/dev/null || true)"
+if [[ -n "$latest_metric_time" && -n "$option_time" && "$latest_metric_time" != "$option_time" ]]; then
+  fail "Latest sync timestamp option does not match latest metrics timestamp."
+fi
+info "Latest sync timestamp option matches metrics when both values exist."
+
+info "PASS: NMKR Connect WP-CLI database-state checks completed without mutations."

--- a/scripts/nmkr-wpcli-db-state.sh
+++ b/scripts/nmkr-wpcli-db-state.sh
@@ -36,15 +36,39 @@ sql_ident() {
 
 query_scalar() {
   local sql="$1"
-  wp_cli db query "$sql" --skip-column-names 2>/dev/null | tr -d '\r' | tail -n 1
+  local value
+
+  if ! value="$(wp_cli db query "$sql" --skip-column-names 2>/dev/null | tr -d '\r' | tail -n 1)"; then
+    fail "Database invariant query failed."
+  fi
+
+  printf '%s' "$value"
+}
+
+query_optional_scalar() {
+  local sql="$1"
+  local value
+
+  if ! value="$(wp_cli db query "$sql" --skip-column-names 2>/dev/null | tr -d '\r' | tail -n 1)"; then
+    fail "Optional database read failed."
+  fi
+
+  printf '%s' "$value"
 }
 
 query_count() {
   local sql="$1"
   local value
-  value="$(query_scalar "$sql" || printf '0')"
+  value="$(query_scalar "$sql")"
   [[ "$value" =~ ^[0-9]+$ ]] || fail "Could not inspect database invariant count."
   printf '%s' "$value"
+}
+
+read_option_value() {
+  local option_name="$1"
+  local escaped_option
+  escaped_option="$(sql_escape "$option_name")"
+  query_optional_scalar "SELECT option_value FROM ${options_ident} WHERE option_name = '${escaped_option}' LIMIT 1;"
 }
 
 assert_zero_count() {
@@ -82,6 +106,7 @@ token_details_table="${prefix}nmkr_token_details"
 sync_stats_table="${prefix}nmkr_sync_stats"
 metrics_table="${prefix}nmkr_sync_metrics"
 analytics_table="${prefix}nmkr_analytics"
+options_table="${prefix}options"
 connect_options="nmkr_connect_options"
 last_sync_option="nmkr_last_sync_time"
 
@@ -91,6 +116,7 @@ token_details_ident="$(sql_ident "$token_details_table")"
 sync_stats_ident="$(sql_ident "$sync_stats_table")"
 metrics_ident="$(sql_ident "$metrics_table")"
 analytics_ident="$(sql_ident "$analytics_table")"
+options_ident="$(sql_ident "$options_table")"
 
 info "Checking required NMKR database tables."
 required_tables=("$projects_table" "$tokens_table" "$token_details_table" "$sync_stats_table" "$metrics_table" "$analytics_table")
@@ -153,8 +179,8 @@ if [[ "$NMKR_DB_STATE_ALLOW_ACTIVE_SYNC" == "true" ]]; then
   info "Active sync-state failure checks were skipped by configuration."
 else
   sync_option="$(wp_cli option get nmkr_sync_in_progress 2>/dev/null || true)"
-  sync_transient="$(wp_cli transient get nmkr_sync_in_progress 2>/dev/null || true)"
-  progress_transient="$(wp_cli transient get nmkr_sync_progress 2>/dev/null || true)"
+  sync_transient="$(read_option_value _transient_nmkr_sync_in_progress)"
+  progress_transient="$(read_option_value _transient_nmkr_sync_progress)"
   if is_truthy "$sync_option" || is_truthy "$sync_transient"; then
     fail "Active sync state detected; run Phase 8 validation only when no sync is active."
   fi


### PR DESCRIPTION
### Motivation

- Add a read-only WP-CLI validation layer to detect schema, index, option, sync-state, and data-integrity problems without mutating plugin or site state.
- Surface a deterministic Phase 8 validation step in the existing Phase 2 runner so maintainers can run deeper DB invariants after deployment and browser smoke checks.

### Description

- Add `scripts/nmkr-wpcli-db-state.sh`, a read-only Bash validator that uses `wp` and `wp db query` to assert plugin activation, required NMKR tables, required schema columns, required indexes/keys, required `nmkr_connect_options` keys, API key presence (without printing it), absence of active sync state by default, aggregate data-integrity invariants, and sync metrics/stats sanity checks; the script prints only public-safe messages and aggregate counts and exits non-zero on failures.
- Add `test:wpcli:db-state` npm script that runs `bash scripts/nmkr-wpcli-db-state.sh` for focused Phase 8 validation.
- Wire the DB-state step into `scripts/nmkr-phase2-test-runner.sh` as a separate step with a `DBSTATE_STATUS` summary line and private log file (`wpcli-db-state.log`), executed after the existing WP-CLI smoke checks and failing the run with its own exit code when necessary.
- Add `docs/testing-phase-8.md` documenting the Phase 8 purpose, usage, guarded `NMKR_DB_STATE_ALLOW_ACTIVE_SYNC` behavior, and public-safety/read-only guarantees, and update `docs/testing-phase-2.md` to include the new DB-state stage and expected summary output.

### Testing

- `bash -n scripts/*.sh` was run and reported no syntax errors for the new and existing scripts.
- `npm run test:public` ran and completed successfully (public-safe checks and Playwright test discovery passed) in this environment.
- `git diff --check` and repository script/style checks were run and reported no problems.
- `npm run test:wpcli:db-state` was attempted in this environment but could not complete because the private Phase 2 env was not available and `wp` was not present; the script is expected to pass in the private VM when run against a deployed site with no active sync state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f9fbb21dc83339748f1ac76764ecc)