### PR TITLE
Refactor Playwright admin AJAX harness helpers

### DIFF
--- a/docs/testing-phase-7.md
+++ b/docs/testing-phase-7.md
@@ -13,7 +13,7 @@ The regression verifies that the dashboard can render a realistic sync lifecycle
 
 ## What the test simulates
 
-The test logs in with the shared WordPress admin helpers, opens `NMKR_DASHBOARD_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-dashboard`), and routes dashboard AJAX calls to local JSON responses.
+The test logs in with the shared WordPress admin helpers, opens `NMKR_DASHBOARD_PATH` (defaulting to `/wp-admin/admin.php?page=nmkr-connect-dashboard`), and routes dashboard AJAX calls through the shared Playwright helper `tests/e2e/helpers/admin-ajax.ts` to local JSON responses.
 
 Locally stubbed AJAX actions are:
 
@@ -37,7 +37,7 @@ The Phase 7 regression is intentionally non-mutating:
 - It does not assert, print, snapshot, or expose nonce values.
 - It does not assert, print, snapshot, or expose API keys, credentials, private URLs, environment values, or logs.
 
-The Playwright route guard records blocked mutating actions and fulfills them locally with harmless JSON if they are attempted, then fails the test if any were observed. Sync/dashboard AJAX actions used by the regression are stubbed locally in Playwright and do not reach WordPress.
+The shared Playwright route guard in `tests/e2e/helpers/admin-ajax.ts` records blocked mutating actions and fulfills them locally with harmless JSON if they are attempted, then fails the test if any were observed. Sync/dashboard AJAX actions used by the regression are stubbed locally in Playwright and do not reach WordPress.
 
 ## Commands
 

--- a/docs/testing-phase-9.md
+++ b/docs/testing-phase-9.md
@@ -8,12 +8,12 @@ The test validates that `window.NMKRProgress.startPolling()` can handle both ret
 
 - Soft, transient polling failures keep the active sync UI in a non-fatal retry state and recover when polling succeeds again.
 - Hard security/capability failures stop polling, show an error state, hide Stop, and restore Start.
-- Every expected read-only AJAX response is served by the Playwright route handler.
+- Every expected read-only AJAX response is served by the shared Playwright route helper.
 - Mutating or unsafe AJAX actions are blocked locally and recorded as test failures.
 
 ## Non-mutating model
 
-The spec installs the `wp-admin/admin-ajax.php` route before any WordPress admin navigation. The route fulfills known read-only requests with public-safe test JSON and blocks unsafe actions with harmless local JSON. The test triggers polling only through `window.NMKRProgress.startPolling()` and never clicks Start or Stop.
+The spec installs the shared `tests/e2e/helpers/admin-ajax.ts` `wp-admin/admin-ajax.php` route before any WordPress admin navigation. The route fulfills known read-only requests with public-safe test JSON and blocks unsafe actions with harmless local JSON. The test triggers polling only through `window.NMKRProgress.startPolling()` and never clicks Start or Stop.
 
 ## Stubbed read actions
 

--- a/tests/e2e/helpers/admin-ajax.ts
+++ b/tests/e2e/helpers/admin-ajax.ts
@@ -1,0 +1,242 @@
+import { Page } from "@playwright/test";
+
+export const ADMIN_AJAX_ROUTE_PATTERN = "**/wp-admin/admin-ajax.php";
+
+export const SYNC_READ_ACTIONS = [
+  "nmkr_check_api_status",
+  "nmkr_sync_progress",
+  "nmkr_get_sync_statistics",
+] as const;
+
+export const DEFAULT_BLOCKED_SYNC_MUTATING_ACTIONS = [
+  "nmkr_start_sync",
+  "nmkr_stop_sync",
+  "nmkr_force_stop_sync",
+  "nmkr_restart_sync_batch",
+  "nmkr_cleanup_sync_jobs",
+  "nmkr_store_active_metrics",
+  "nmkr_clear_all_logs",
+  "nmkr_clear_section_logs",
+] as const;
+
+export type AdminAjaxRequestContext = {
+  action: string | null;
+  params: URLSearchParams;
+  postDataPresent: boolean;
+  actionCount: number;
+  progressCallCount: number;
+  progressActionsWithCacheBuster: number;
+  statisticsCallCount: number;
+  state: {
+    completionSeen: boolean;
+  };
+};
+
+export type AdminAjaxFulfillment = {
+  status?: number;
+  contentType?: string;
+  body: unknown;
+};
+
+export type AdminAjaxHandler = (
+  context: AdminAjaxRequestContext,
+) => AdminAjaxFulfillment | Promise<AdminAjaxFulfillment>;
+
+export type AdminAjaxActionHandlers = Partial<Record<string, AdminAjaxHandler>>;
+
+export type AdminAjaxHarness = {
+  blockedActions: string[];
+  actionCount: (action: string) => number;
+  progressCallCount: () => number;
+  progressActionsWithCacheBuster: () => number;
+  statisticsCallCount: () => number;
+  statisticsCallsAfterCompletion: () => number;
+  markCompletionSeen: () => void;
+  completionSeen: () => boolean;
+};
+
+type AdminAjaxHarnessOptions = {
+  allowedActions: readonly string[];
+  blockedMutatingActions: readonly string[];
+  handlers: AdminAjaxActionHandlers;
+};
+
+type NmkrSyncAjaxHarnessOptions = {
+  onSyncProgress?: AdminAjaxHandler;
+  apiStatusPayload?: unknown;
+  syncStatisticsPayload?: unknown;
+  handlers?: AdminAjaxActionHandlers;
+  allowedActions?: readonly string[];
+  blockedMutatingActions?: readonly string[];
+};
+
+export function defaultApiStatusPayload(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    success: true,
+    data: {
+      message: "Test stub: API status check skipped.",
+      connected: true,
+      sync_in_progress: false,
+      progress: 0,
+      heartbeat_age: -1,
+      last_update: 0,
+      grace: 0,
+      last_result: "",
+      last_recovery_at: 0,
+      ...overrides,
+    },
+  };
+}
+
+export function defaultSyncStatisticsPayload(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    success: true,
+    data: {
+      last_sync_time: "Not run in resilience test",
+      total_projects: 0,
+      total_tokens: 0,
+      total_sync_duration: "0s",
+      total_api_time: "0s",
+      average_response_time: "0.00ms",
+      average_response_time_raw: 0,
+      api_requests: 0,
+      memory_usage: "0 MB",
+      memory_usage_raw: 0,
+      response_time_class: "status-neutral",
+      memory_class: "status-neutral",
+      ...overrides,
+    },
+  };
+}
+
+export async function installAdminAjaxHarness(
+  page: Page,
+  options: AdminAjaxHarnessOptions,
+): Promise<AdminAjaxHarness> {
+  const allowedActions = new Set(options.allowedActions);
+  const blockedMutatingActions = new Set(options.blockedMutatingActions);
+  const blockedActions: string[] = [];
+  const actionCounts = new Map<string, number>();
+  const state = { completionSeen: false };
+  let progressCallCount = 0;
+  let progressActionsWithCacheBuster = 0;
+  let statisticsCallCount = 0;
+  let statisticsCallsAfterCompletion = 0;
+
+  await page.route(ADMIN_AJAX_ROUTE_PATTERN, async (route, request) => {
+    const postData = request.postData();
+    const params = new URLSearchParams(postData || "");
+    const action = params.get("action");
+
+    if (action) {
+      actionCounts.set(action, (actionCounts.get(action) || 0) + 1);
+    }
+
+    if (action === "nmkr_sync_progress") {
+      progressCallCount += 1;
+      if (params.has("_")) {
+        progressActionsWithCacheBuster += 1;
+      }
+    }
+
+    if (action === "nmkr_get_sync_statistics") {
+      statisticsCallCount += 1;
+      if (state.completionSeen) {
+        statisticsCallsAfterCompletion += 1;
+      }
+    }
+
+    if (action && blockedMutatingActions.has(action)) {
+      blockedActions.push(action);
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: { message: "Test stub: mutating sync action skipped." },
+        }),
+      });
+      return;
+    }
+
+    const handler = action ? options.handlers[action] : undefined;
+    if (handler) {
+      const fulfillment = await handler({
+        action,
+        params,
+        postDataPresent: postData !== null,
+        actionCount: action ? actionCounts.get(action) || 0 : 0,
+        progressCallCount,
+        progressActionsWithCacheBuster,
+        statisticsCallCount,
+        state,
+      });
+      await route.fulfill({
+        status: fulfillment.status,
+        contentType: fulfillment.contentType || "application/json",
+        body: JSON.stringify(fulfillment.body),
+      });
+      return;
+    }
+
+    if (action && allowedActions.has(action)) {
+      throw new Error(`Unhandled allowed stubbed action: ${action}`);
+    }
+
+    await route.continue();
+  });
+
+  return {
+    blockedActions,
+    actionCount: (action: string) => actionCounts.get(action) || 0,
+    progressCallCount: () => progressCallCount,
+    progressActionsWithCacheBuster: () => progressActionsWithCacheBuster,
+    statisticsCallCount: () => statisticsCallCount,
+    statisticsCallsAfterCompletion: () => statisticsCallsAfterCompletion,
+    markCompletionSeen: () => {
+      state.completionSeen = true;
+    },
+    completionSeen: () => state.completionSeen,
+  };
+}
+
+export async function installNmkrSyncAjaxHarness(
+  page: Page,
+  options: NmkrSyncAjaxHarnessOptions = {},
+): Promise<AdminAjaxHarness> {
+  const handlers: AdminAjaxActionHandlers = {
+    nmkr_check_api_status: () => ({
+      body: options.apiStatusPayload || defaultApiStatusPayload(),
+    }),
+    nmkr_get_sync_statistics: () => ({
+      body: options.syncStatisticsPayload || defaultSyncStatisticsPayload(),
+    }),
+    ...(options.handlers || {}),
+  };
+
+  if (options.onSyncProgress) {
+    handlers.nmkr_sync_progress = options.onSyncProgress;
+  }
+
+  return installAdminAjaxHarness(page, {
+    allowedActions: options.allowedActions || SYNC_READ_ACTIONS,
+    blockedMutatingActions:
+      options.blockedMutatingActions || DEFAULT_BLOCKED_SYNC_MUTATING_ACTIONS,
+    handlers,
+  });
+}
+
+export async function startPollingFromWindow(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const progress = (
+      window as Window & { NMKRProgress?: { startPolling?: () => void } }
+    ).NMKRProgress;
+    if (!progress || typeof progress.startPolling !== "function") {
+      throw new Error("NMKRProgress.startPolling is not available.");
+    }
+    progress.startPolling();
+  });
+}

--- a/tests/e2e/nmkr-sync-resilience.regression.spec.ts
+++ b/tests/e2e/nmkr-sync-resilience.regression.spec.ts
@@ -1,22 +1,10 @@
 import { expect, Page, test } from "@playwright/test";
+import {
+  installNmkrSyncAjaxHarness,
+  startPollingFromWindow,
+  type AdminAjaxHarness,
+} from "./helpers/admin-ajax";
 import { env, expectWpAdmin, loginToWpAdmin, urlFor } from "./helpers/wp-admin";
-
-const allowedStubbedActions = new Set([
-  "nmkr_check_api_status",
-  "nmkr_sync_progress",
-  "nmkr_get_sync_statistics",
-]);
-
-const blockedMutatingActions = new Set([
-  "nmkr_start_sync",
-  "nmkr_stop_sync",
-  "nmkr_force_stop_sync",
-  "nmkr_restart_sync_batch",
-  "nmkr_cleanup_sync_jobs",
-  "nmkr_store_active_metrics",
-  "nmkr_clear_all_logs",
-  "nmkr_clear_section_logs",
-]);
 
 const dashboardPath = env(
   "NMKR_DASHBOARD_PATH",
@@ -25,12 +13,6 @@ const dashboardPath = env(
 const fixedUpdatedAt = 1783596000;
 
 type ProgressMode = "soft-retry" | "hard-failure";
-
-type AjaxHarness = {
-  blockedActions: string[];
-  progressActionsWithCacheBuster: () => number;
-  progressCallCount: () => number;
-};
 
 function inProgressPayload(progress: number, currentItem: string) {
   return {
@@ -57,136 +39,40 @@ function inProgressPayload(progress: number, currentItem: string) {
   };
 }
 
-async function installAdminAjaxHarness(
-  page: Page,
-  mode: ProgressMode,
-): Promise<AjaxHarness> {
-  const blockedActions: string[] = [];
-  let progressCallCount = 0;
-  let progressActionsWithCacheBuster = 0;
-
-  await page.route("**/wp-admin/admin-ajax.php", async (route, request) => {
-    const params = new URLSearchParams(request.postData() || "");
-    const action = params.get("action");
-
-    if (action === "nmkr_check_api_status") {
-      await route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify({
-          success: true,
-          data: {
-            message: "Test stub: API status check skipped.",
-            connected: true,
-            sync_in_progress: false,
-            progress: 0,
-            heartbeat_age: -1,
-            last_update: 0,
-            grace: 0,
-            last_result: "",
-            last_recovery_at: 0,
-          },
-        }),
-      });
-      return;
-    }
-
-    if (action === "nmkr_sync_progress") {
-      progressCallCount += 1;
-      if (params.has("_")) {
-        progressActionsWithCacheBuster += 1;
-      }
-
-      if (mode === "soft-retry" && progressCallCount === 1) {
-        await route.fulfill({
-          status: 503,
-          contentType: "application/json",
-          body: JSON.stringify({
-            success: false,
-            data: { message: "Temporary sync polling interruption." },
-          }),
-        });
-        return;
-      }
-
-      if (mode === "hard-failure") {
-        await route.fulfill({
-          status: 403,
-          contentType: "application/json",
-          body: JSON.stringify({
-            success: false,
-            data: { message: "Forbidden" },
-          }),
-        });
-        return;
-      }
-
-      await route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify(
-          inProgressPayload(
-            42,
-            "Recovered test progress after transient polling failure",
-          ),
-        ),
-      });
-      return;
-    }
-
-    if (action === "nmkr_get_sync_statistics") {
-      await route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify({
-          success: true,
-          data: {
-            last_sync_time: "Not run in resilience test",
-            total_projects: 0,
-            total_tokens: 0,
-            total_sync_duration: "0s",
-            total_api_time: "0s",
-            average_response_time: "0.00ms",
-            average_response_time_raw: 0,
-            api_requests: 0,
-            memory_usage: "0 MB",
-            memory_usage_raw: 0,
-            response_time_class: "status-neutral",
-            memory_class: "status-neutral",
-          },
-        }),
-      });
-      return;
-    }
-
-    if (action && blockedMutatingActions.has(action)) {
-      blockedActions.push(action);
-      await route.fulfill({
-        contentType: "application/json",
-        body: JSON.stringify({
-          success: true,
-          data: { message: "Test stub: mutating sync action skipped." },
-        }),
-      });
-      return;
-    }
-
-    if (action && allowedStubbedActions.has(action)) {
-      throw new Error(`Unhandled allowed stubbed action: ${action}`);
-    }
-
-    await route.continue();
-  });
-
-  return {
-    blockedActions,
-    progressActionsWithCacheBuster: () => progressActionsWithCacheBuster,
-    progressCallCount: () => progressCallCount,
-  };
-}
-
 async function openDashboardWithHarness(
   page: Page,
   mode: ProgressMode,
-): Promise<AjaxHarness> {
-  const harness = await installAdminAjaxHarness(page, mode);
+): Promise<AdminAjaxHarness> {
+  const harness = await installNmkrSyncAjaxHarness(page, {
+    onSyncProgress: ({ progressCallCount }) => {
+      if (mode === "soft-retry" && progressCallCount === 1) {
+        return {
+          status: 503,
+          body: {
+            success: false,
+            data: { message: "Temporary sync polling interruption." },
+          },
+        };
+      }
+
+      if (mode === "hard-failure") {
+        return {
+          status: 403,
+          body: {
+            success: false,
+            data: { message: "Forbidden" },
+          },
+        };
+      }
+
+      return {
+        body: inProgressPayload(
+          42,
+          "Recovered test progress after transient polling failure",
+        ),
+      };
+    },
+  });
   const baseUrl = await loginToWpAdmin(page);
   await page.goto(urlFor(baseUrl, dashboardPath));
   await expectWpAdmin(page);
@@ -197,18 +83,6 @@ async function openDashboardWithHarness(
   await expect(page.locator("#nmkr-sync-button")).toBeAttached();
   await expect(page.locator("#nmkr-stop-sync-button")).toBeAttached();
   return harness;
-}
-
-async function startPollingFromWindow(page: Page): Promise<void> {
-  await page.evaluate(() => {
-    const progress = (
-      window as Window & { NMKRProgress?: { startPolling?: () => void } }
-    ).NMKRProgress;
-    if (!progress || typeof progress.startPolling !== "function") {
-      throw new Error("NMKRProgress.startPolling is not available.");
-    }
-    progress.startPolling();
-  });
 }
 
 test.describe("NMKR Connect sync AJAX resilience regression", () => {

--- a/tests/e2e/nmkr-sync-state.regression.spec.ts
+++ b/tests/e2e/nmkr-sync-state.regression.spec.ts
@@ -1,22 +1,9 @@
-import { expect, test } from '@playwright/test';
-import { env, expectWpAdmin, loginToWpAdmin, urlFor } from './helpers/wp-admin';
-
-const allowedStubbedActions = new Set([
-  'nmkr_check_api_status',
-  'nmkr_sync_progress',
-  'nmkr_get_sync_statistics',
-]);
-
-const blockedMutatingActions = new Set([
-  'nmkr_start_sync',
-  'nmkr_stop_sync',
-  'nmkr_force_stop_sync',
-  'nmkr_restart_sync_batch',
-  'nmkr_cleanup_sync_jobs',
-  'nmkr_store_active_metrics',
-  'nmkr_clear_all_logs',
-  'nmkr_clear_section_logs',
-]);
+import { expect, test } from "@playwright/test";
+import {
+  installNmkrSyncAjaxHarness,
+  startPollingFromWindow,
+} from "./helpers/admin-ajax";
+import { env, expectWpAdmin, loginToWpAdmin, urlFor } from "./helpers/wp-admin";
 
 const fixedUpdatedAt = 1783596000;
 
@@ -26,11 +13,11 @@ function progressPayload(progressCallCount: number) {
       success: true,
       data: {
         progress: 37,
-        current_item: 'Processing test project',
+        current_item: "Processing test project",
         in_progress: true,
         finished: false,
         aborted: false,
-        error: '',
+        error: "",
         total_items: 100,
         live_metrics: {
           total_projects: 3,
@@ -50,11 +37,11 @@ function progressPayload(progressCallCount: number) {
     success: true,
     data: {
       progress: 100,
-      current_item: 'All data synchronized',
+      current_item: "All data synchronized",
       in_progress: false,
       finished: true,
       aborted: false,
-      error: '',
+      error: "",
       total_items: 100,
       live_metrics: {
         total_projects: 3,
@@ -70,90 +57,38 @@ function progressPayload(progressCallCount: number) {
   };
 }
 
-test.describe('NMKR Connect sync-state regression', () => {
-  test('simulates active sync progress and completion without mutating WordPress state', async ({ page }) => {
-    const dashboardPath = env('NMKR_DASHBOARD_PATH', '/wp-admin/admin.php?page=nmkr-connect-dashboard');
-    const unexpectedMutatingActions: string[] = [];
-    let progressCallCount = 0;
-    let statisticsCallCount = 0;
-    let statisticsCallsAfterCompletion = 0;
-    let completionSeen = false;
-
-    await page.route('**/wp-admin/admin-ajax.php', async (route, request) => {
-      const params = new URLSearchParams(request.postData() || '');
-      const action = params.get('action');
-
-      if (action === 'nmkr_check_api_status') {
-        await route.fulfill({
-          contentType: 'application/json',
-          body: JSON.stringify({
-            success: true,
-            data: {
-              message: 'Test stub: API status check skipped.',
-              connected: true,
-              sync_in_progress: false,
-              progress: 0,
-              heartbeat_age: -1,
-              last_update: 0,
-              grace: 0,
-              last_result: '',
-              last_recovery_at: 0,
-            },
-          }),
-        });
-        return;
-      }
-
-      if (action === 'nmkr_sync_progress') {
-        progressCallCount += 1;
+test.describe("NMKR Connect sync-state regression", () => {
+  test("simulates active sync progress and completion without mutating WordPress state", async ({
+    page,
+  }) => {
+    const dashboardPath = env(
+      "NMKR_DASHBOARD_PATH",
+      "/wp-admin/admin.php?page=nmkr-connect-dashboard",
+    );
+    const harness = await installNmkrSyncAjaxHarness(page, {
+      onSyncProgress: ({ progressCallCount, state }) => {
         const payload = progressPayload(progressCallCount);
-        completionSeen = completionSeen || payload.data.finished === true;
-        await route.fulfill({ contentType: 'application/json', body: JSON.stringify(payload) });
-        return;
-      }
-
-      if (action === 'nmkr_get_sync_statistics') {
-        statisticsCallCount += 1;
-        if (completionSeen) {
-          statisticsCallsAfterCompletion += 1;
-        }
-        await route.fulfill({
-          contentType: 'application/json',
-          body: JSON.stringify({
-            success: true,
-            data: {
-              last_sync_time: '2026-07-09 11:20 UTC',
-              total_projects: 3,
-              total_tokens: 14,
-              total_sync_duration: '12.5s',
-              total_api_time: '1.25s',
-              average_response_time: '310.00ms',
-              average_response_time_raw: 0.31,
-              api_requests: 4,
-              memory_usage: '24.5 MB',
-              memory_usage_raw: 24.5,
-              response_time_class: 'status-excellent',
-              memory_class: 'status-excellent',
-            },
-          }),
-        });
-        return;
-      }
-
-      if (action && blockedMutatingActions.has(action)) {
-        unexpectedMutatingActions.push(action);
-        await route.fulfill({
-          contentType: 'application/json',
-          body: JSON.stringify({ success: true, data: { message: 'Test stub: mutating sync action skipped.' } }),
-        });
-        return;
-      }
-
-      if (action && allowedStubbedActions.has(action)) {
-        throw new Error(`Unhandled allowed stubbed action: ${action}`);
-      }
-
-      await route.continue();
+        state.completionSeen =
+          state.completionSeen || payload.data.finished === true;
+        return { body: payload };
+      },
+      syncStatisticsPayload: {
+        success: true,
+        data: {
+          last_sync_time: "2026-07-09 11:20 UTC",
+          total_projects: 3,
+          total_tokens: 14,
+          total_sync_duration: "12.5s",
+          total_api_time: "1.25s",
+          average_response_time: "310.00ms",
+          average_response_time_raw: 0.31,
+          api_requests: 4,
+          memory_usage: "24.5 MB",
+          memory_usage_raw: 24.5,
+          response_time_class: "status-excellent",
+          memory_class: "status-excellent",
+        },
+      },
     });
 
     const baseUrl = await loginToWpAdmin(page);
@@ -161,48 +96,52 @@ test.describe('NMKR Connect sync-state regression', () => {
     await expectWpAdmin(page);
     await expect(page).toHaveURL(/page=nmkr-connect-dashboard/);
 
-    await expect(page.locator('.sync-data')).toBeAttached();
-    await expect(page.locator('#nmkr-sync-progress-container')).toBeAttached();
-    await expect(page.locator('#nmkr-sync-progress-bar')).toBeAttached();
-    await expect(page.locator('#status-message')).toBeAttached();
-    await expect(page.locator('#active-sync-metrics')).toBeAttached();
-    await expect(page.locator('.sync-statistics')).toBeAttached();
+    await expect(page.locator(".sync-data")).toBeAttached();
+    await expect(page.locator("#nmkr-sync-progress-container")).toBeAttached();
+    await expect(page.locator("#nmkr-sync-progress-bar")).toBeAttached();
+    await expect(page.locator("#status-message")).toBeAttached();
+    await expect(page.locator("#active-sync-metrics")).toBeAttached();
+    await expect(page.locator(".sync-statistics")).toBeAttached();
 
-    const startButton = page.locator('#nmkr-sync-button');
-    const stopButton = page.locator('#nmkr-stop-sync-button');
+    const startButton = page.locator("#nmkr-sync-button");
+    const stopButton = page.locator("#nmkr-stop-sync-button");
     await expect(startButton).toBeAttached();
     await expect(stopButton).toBeAttached();
 
-    await page.evaluate(() => {
-      const progress = (window as Window & { NMKRProgress?: { startPolling?: () => void } }).NMKRProgress;
-      if (!progress || typeof progress.startPolling !== 'function') {
-        throw new Error('NMKRProgress.startPolling is not available.');
-      }
-      progress.startPolling();
-    });
+    await startPollingFromWindow(page);
 
-    await expect(page.locator('#nmkr-sync-progress-bar')).toContainText('37%');
-    await expect(page.locator('#status-message')).toContainText('Processing test project');
-    await expect(page.locator('#active-sync-metrics')).toBeVisible();
-    await expect(page.locator('.total-projects-active')).toContainText('3');
-    await expect(page.locator('.total-tokens-active')).toContainText('14');
-    await expect(page.locator('.api-requests')).toContainText('4');
-    await expect(page.locator('.memory-usage')).toContainText(/\S+/);
+    await expect(page.locator("#nmkr-sync-progress-bar")).toContainText("37%");
+    await expect(page.locator("#status-message")).toContainText(
+      "Processing test project",
+    );
+    await expect(page.locator("#active-sync-metrics")).toBeVisible();
+    await expect(page.locator(".total-projects-active")).toContainText("3");
+    await expect(page.locator(".total-tokens-active")).toContainText("14");
+    await expect(page.locator(".api-requests")).toContainText("4");
+    await expect(page.locator(".memory-usage")).toContainText(/\S+/);
 
-    await expect(page.locator('#nmkr-sync-progress-bar')).toContainText('100%', { timeout: 7000 });
-    await expect(page.locator('#status-message')).toContainText(/Synchronization completed successfully|All data synchronized/);
+    await expect(page.locator("#nmkr-sync-progress-bar")).toContainText(
+      "100%",
+      { timeout: 7000 },
+    );
+    await expect(page.locator("#status-message")).toContainText(
+      /Synchronization completed successfully|All data synchronized/,
+    );
     await expect(startButton).toBeVisible();
     await expect(startButton).toBeEnabled();
     await expect(stopButton).toBeHidden();
 
-    await expect(page.locator('#last-synced')).toContainText('2026-07-09 11:20 UTC', { timeout: 3000 });
-    await expect(page.locator('#total-projects')).toContainText('3');
-    await expect(page.locator('#total-tokens')).toContainText('14');
-    await expect(page.locator('#request-count')).toContainText('4');
+    await expect(page.locator("#last-synced")).toContainText(
+      "2026-07-09 11:20 UTC",
+      { timeout: 3000 },
+    );
+    await expect(page.locator("#total-projects")).toContainText("3");
+    await expect(page.locator("#total-tokens")).toContainText("14");
+    await expect(page.locator("#request-count")).toContainText("4");
 
-    expect(unexpectedMutatingActions).toEqual([]);
-    expect(progressCallCount).toBeGreaterThanOrEqual(2);
-    expect(statisticsCallCount).toBeGreaterThanOrEqual(1);
-    expect(statisticsCallsAfterCompletion).toBeGreaterThanOrEqual(1);
+    expect(harness.blockedActions).toEqual([]);
+    expect(harness.progressCallCount()).toBeGreaterThanOrEqual(2);
+    expect(harness.statisticsCallCount()).toBeGreaterThanOrEqual(1);
+    expect(harness.statisticsCallsAfterCompletion()).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
### Motivation
- Consolidate duplicated Playwright admin-AJAX route/stubbing logic from Phase 7 and Phase 9 into a single shared test-only helper to reduce duplication and make the sync harness reusable while preserving existing test semantics.
- Keep production PHP/JS untouched and continue to block all mutating sync AJAX actions locally to ensure tests remain non-mutating and public-safe.

### Description
- Add a shared helper `tests/e2e/helpers/admin-ajax.ts` that exports `ADMIN_AJAX_ROUTE_PATTERN`, `SYNC_READ_ACTIONS`, `DEFAULT_BLOCKED_SYNC_MUTATING_ACTIONS`, narrow TypeScript types, `defaultApiStatusPayload()`, `defaultSyncStatisticsPayload()`, `installAdminAjaxHarness()`, `installNmkrSyncAjaxHarness()`, and `startPollingFromWindow()` to centralize admin-AJAX stubbing and tracking.
- The harness parses POST data with `new URLSearchParams(request.postData() || "")`, counts actions, records blocked mutating actions, tracks `nmkr_sync_progress` calls and cache-busted requests, tracks `nmkr_get_sync_statistics` and statistics-after-completion, and fulfills blocked mutating actions with harmless JSON while never leaking request bodies or secrets.
- Refactor `tests/e2e/nmkr-sync-resilience.regression.spec.ts` to use `installNmkrSyncAjaxHarness()` and `startPollingFromWindow()` while preserving soft-retry (HTTP 503), hard-failure (HTTP 403), cache-buster assertions, and blocked-action assertions.
- Refactor `tests/e2e/nmkr-sync-state.regression.spec.ts` to use `installNmkrSyncAjaxHarness()` with the original exact progress payloads, completion handling, and statistics payloads so UI assertions remain unchanged.
- Update `docs/testing-phase-7.md` and `docs/testing-phase-9.md` to reference the new shared helper and retain the same public-safety and non-mutating guarantees.

### Testing
- Ran `git diff --check` to validate the local changes and staged files (no diff errors detected). 
- Ran the public-safe checks via `npm run test:public`, which completed successfully for discovery and PHP public-safety validations. 
- Attempted `npm run test:e2e:sync-state` and `npm run test:e2e:sync-resilience`, but executing the Playwright browser failed in this environment because the Chromium binary was not present and `npx playwright install chromium` was blocked by network/download policy (download returned `403 Domain forbidden`), so full e2e verification is blocked here. 
- Attempted full `npm run test:e2e` and `npm run test:phase2`, both of which were blocked by the same environment/browser preflight constraints described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4fd1c1716483338bff1de5589399a7)