### PR TITLE
Make Phase 16A regression independent of ripgrep

### DIFF
--- a/docs/testing-phase-16a.md
+++ b/docs/testing-phase-16a.md
@@ -1,0 +1,49 @@
+# Phase 16A guarded controlled real-sync harness
+
+Phase 16A is a private-only harness for one later, explicitly operator-approved real synchronization on a development VM. Installing the harness and running the public regression do not start, stop, restart, clean up, force-stop, or call NMKR.
+
+## Relationship to Phase 15
+
+Phase 15 remains the read-only preflight. Operators must run Phase 15 successfully, record the exact receipt in that run directory, and export it explicitly, for example `export NMKR_PHASE16A_RECEIPT="/private/state/runs/<phase15-run>/real-sync-preflight.receipt.json"`. Phase 16A does not search for or automatically select the latest Phase 15 receipt. It initially validates the unchanged version-1 `nmkr-real-sync-preflight` receipt without consuming it. After browser login, dashboard bootstrap, preparatory AJAX interception, and the frozen request window, the driver calls the controller-owned final-authorization operation. That operation validates the same receipt again, verifies its fingerprint is unchanged, checks that sufficient lifetime remains, captures the pre-run aggregate snapshot, and atomically renames the receipt to a consumed file. Any failed, interrupted, ambiguous, or completed Start attempt consumes the receipt and requires a fresh Phase 15 run before another attempt.
+
+## Private controller sequence
+
+The controller `scripts/nmkr-real-sync-phase16a.sh` refuses CI before env sourcing, requires `RUN_REAL_SYNC=true`, `PW_SAVE_ARTIFACTS=false`, `NMKR_REAL_SYNC_CONFIRM=I_UNDERSTAND_THIS_MUTATES_DEV`, and `NMKR_PHASE16A_CONFIRM=I_AUTHORIZE_EXACTLY_ONE_START`, validates owner-controlled private paths, acquires an owner-only lock, validates source/deployed commits and clean worktrees, recomputes the normalized HTTPS origin digest across the allowed origin, base URL, WordPress home, and siteurl, checks WordPress/plugin readiness, verifies the named administrator has `nmkr_manage_sync`, and invokes the driver exactly once. It does not execute the driver for default-refusal tests.
+
+The required order is: default/CI refusal, private path and lock validation, strict receipt validation without consumption, browser login and dashboard bootstrap, preparatory API-status interception, frozen request mode, final revalidation and pre-run snapshot, atomic receipt consumption, exactly one Start, bounded polling, post-run snapshot, final aggregate validation, DB-state validation, and source/deployment rechecks.
+
+## Browser login, dashboard bootstrap, and nonce handling
+
+The driver `scripts/nmkr-real-sync-phase16a-driver.mjs` dynamically imports Playwright only in the private CLI path, launches headless Chromium without screenshots, traces, videos, reports, downloads, or storage-state persistence, logs in through the real WordPress login form using private environment credentials, handles the administration-email confirmation screen when present, and navigates to the NMKR dashboard. It extracts the localized sync nonce from the loaded page in memory. The nonce is never accepted from an environment variable, never written to disk, and never printed.
+
+Before dashboard navigation, the driver installs admin-AJAX routing. During preparation it synthetically fulfils `nmkr_check_api_status` with a generic successful response so the dashboard's preparatory API-status check cannot contact WordPress/NMKR API code. It blocks mutating synchronization actions and allows only bootstrap traffic needed to render the dashboard and obtain the nonce.
+
+## Frozen window, exactly-once Start, and polling
+
+Before final authorization, the driver enters frozen mode. Frozen mode blocks heartbeat, statistics refreshes, dashboard polling, unrelated admin-AJAX, PHP/admin navigation, and requests capable of dispatching WP-Cron. No WordPress/PHP request is allowed between the final cron guard and the explicit Start except the Start request itself.
+
+After final authorization succeeds, the driver permits one already-authorized `nmkr_start_sync` POST to the production authenticated `admin-ajax.php` endpoint. It uses the in-memory nonce and browser cookies, increments a Start counter, and never retries Start. A timeout or transport failure after dispatch is ambiguous and remains non-retriable. After Start, Stop, force-stop, restart, cleanup, metrics-storage, log cleanup, unrelated admin-AJAX, and any second Start are blocked. Start and polling send the localized AJAX nonce only in the production `nonce` form field. Polling uses the same nonce on every `nmkr_sync_progress` request, is non-overlapping, begins near three seconds, backs off retriable failures up to about thirty seconds, rejects 4xx/malformed responses and progress decreases, and requires explicit terminal evidence followed by final database validation. `in_progress=false` without terminal evidence is not success.
+
+## Aggregate snapshots and final validation
+
+The read-only WP-CLI helper `scripts/nmkr-real-sync-phase16a-state.php` emits exact-schema aggregate JSON only: required-table booleans, counts/max IDs, active/terminal history classification, duplicate/relationship/impossible-counter counts, option/transient/stale-recovery/heartbeat-worker evidence, blocked cron hook counts, light-profile validity, API-key presence from `nmkr_connect_options`, timestamp consistency, terminal-history digest, latest history classification, and snapshot epoch. It does not expose UIDs, names, addresses, option values, transient values, cron arguments, credentials, identities, payloads, or raw rows.
+
+Post-run target integrity checks do not reapply receipt expiry, remaining-lifetime, backup freshness, unconsumed-receipt, or final-authorization fingerprint timing rules. Final validation requires one Start, exactly one new completed history row with a valid end time, exactly one new metrics row, unchanged digest for pre-existing terminal history, zero active runtime markers, zero blocked cron hooks, inspectable cron, required tables present, valid light profile, API key present, terminal-or-absent retained sync data, matching latest metrics time and `nmkr_last_sync_time`, nondecreasing project/token/detail counts, zero duplicate/relationship/impossible aggregates, the existing DB-state validator passing with active sync disallowed, WordPress/plugin readiness, and clean matching source/deployed commits. A completed frontend response is insufficient without these assertions.
+
+## Interruption and cleanup boundary
+
+On interrupt, driver error, timeout, or ambiguous Start, Phase 16A stops only local driver/polling activity, preserves any consumed receipt, releases only the controller-owned lock, writes sanitized failure evidence, and performs no WordPress cleanup. Operators must inspect private state through approved procedures and generate a new Phase 15 receipt before another attempt.
+
+## Public-safe regression
+
+Run:
+
+```bash
+npm run test:real-sync:phase16a:regression
+```
+
+The regression is synthetic and public-safe: it uses fake receipts, fake WP-CLI output, a fake driver, and injected transports. It proves the driver is invoked zero times on preauthorization refusal, exactly once on the authorized synthetic path, not before the consumed-receipt sentinel, and that consumption occurs only during final authorization. It covers origin digest mismatches, capability failures, receipt failures, real form-builder nonce field shape, route POST-body parsing, frozen-mode blocking, second-Start blocking, nonce propagation to Start and progress without output leakage, no-terminal polling failure, no browser artifacts, and absence from normal Playwright discovery. No real run was performed in PR testing.
+
+## Rollback and deferred hardening
+
+Rollback is a normal Git revert of the Phase 16A commit or branch. Merely installing the harness should not require WordPress rollback because public paths are non-mutating. Production Start idempotency, durable worker locks, scheduled-event result handling, and stricter production active-sync rejection remain deferred to Phase 16B or Phase 16C.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:wpcli:db-state": "bash scripts/nmkr-wpcli-db-state.sh",
     "test:e2e:sync-resilience": "playwright test tests/e2e/nmkr-sync-resilience.regression.spec.ts",
     "test:e2e:sync-final-state": "playwright test tests/e2e/nmkr-sync-final-state.regression.spec.ts",
-    "test:real-sync:preflight": "bash scripts/nmkr-real-sync-preflight.sh"
+    "test:real-sync:preflight": "bash scripts/nmkr-real-sync-preflight.sh",
+    "test:real-sync:phase16a:regression": "bash scripts/nmkr-real-sync-phase16a-regression.sh"
   },
   "devDependencies": {
     "@playwright/test": "^1.53.0",

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -20,5 +20,9 @@ npm run test:e2e -- --list --reporter=list
 printf '\n== Public-safe Phase 15 preflight regression checks ==\n'
 bash scripts/nmkr-real-sync-preflight-regression.sh
 
+
+printf '\n== Public-safe Phase 16A controlled real-sync regression checks ==\n'
+bash scripts/nmkr-real-sync-phase16a-regression.sh
+
 printf '\n== Public-safe PHP 7.4 compatibility guard ==\n'
 npm run test:php74

--- a/scripts/nmkr-real-sync-phase16a-driver.mjs
+++ b/scripts/nmkr-real-sync-phase16a-driver.mjs
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+const MUTATING_ACTIONS = new Set(['nmkr_start_sync','nmkr_stop_sync','nmkr_force_stop_sync','nmkr_restart_sync_batch','nmkr_cleanup_sync_jobs','nmkr_store_active_metrics','nmkr_store_active_sync_metrics','nmkr_clear_all_logs','nmkr_clear_section_logs','nmkr_clear_sync_log']);
+const READ_ONLY_AFTER_START = new Set(['nmkr_sync_progress']);
+const FROZEN_BLOCKED = new Set(['heartbeat','nmkr_get_sync_statistics','nmkr_sync_progress','nmkr_check_api_status']);
+
+export function actionFromRequestLike(input) {
+  const url = typeof input?.url === 'function' ? input.url() : (input?.url || 'about:blank');
+  const method = (typeof input?.method === 'function' ? input.method() : (input?.method || 'GET')).toUpperCase();
+  const postData = typeof input?.postData === 'function' ? input.postData() : (input?.postData || '');
+  const parsed = new URL(url, 'https://phase16a.invalid');
+  const queryAction = parsed.searchParams.get('action');
+  if (queryAction) return queryAction;
+  if (method !== 'GET' && postData) return new URLSearchParams(postData).get('action') || '';
+  return '';
+}
+
+export function routeDecisionForAction(action, mode = 'prepare', startAlreadySent = false) {
+  if (mode === 'prepare') {
+    if (action === 'nmkr_check_api_status') return 'synthetic-ok';
+    if (MUTATING_ACTIONS.has(action)) return 'block';
+    return 'allow';
+  }
+  if (mode === 'frozen') return 'block';
+  if (mode === 'after-start') {
+    if (action === 'nmkr_start_sync') return startAlreadySent ? 'block' : 'allow-once';
+    if (READ_ONLY_AFTER_START.has(action)) return 'allow';
+    return 'block';
+  }
+  return FROZEN_BLOCKED.has(action) || MUTATING_ACTIONS.has(action) ? 'block' : 'allow';
+}
+export const routeDecision = routeDecisionForAction;
+
+function normalizedHttpOrigin(value, baseUrl) {
+  const parsed = new URL(value, baseUrl);
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return null;
+  if (parsed.username || parsed.password) return 'invalid-http';
+  const port = parsed.port || (parsed.protocol === 'https:' ? '443' : '80');
+  return `${parsed.protocol}//${parsed.hostname.toLowerCase()}:${port}`;
+}
+
+export function frozenRouteDecisionForUrl(requestUrl, baseUrl) {
+  try {
+    const requestOrigin = normalizedHttpOrigin(requestUrl, baseUrl);
+    if (requestOrigin === null) return 'allow';
+    if (requestOrigin === 'invalid-http') return 'block';
+    const baseOrigin = normalizedHttpOrigin(baseUrl, undefined);
+    return requestOrigin === baseOrigin ? 'block' : 'allow';
+  } catch {
+    return /^(https?:)?\/\//i.test(String(requestUrl)) || /^[/?#]/.test(String(requestUrl)) ? 'block' : 'allow';
+  }
+}
+
+export function sanitizeResult(state) {
+  return {
+    startCount: state.startCount || 0,
+    pollCount: state.pollCount || 0,
+    maxProgress: state.maxProgress || 0,
+    nonterminalObserved: !!state.nonterminalObserved,
+    validLiveMetricsObserved: !!state.validLiveMetricsObserved,
+    terminalClassification: state.terminalClassification || 'none',
+    transportRetryCount: state.transportRetryCount || 0,
+    activeHistoryIdObserved: state.activeHistoryIdObserved || 0,
+    elapsedSeconds: Math.max(0, Math.round(((state.now ? state.now() : Date.now()) - (state.startedAt || Date.now())) / 1000)),
+  };
+}
+
+function validMetrics(metrics) {
+  return !!metrics && typeof metrics === 'object' && ['total_projects','total_tokens','api_requests','memory_usage'].some((key) => Number.isFinite(Number(metrics[key])) && Number(metrics[key]) >= 0);
+}
+export function buildStartForm(nonce) { return { action: 'nmkr_start_sync', nonce }; }
+export function buildProgressForm(nonce) { return { action: 'nmkr_sync_progress', nonce }; }
+function classifyStart(response) {
+  if (!response || typeof response !== 'object') return 'fatal';
+  if (response.transportError || response.timeout) return 'ambiguous';
+  if (!Number.isInteger(response.status) || response.status < 200 || response.status >= 300) return 'fatal';
+  if (response.malformed || !response.json || typeof response.json !== 'object') return 'fatal';
+  if (response.json.success === false) return 'fatal';
+  return 'ok';
+}
+function classifyPoll(response) {
+  if (!response || typeof response !== 'object') return { kind: 'retry' };
+  if (response.transportError || response.timeout || response.offline || (response.status >= 500 && response.status < 600)) return { kind: 'retry' };
+  if (response.status >= 400 && response.status < 500) return { kind: 'fatal' };
+  if (response.malformed || !response.json || typeof response.json !== 'object') return { kind: 'fatal' };
+  if (response.json.success === false) return { kind: 'fatal' };
+  const data = response.json.data && typeof response.json.data === 'object' ? response.json.data : response.json;
+  const progress = Number(data.progress ?? data.percentage ?? 0);
+  if (!Number.isFinite(progress) || progress < 0 || progress > 100) return { kind: 'fatal' };
+  const terminal = data.status === 'completed' || data.completed === true || data.finished === true;
+  const explicitNotDone = data.in_progress === false && !terminal;
+  const activeHistoryId = Number(data.history_id ?? data.sync_id ?? 0);
+  return { kind: 'ok', progress, terminal, explicitNotDone, activeHistoryId, metrics: data.live_metrics ?? data.metrics };
+}
+
+export async function runExactlyOnceSync({ transport, nonce, adminAjaxUrl = 'about:blank', receipt, now = () => Date.now(), sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)) }) {
+  if (!transport || typeof transport.start !== 'function' || typeof transport.poll !== 'function') throw new Error('transport-required');
+  if (!nonce) throw new Error('nonce-required');
+  const maxMs = Math.max(1, Number(receipt?.maxDurationSeconds || receipt?.max_duration_seconds || 30)) * 1000;
+  const pollTimeoutMs = Math.max(1, Number(receipt?.pollTimeoutSeconds || receipt?.poll_timeout_seconds || 5)) * 1000;
+  const state = { startCount: 0, pollCount: 0, maxProgress: 0, nonterminalObserved: false, validLiveMetricsObserved: false, terminalClassification: 'none', transportRetryCount: 0, activeHistoryIdObserved: 0, startedAt: now(), now };
+  let interval = 3000;
+  state.startCount += 1;
+  const startResponse = await transport.start({ url: adminAjaxUrl, nonce, timeoutMs: pollTimeoutMs });
+  const startClass = classifyStart(startResponse);
+  if (startClass === 'ambiguous') { state.terminalClassification = 'ambiguous-start'; return { ok: false, ambiguous: true, sanitized: sanitizeResult(state) }; }
+  if (startClass !== 'ok') { state.terminalClassification = 'start-fatal'; return { ok: false, fatal: true, sanitized: sanitizeResult(state) }; }
+  while (now() - state.startedAt < maxMs) {
+    state.pollCount += 1;
+    const pollResponse = await transport.poll({ timeoutMs: Math.min(pollTimeoutMs, Math.max(1, maxMs - (now() - state.startedAt))), nonce });
+    const poll = classifyPoll(pollResponse);
+    if (poll.kind === 'fatal') { state.terminalClassification = 'poll-fatal'; return { ok: false, fatal: true, sanitized: sanitizeResult(state) }; }
+    if (poll.kind === 'retry') { state.transportRetryCount += 1; await sleep(interval); interval = Math.min(30000, interval * 2); continue; }
+    if (poll.progress < state.maxProgress) { state.terminalClassification = 'progress-decrease'; return { ok: false, fatal: true, sanitized: sanitizeResult(state) }; }
+    state.maxProgress = poll.progress;
+    if (poll.activeHistoryId > 0) state.activeHistoryIdObserved = poll.activeHistoryId;
+    if (!poll.terminal) {
+      state.nonterminalObserved = true;
+      if (validMetrics(poll.metrics)) state.validLiveMetricsObserved = true;
+      if (poll.explicitNotDone) { await sleep(3000); continue; }
+    }
+    if (poll.terminal) { state.terminalClassification = 'terminal-observed'; return { ok: true, sanitized: sanitizeResult(state) }; }
+    await sleep(3000);
+  }
+  state.terminalClassification = 'timeout';
+  return { ok: false, timeout: true, sanitized: sanitizeResult(state) };
+}
+
+async function authorizeWithController() {
+  const script = process.env.NMKR_PHASE16A_FINAL_AUTH_SCRIPT;
+  const runDir = process.env.NMKR_PHASE16A_FINAL_AUTH_RUN_DIR;
+  if (!script || !runDir) throw new Error('final-authorization-callback-required');
+  const { stdout } = await execFileAsync('bash', [script, '--final-authorize', runDir], { timeout: 120000, maxBuffer: 1024 * 64 });
+  const parsed = JSON.parse(stdout.trim().split(/\n/).pop() || '{}');
+  if (parsed.ok !== true) throw new Error('final-authorization-denied');
+}
+
+async function extractNonce(page) {
+  return page.evaluate(() => {
+    const candidates = [
+      window.nmkrSync?.nonce,
+      window.nmkrSync?.sync_nonce,
+      window.nmkr_ajax?.nonce,
+      window.nmkrDashboard?.syncNonce,
+      document.querySelector('#nmkr-sync-nonce')?.value,
+      document.querySelector('input[name="nmkr_sync_nonce"]')?.value,
+    ].filter(Boolean);
+    return String(candidates[0] || '');
+  });
+}
+
+async function login(page, baseUrl) {
+  const user = process.env.WP_ADMIN_USER;
+  const pass = process.env.WP_ADMIN_PASSWORD;
+  if (!user || !pass) throw new Error('wp-credentials-required');
+  await page.goto(new URL('/wp-login.php', baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+  await page.fill('#user_login', user);
+  await page.fill('#user_pass', pass);
+  await Promise.all([page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => null), page.click('#wp-submit')]);
+  const confirm = page.locator('text=/administration email/i');
+  if (await confirm.count().catch(() => 0)) {
+    const remind = page.locator('a:has-text("Remind me later"), input[value*="Remind me later"], button:has-text("Remind me later")').first();
+    if (await remind.count().catch(() => 0)) await Promise.all([page.waitForNavigation({ waitUntil: 'domcontentloaded' }).catch(() => null), remind.click()]);
+  }
+}
+
+async function realCli() {
+  if (process.env.RUN_REAL_SYNC !== 'true') throw new Error('RUN_REAL_SYNC-required');
+  const baseUrl = process.env.WP_BASE_URL;
+  const dashboardPath = process.env.NMKR_DASHBOARD_PATH || '/wp-admin/admin.php?page=nmkr-connect-dashboard';
+  if (!baseUrl || !baseUrl.startsWith('https://')) throw new Error('https-base-url-required');
+  const { chromium } = await import('@playwright/test');
+  const browser = await chromium.launch({ headless: true });
+  let routingMode = 'prepare';
+  let startAlreadySent = false;
+  try {
+    const context = await browser.newContext({ recordVideo: undefined, storageState: undefined, acceptDownloads: false });
+    const page = await context.newPage();
+    await page.route('**/*', async (route, request) => {
+      const url = request.url();
+      const isAjax = url.includes('/admin-ajax.php');
+      if (routingMode === 'frozen' && frozenRouteDecisionForUrl(url, baseUrl) === 'block') return route.fulfill({ status: 403, body: '{}' });
+      if (!isAjax) return route.continue();
+      const action = actionFromRequestLike(request);
+      const decision = routeDecisionForAction(action, routingMode, startAlreadySent);
+      if (decision === 'synthetic-ok') return route.fulfill({ status: 200, contentType: 'application/json', body: '{"success":true,"data":{"connected":true}}' });
+      if (decision === 'block') return route.fulfill({ status: 403, contentType: 'application/json', body: '{"success":false}' });
+      return route.continue();
+    });
+    await login(page, baseUrl);
+    await page.goto(new URL(dashboardPath, baseUrl).toString(), { waitUntil: 'domcontentloaded' });
+    const nonce = await extractNonce(page);
+    if (!nonce) throw new Error('sync-nonce-missing');
+    routingMode = 'frozen';
+    await authorizeWithController();
+    routingMode = 'after-start';
+    const adminAjaxUrl = new URL('/wp-admin/admin-ajax.php', baseUrl).toString();
+    const result = await runExactlyOnceSync({
+      adminAjaxUrl,
+      nonce,
+      receipt: { maxDurationSeconds: Number(process.env.NMKR_REAL_SYNC_MAX_DURATION_SECONDS || 1800), pollTimeoutSeconds: Number(process.env.NMKR_REAL_SYNC_POLL_TIMEOUT_SECONDS || 45) },
+      transport: {
+        start: async ({ url, nonce, timeoutMs }) => {
+          if (startAlreadySent) return { status: 409, json: { success: false } };
+          startAlreadySent = true;
+          try {
+            const res = await context.request.post(url, { form: buildStartForm(nonce), timeout: timeoutMs });
+            let json; try { json = await res.json(); } catch { return { status: res.status(), malformed: true }; }
+            return { status: res.status(), json };
+          } catch (error) { return { timeout: /Timeout|Abort/i.test(String(error?.message || error)), transportError: true }; }
+        },
+        poll: async ({ timeoutMs, nonce }) => {
+          try {
+            const res = await context.request.post(adminAjaxUrl, { form: buildProgressForm(nonce), timeout: timeoutMs });
+            let json; try { json = await res.json(); } catch { return { status: res.status(), malformed: true }; }
+            return { status: res.status(), json };
+          } catch (error) { return { timeout: /Timeout|Abort/i.test(String(error?.message || error)), transportError: true }; }
+        },
+      },
+    });
+    console.log(JSON.stringify(result.sanitized));
+    if (!result.ok) process.exit(result.ambiguous ? 3 : 2);
+  } finally {
+    await browser.close();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  realCli().catch((error) => { console.error(`Phase16A driver FAIL: ${String(error?.message || error).replace(/[\r\n].*/s, '')}`); process.exit(1); });
+}

--- a/scripts/nmkr-real-sync-phase16a-regression.sh
+++ b/scripts/nmkr-real-sync-phase16a-regression.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+REAL_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+fail(){ echo "FAIL: $1" >&2; exit 1; }
+pass(){ echo "PASS: $1"; }
+run_fail(){ local name="$1"; shift; local out="$TMP/${name// /_}.out"; if "$@" >"$out" 2>&1; then fail "$name unexpectedly passed"; fi; pass "$name"; }
+
+build_clean_source_fixture(){
+  local src="$1" dest="$2"
+  rm -rf "$dest"; mkdir -p "$dest"
+  git -C "$src" ls-files -z | python3 -c '
+import os, shutil, sys
+src, dest = sys.argv[1:3]
+for raw in [p for p in sys.stdin.buffer.read().split(b"\0") if p]:
+    rel = raw.decode("utf-8")
+    if rel.startswith(("vendor/", "node_modules/")):
+        continue
+    source = os.path.join(src, rel)
+    target = os.path.join(dest, rel)
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    if os.path.islink(source):
+        os.symlink(os.readlink(source), target)
+    else:
+        shutil.copy2(source, target)
+' "$src" "$dest"
+  git -C "$dest" init -q
+  git -C "$dest" add -A
+  git -C "$dest" -c user.email=phase16a@example.invalid -c user.name=Phase16A commit -q -m "phase16a clean source fixture"
+  [[ -z "$(git -C "$dest" status --porcelain=v1 --untracked-files=all)" ]] || fail "clean source fixture dirty"
+}
+
+DIRTY_INPUT="$TMP/dirty-input"; CLEAN_FROM_DIRTY="$TMP/clean-from-dirty"
+build_clean_source_fixture "$REAL_ROOT" "$DIRTY_INPUT"
+printf '\nphase16a tracked fixture change\n' >>"$DIRTY_INPUT/README.md"
+printf 'untracked sentinel\n' >"$DIRTY_INPUT/untracked-phase16a-sentinel.txt"
+build_clean_source_fixture "$DIRTY_INPUT" "$CLEAN_FROM_DIRTY"
+grep -Eq -- 'phase16a tracked fixture change' "$CLEAN_FROM_DIRTY/README.md" || fail "tracked dirty input was not represented in clean fixture"
+[[ ! -e "$CLEAN_FROM_DIRTY/untracked-phase16a-sentinel.txt" ]] || fail "untracked dirty input sentinel copied"
+[[ -z "$(git -C "$CLEAN_FROM_DIRTY" status --porcelain=v1 --untracked-files=all)" ]] || fail "clean dirty-input fixture not clean"
+pass "clean source fixture captures tracked WIP and excludes untracked sentinels"
+
+ROOT="$TMP/clean-source"
+build_clean_source_fixture "$REAL_ROOT" "$ROOT"
+! grep -En -- 'driver-default|phase16a-driver\.mjs" >/dev/null' "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >/dev/null || fail "premature private driver invocation remains"
+pass "controller contains no premature driver execution"
+
+WP="$TMP/wp"; STATE="$TMP/state"; ACTIVE_PLUGIN="$WP/wp-content/plugins/nmkr-connect"
+mkdir -p "$WP/wp-content/plugins" "$STATE"; chmod 700 "$TMP" "$STATE"
+git clone -q "$ROOT" "$ACTIVE_PLUGIN"
+git -C "$ACTIVE_PLUGIN" checkout -q "$(git -C "$ROOT" rev-parse HEAD)"
+reset_active_plugin(){ git -C "$ACTIVE_PLUGIN" reset --hard -q "$(git -C "$ROOT" rev-parse HEAD)"; git -C "$ACTIVE_PLUGIN" clean -fdq; }
+make_receipt(){ local path="$1" ttl="${2:-300}" created_offset="${3:-0}"; local head; head="$(git -C "$ROOT" rev-parse HEAD)"; python3 - "$path" "$head" "$ttl" "$created_offset" <<'PY'
+import json,os,sys,time
+p,head,ttl,created_offset=sys.argv[1:5]; now=int(time.time()); created=now+int(created_offset); ttl=int(ttl)
+d={'receipt_version':1,'purpose':'nmkr-real-sync-preflight','created_at_epoch':created,'expires_at_epoch':created+ttl,'source_commit':head,'deployed_commit':head,'origin_sha256':'95bd8950c21c1294c6c0408521381453bde62be1df02df429f79791abb319f37','plugin_active':True,'admin_capability_ok':True,'db_state_clean':True,'api_key_present':True,'runtime_state_clean':True,'cron_state_clean':True,'object_cache_state_clean':True,'profile_guard_passed':True,'backup_confirmed':True,'backup_confirmed_at_epoch':now,'max_duration_seconds':300,'poll_timeout_seconds':10,'receipt_ttl_seconds':ttl}
+json.dump(d,open(p,'w')); os.chmod(p,0o600)
+PY
+}
+state_json(){ local history="$1" metrics="$2" maxh="$3" maxm="$4" digest="$5" sync_class="${6:-absent}"; cat <<JSON
+{"schema_version":1,"required_tables_present":{"projects":true,"tokens":true,"token_details":true,"sync_stats":true,"sync_metrics":true},"project_count":1,"project_max_id":1,"token_count":1,"token_max_id":1,"token_detail_count":1,"token_detail_max_id":1,"sync_history_total_count":$history,"active_history_count":0,"terminal_history_count":$history,"max_history_id":$maxh,"metrics_total_count":$metrics,"max_metrics_id":$maxm,"duplicate_project_uid_count":0,"duplicate_token_uid_count":0,"duplicate_token_detail_uid_count":0,"invalid_relationship_count":0,"impossible_counter_count":0,"option_active_marker_count":0,"transient_active_marker_count":0,"stale_recovery_marker_count":0,"heartbeat_worker_evidence_count":0,"sync_data_classification":"$sync_class","blocked_cron_hook_counts":{"nmkr_execute_sync_background":0,"nmkr_process_batch_hook":0,"nmkr_sync_cron_hook":0,"nmkr_install_sync_cron_hook":0},"blocked_sync_cron_count":0,"cron_inspectable":true,"light_profile_guard":true,"api_key_present":true,"last_sync_time_matches_latest_metrics":true,"terminal_history_digest":"$digest","latest_history_id":$maxh,"latest_history_status_classification":"completed","latest_history_completed":true,"latest_history_end_time_valid":true,"snapshot_epoch":1}
+JSON
+}
+FAKE_WP="$TMP/fake-wp"; cat >"$FAKE_WP" <<'SH'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+cmd=""; for a in "$@"; do [[ "$a" != --path=* ]] && { cmd="$a"; break; }; done
+if [[ "$cmd" == core ]]; then exit 0; fi
+if [[ "$cmd" == plugin ]]; then [[ "${NMKR_FAKE_PLUGIN_INACTIVE:-false}" == true ]] && exit 1 || exit 0; fi
+if [[ "$cmd" == option ]]; then echo "${NMKR_FAKE_WP_ORIGIN:-https://example.invalid}"; exit 0; fi
+if [[ "$cmd" == eval ]]; then [[ "${NMKR_FAKE_CAPABILITY:-ok}" == ok ]] && exit 0 || exit 1; fi
+if [[ "$cmd" == eval-file ]]; then
+  if [[ -n "${NMKR_PHASE16A_HISTORY_MAX_ID:-}" ]]; then cat "$NMKR_FAKE_POST_STATE"; else cat "$NMKR_FAKE_PRE_STATE"; fi
+  exit 0
+fi
+exit 0
+SH
+chmod +x "$FAKE_WP"
+FAKE_DRIVER="$TMP/fake-driver.mjs"; cat >"$FAKE_DRIVER" <<'JS'
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { existsSync, appendFileSync, readFileSync } from 'node:fs';
+const log=process.env.NMKR_FAKE_DRIVER_LOG;
+appendFileSync(log, `before:${existsSync(process.env.NMKR_FAKE_CONSUMED) ? 'consumed' : 'unconsumed'}\n`);
+const out=execFileSync('bash',[process.env.NMKR_PHASE16A_FINAL_AUTH_SCRIPT,'--final-authorize',process.env.NMKR_PHASE16A_FINAL_AUTH_RUN_DIR],{encoding:'utf8'});
+if(!JSON.parse(out.trim().split(/\n/).pop()).ok) process.exit(2);
+appendFileSync(log, `after:${existsSync(process.env.NMKR_FAKE_CONSUMED) ? 'consumed' : 'unconsumed'}\n`);
+console.log(JSON.stringify({startCount:1,pollCount:2,maxProgress:100,nonterminalObserved:true,validLiveMetricsObserved:true,terminalClassification:'terminal-observed',transportRetryCount:0,activeHistoryIdObserved:2,elapsedSeconds:4}));
+JS
+chmod +x "$FAKE_DRIVER"
+base_env(){ local state_dir="$1"; shift; env -u CI -u GITHUB_ACTIONS -u GITLAB_CI -u CIRCLECI -u BUILDKITE -u TF_BUILD RUN_REAL_SYNC=true PW_SAVE_ARTIFACTS=false NMKR_REAL_SYNC_CONFIRM=I_UNDERSTAND_THIS_MUTATES_DEV NMKR_PHASE16A_CONFIRM=I_AUTHORIZE_EXACTLY_ONE_START WP_PATH="$WP" WP_CLI_BIN="$FAKE_WP" WP_BASE_URL="${NMKR_TEST_WP_BASE_URL:-https://example.invalid}" NMKR_REAL_SYNC_ALLOWED_ORIGIN="${NMKR_TEST_ALLOWED_ORIGIN:-https://example.invalid}" WP_ADMIN_USER="admin@example.invalid" NMKR_PHASE2_LOG_DIR="$state_dir" NMKR_PHASE16A_PUBLIC_REGRESSION=true NMKR_PHASE16A_TEST_DRIVER_BIN="$FAKE_DRIVER" "$@"; }
+run_refusal(){ local name="$1"; shift; local d="$TMP/$name"; mkdir -m700 "$d"; : >"$TMP/$name.driver"; run_fail "$name" env -u RUN_REAL_SYNC -u CI -u GITHUB_ACTIONS -u GITLAB_CI -u CIRCLECI -u BUILDKITE -u TF_BUILD NMKR_FAKE_DRIVER_LOG="$TMP/$name.driver" "$@"; [[ ! -s "$TMP/$name.driver" ]] || fail "$name invoked driver"; pass "$name driver zero-times"; }
+run_refusal "default RUN_REAL_SYNC=false" WP_PATH="$WP" NMKR_PHASE2_LOG_DIR="$STATE" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+run_refusal "CI refusal before env" CI=true RUN_REAL_SYNC=true WP_PATH="$WP" NMKR_PHASE2_ENV_FILE="$TMP/nope" NMKR_PHASE2_LOG_DIR="$STATE" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+run_refusal "PW_SAVE_ARTIFACTS true" RUN_REAL_SYNC=true PW_SAVE_ARTIFACTS=true WP_PATH="$WP" NMKR_PHASE2_LOG_DIR="$STATE" NMKR_REAL_SYNC_CONFIRM=I_UNDERSTAND_THIS_MUTATES_DEV NMKR_PHASE16A_CONFIRM=I_AUTHORIZE_EXACTLY_ONE_START bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+D="$TMP/auth"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"; R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"; PRE="$TMP/pre.json"; POST="$TMP/post.json"; state_json 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"; LOG="$TMP/driver.log"
+base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >"$TMP/auth.out" 2>&1 || { cat "$TMP/auth.out"; fail "authorized synthetic path failed"; }
+[[ "$(wc -l <"$LOG")" -eq 2 ]] || fail "driver invoked more than once"
+grep -q '^before:unconsumed$' "$LOG" || fail "driver started after premature consumption sentinel failed"
+grep -q '^after:consumed$' "$LOG" || fail "receipt not consumed during final authorization"
+[[ -f "$C" && ! -f "$R" ]] || fail "receipt consumption was not atomic"
+pass "authorized synthetic path invokes driver exactly once after initial validation and consumes during final authorization"
+
+D="$TMP/active_override"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"
+R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"
+PRE="$TMP/active_override.pre.json"; POST="$TMP/active_override.post.json"; LOG="$TMP/active_override.driver"
+state_json 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"
+base_env "$D" NMKR_DEPLOYED_PLUGIN_PATH="$ACTIVE_PLUGIN" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >/dev/null 2>&1 || fail "explicit active deployed override unexpectedly failed"
+pass "explicit deployed override resolving to active plugin checkout accepted"
+
+deployment_refusal(){
+  local name="$1"; shift
+  D="$TMP/deploy_${name// /_}"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"
+  R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"
+  PRE="$TMP/deploy_${name// /_}.pre.json"; POST="$TMP/deploy_${name// /_}.post.json"; LOG="$TMP/deploy_${name// /_}.driver"
+  state_json 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"; : >"$LOG"
+  run_fail "deployment $name" base_env "$D" "$@" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+  [[ ! -s "$LOG" ]] || fail "deployment $name invoked driver"
+  [[ -f "$R" && ! -e "$C" ]] || fail "deployment $name consumed receipt"
+}
+
+reset_active_plugin
+printf 'stale\n' >>"$ACTIVE_PLUGIN/phase16a-stale.txt"; git -C "$ACTIVE_PLUGIN" add phase16a-stale.txt; git -C "$ACTIVE_PLUGIN" -c user.email=a@b.invalid -c user.name=a commit -q -m "phase16a stale deployed fixture"
+deployment_refusal "stale deployed HEAD"
+reset_active_plugin
+printf 'dirty\n' >>"$ACTIVE_PLUGIN/phase16a-dirty.txt"
+deployment_refusal "dirty deployed checkout"
+reset_active_plugin
+deployment_refusal "override source checkout" NMKR_DEPLOYED_PLUGIN_PATH="$ROOT"
+OTHER="$TMP/other-deploy"; git clone -q "$ROOT" "$OTHER"; git -C "$OTHER" checkout -q "$(git -C "$ROOT" rev-parse HEAD)"
+deployment_refusal "override other checkout" NMKR_DEPLOYED_PLUGIN_PATH="$OTHER"
+WP_PARENT="$TMP/wp-parent"; mkdir -p "$WP_PARENT/wp-content/plugins/nmkr-connect"; git -C "$WP_PARENT/wp-content/plugins" init -q; printf 'parent\n' >"$WP_PARENT/wp-content/plugins/nmkr-connect/fixture.txt"; git -C "$WP_PARENT/wp-content/plugins" add nmkr-connect/fixture.txt; git -C "$WP_PARENT/wp-content/plugins" -c user.email=a@b.invalid -c user.name=a commit -q -m parent
+deployment_refusal "active plugin git top-level parent" WP_PATH="$WP_PARENT"
+pass "active deployed checkout gate rejects stale dirty wrong override and parent worktree cases"
+
+mutate_receipt(){ python3 - "$1" "$2" "$3" <<'PY'
+import json,sys
+p,k,v=sys.argv[1:4]
+d=json.load(open(p)); d[k]=int(v); json.dump(d,open(p,'w'))
+PY
+}
+set_receipt_ttl(){ python3 - "$1" "$2" <<'PY'
+import json,sys
+p,ttl=sys.argv[1:3]
+d=json.load(open(p)); d['receipt_ttl_seconds']=int(ttl); d['expires_at_epoch']=d['created_at_epoch']+int(ttl); json.dump(d,open(p,'w'))
+PY
+}
+for spec in "max_duration_seconds 300 accept" "max_duration_seconds 3600 accept" "poll_timeout_seconds 10 accept" "poll_timeout_seconds 60 accept" "receipt_ttl_seconds 60 accept" "receipt_ttl_seconds 300 accept"; do
+  set -- $spec; field="$1"; value="$2"
+  D="$TMP/bounds_${field}_${value}"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"
+  R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"; if [[ "$field" == receipt_ttl_seconds ]]; then set_receipt_ttl "$R" "$value"; else mutate_receipt "$R" "$field" "$value"; fi
+  PRE="$TMP/bounds_${field}_${value}.pre.json"; POST="$TMP/bounds_${field}_${value}.post.json"; LOG="$TMP/bounds_${field}_${value}.driver"
+  state_json 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"
+  base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >/dev/null 2>&1 || fail "receipt bound $field=$value unexpectedly failed"
+done
+pass "Phase 15 receipt timeout boundary values accepted"
+for spec in "max_duration_seconds 299" "max_duration_seconds 3601" "poll_timeout_seconds 9" "poll_timeout_seconds 61" "receipt_ttl_seconds 59" "receipt_ttl_seconds 301"; do
+  set -- $spec; field="$1"; value="$2"
+  D="$TMP/bounds_bad_${field}_${value}"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"
+  R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"; mutate_receipt "$R" "$field" "$value"; LOG="$TMP/bounds_bad_${field}_${value}.driver"; : >"$LOG"
+  run_fail "receipt bound $field=$value" base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+  [[ ! -s "$LOG" ]] || fail "receipt bound $field=$value invoked driver"
+  [[ -f "$R" && ! -e "$C" ]] || fail "receipt bound $field=$value consumed receipt"
+done
+pass "Phase 15 receipt timeout out-of-range values rejected before driver"
+for case in "expiry plus one" "expiry minus one" "old creation future expiry" "unrelated future expiry" "expiry equals creation" "expiry before creation"; do
+  D="$TMP/timing_${case// /_}"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"
+  R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"; LOG="$TMP/timing_${case// /_}.driver"; : >"$LOG"
+  python3 - "$R" "$case" <<'PY'
+import json,sys,time
+p,case=sys.argv[1:3]
+d=json.load(open(p))
+if case == 'expiry plus one':
+    d['expires_at_epoch'] = d['created_at_epoch'] + d['receipt_ttl_seconds'] + 1
+elif case == 'expiry minus one':
+    d['expires_at_epoch'] = d['created_at_epoch'] + d['receipt_ttl_seconds'] - 1
+elif case == 'old creation future expiry':
+    d['created_at_epoch'] = int(time.time()) - 1000
+    d['expires_at_epoch'] = int(time.time()) + 200
+elif case == 'unrelated future expiry':
+    d['expires_at_epoch'] = int(time.time()) + 123
+elif case == 'expiry equals creation':
+    d['expires_at_epoch'] = d['created_at_epoch']
+elif case == 'expiry before creation':
+    d['expires_at_epoch'] = d['created_at_epoch'] - 1
+json.dump(d,open(p,'w'))
+PY
+  run_fail "receipt timing $case" base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+  [[ ! -s "$LOG" ]] || fail "receipt timing $case invoked driver"
+  [[ -f "$R" && ! -e "$C" ]] || fail "receipt timing $case consumed receipt"
+done
+pass "receipt creation expiry TTL mismatches rejected before driver"
+
+for sync_class in absent terminal active unknown; do
+  D="$TMP/post-sync-$sync_class"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"
+  R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"
+  PRE="$TMP/post-sync-$sync_class.pre.json"; POST="$TMP/post-sync-$sync_class.post.json"; LOG="$TMP/post-sync-$sync_class.driver"
+  state_json 1 1 1 1 abc absent >"$PRE"; state_json 2 2 2 2 abc "$sync_class" >"$POST"
+  if [[ "$sync_class" == absent || "$sync_class" == terminal ]]; then
+    base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >"$TMP/post-sync-$sync_class.out" 2>&1 || { cat "$TMP/post-sync-$sync_class.out"; fail "post-run $sync_class state unexpectedly failed"; }
+    grep -q '^after:consumed$' "$LOG" || fail "post-run $sync_class did not consume receipt"
+    pass "post-run sync_data_classification=$sync_class accepted"
+  else
+    if base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >"$TMP/post-sync-$sync_class.out" 2>&1; then
+      fail "post-run $sync_class state unexpectedly passed"
+    fi
+    [[ "$(wc -l <"$LOG")" -eq 2 ]] || fail "post-run $sync_class invoked driver more than once or skipped authorized Start"
+    grep -q '^after:consumed$' "$LOG" || fail "post-run $sync_class did not consume before final failure"
+    [[ -f "$C" ]] || fail "post-run $sync_class did not preserve consumed receipt"
+    pass "post-run sync_data_classification=$sync_class rejected after one authorized synthetic Start"
+  fi
+done
+for case in "allowed origin mismatch" "wordpress home mismatch" "wordpress siteurl mismatch" "http origin" "explicit port" "path query fragment" "missing administrator identifier" "capability failure"; do
+  D="$TMP/${case// /_}"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"; R="$D/runs/phase15/real-sync-preflight.receipt.json"; make_receipt "$R"; PRE="$TMP/${case// /_}.pre.json"; POST="$TMP/${case// /_}.post.json"; state_json 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"; : >"$TMP/$case.driver"
+  extra=(WP_ADMIN_USER="admin@example.invalid")
+  case "$case" in
+    "allowed origin mismatch") extra=(NMKR_REAL_SYNC_ALLOWED_ORIGIN="https://other.invalid");;
+    "wordpress home mismatch"|"wordpress siteurl mismatch") extra=(NMKR_FAKE_WP_ORIGIN="https://other.invalid");;
+    "http origin") extra=(NMKR_REAL_SYNC_ALLOWED_ORIGIN="http://example.invalid" WP_BASE_URL="http://example.invalid" NMKR_FAKE_WP_ORIGIN="http://example.invalid");;
+    "explicit port") extra=(NMKR_REAL_SYNC_ALLOWED_ORIGIN="https://example.invalid:443" WP_BASE_URL="https://example.invalid:443" NMKR_FAKE_WP_ORIGIN="https://example.invalid:443");;
+    "path query fragment") extra=(NMKR_REAL_SYNC_ALLOWED_ORIGIN="https://example.invalid/path?x=1#f" WP_BASE_URL="https://example.invalid/path?x=1#f" NMKR_FAKE_WP_ORIGIN="https://example.invalid/path?x=1#f");;
+    "missing administrator identifier") extra=(WP_ADMIN_USER="");;
+    "capability failure") extra=(NMKR_FAKE_CAPABILITY="denied");;
+  esac
+  run_fail "$case" base_env "$D" "${extra[@]}" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$TMP/$case.driver" NMKR_FAKE_CONSUMED="$D/runs/phase15/real-sync-preflight.receipt.consumed.json" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+  pass "$case synthetic guard"
+done
+D="$TMP/origin_normalization"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"; R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"; PRE="$TMP/origin_norm.pre.json"; POST="$TMP/origin_norm.post.json"; state_json 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"; LOG="$TMP/origin_norm.driver"
+base_env "$D" NMKR_REAL_SYNC_ALLOWED_ORIGIN="https://EXAMPLE.INVALID." WP_BASE_URL="https://example.invalid" NMKR_FAKE_WP_ORIGIN="https://example.invalid." NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh" >/dev/null 2>&1 || fail "origin normalization unexpectedly failed"
+pass "origin hostname case and trailing-dot normalization"
+for case in "consumed destination collision" "expired receipt" "insufficient remaining lifetime after dashboard bootstrap" "stale backup"; do
+  D="$TMP/${case// /_}"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"; R="$D/runs/phase15/real-sync-preflight.receipt.json"; make_receipt "$R"
+  case "$case" in
+    "consumed destination collision") touch "$D/runs/phase15/real-sync-preflight.receipt.consumed.json";;
+    "expired receipt") make_receipt "$R" -1;;
+    "insufficient remaining lifetime after dashboard bootstrap") make_receipt "$R" 60 -40;;
+    "stale backup") python3 - "$R" -c 'import json,sys,time; d=json.load(open(sys.argv[1])); d["backup_confirmed_at_epoch"]=int(time.time())-900000; json.dump(d,open(sys.argv[1],"w"))';;
+  esac
+  : >"$TMP/$case.driver"; run_fail "$case" base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_DRIVER_LOG="$TMP/$case.driver" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+  if [[ "$case" == "insufficient remaining lifetime after dashboard bootstrap" || "$case" == "stale backup" ]]; then
+    [[ -s "$TMP/$case.driver" ]] || fail "$case did not reach driver/final authorization"
+  else
+    [[ ! -s "$TMP/$case.driver" ]] || fail "$case invoked driver"
+  fi
+done
+STATE_HELPER_HARNESS="$TMP/state-helper-harness.php"; cat >"$STATE_HELPER_HARNESS" <<'PHP'
+<?php
+define('ABSPATH', __DIR__);
+define('ARRAY_A', 'ARRAY_A');
+function esc_sql($value) { return str_replace("'", "''", (string) $value); }
+function wp_json_encode($value, $flags = 0) { return json_encode($value, $flags); }
+function get_option($key, $default = false) {
+    $case = getenv('NMKR_PHASE16A_FAKE_OPTION_CASE');
+    if ($case === 'near-terminal-residue' && $key === 'nmkr_sync_near_completion') { return true; }
+    if ($case === 'near-in-progress' && ($key === 'nmkr_sync_in_progress' || $key === 'nmkr_sync_near_completion')) { return true; }
+    if ($case === 'near-active-status' && $key === 'nmkr_sync_status') { return 'processing'; }
+    if ($case === 'near-active-status' && $key === 'nmkr_sync_near_completion') { return true; }
+    if ($case === 'near-active-sync-data' && $key === 'nmkr_sync_data') { return array('status' => 'processing'); }
+    if ($case === 'near-active-sync-data' && $key === 'nmkr_sync_near_completion') { return true; }
+    if ($case === 'near-progress-only' && $key === 'nmkr_sync_progress') { return 50; }
+    if ($case === 'near-progress-only' && $key === 'nmkr_sync_near_completion') { return true; }
+    if ($case === 'near-terminal-status-data' && $key === 'nmkr_sync_status') { return 'completed'; }
+    if ($case === 'near-terminal-status-data' && $key === 'nmkr_sync_data') { return array('status' => 'completed'); }
+    if ($case === 'near-terminal-status-data' && $key === 'nmkr_sync_near_completion') { return true; }
+    $fixture_path = getenv('NMKR_PHASE16A_FAKE_OPTIONS_JSON_FILE');
+    $fixture_raw = $fixture_path ? file_get_contents($fixture_path) : (getenv('NMKR_PHASE16A_FAKE_OPTIONS_JSON') ?: '{}');
+    $fixture = json_decode($fixture_raw, true);
+    if (is_array($fixture) && array_key_exists($key, $fixture)) { return $fixture[$key]; }
+    if ($key === 'nmkr_connect_options') { return array('sync_profile' => 'light', 'sync_batch_size' => 1, 'sync_batch_delay' => 3, 'api_key' => 'synthetic'); }
+    if ($key === 'cron') { return array('version' => 2); }
+    return $default;
+}
+function wp_using_ext_object_cache() { return false; }
+function get_transient($key) { return false; }
+class NMKR16FakeWpdb {
+    public $prefix = 'wp_';
+    private $history;
+    public function __construct() { $this->history = json_decode(getenv('NMKR_PHASE16A_FAKE_HISTORY_JSON') ?: '[]', true); }
+    public function prepare($sql, $value) { return str_replace('%s', "'" . str_replace("'", "''", $value) . "'", $sql); }
+    private function tableFrom($sql) { return preg_match('/FROM `([^`]+)`/', $sql, $m) ? $m[1] : ''; }
+    private function terminal($row) { return in_array(strtolower($row['status']), array('completed','success','failed','error','stopped','cancelled','aborted'), true); }
+    private function active($row) { return in_array(strtolower($row['status']), array('initializing','processing','processing_projects','processing_tokens','in_progress','running','pending','active','started'), true); }
+    private function boundedRows($sql) {
+        $rows = array_values(array_filter($this->history, function($row) { return $this->terminal($row); }));
+        if (preg_match('/id <= ([0-9]+)/', $sql, $m)) { $limit = (int) $m[1]; $rows = array_values(array_filter($rows, function($row) use ($limit) { return (int) $row['id'] <= $limit; })); }
+        usort($rows, function($a, $b) { return (int) $a['id'] <=> (int) $b['id']; });
+        return $rows;
+    }
+    public function get_results($sql, $format = null) { return $this->boundedRows($sql); }
+    public function get_var($sql) {
+        if (strpos($sql, 'SHOW TABLES LIKE') === 0 && preg_match("/'([^']+)'/", $sql, $m)) { return $m[1]; }
+        if (strpos($sql, 'SHOW COLUMNS FROM') === 0) { return null; }
+        $table = $this->tableFrom($sql);
+        if (strpos($sql, 'MAX(id)') !== false) { return $table === 'wp_nmkr_sync_stats' && $this->history ? max(array_map(function($row) { return (int) $row['id']; }, $this->history)) : 0; }
+        if (strpos($sql, 'ORDER BY id DESC LIMIT 1') !== false) {
+            if (!$this->history) { return ''; }
+            $rows = $this->history; usort($rows, function($a, $b) { return (int) $b['id'] <=> (int) $a['id']; });
+            return $rows[0]['status'];
+        }
+        if (strpos($sql, 'end_time IS NOT NULL') !== false && strpos($sql, 'SELECT MAX(id)') !== false) {
+            if (!$this->history) { return 0; }
+            $max = max(array_map(function($row) { return (int) $row['id']; }, $this->history));
+            foreach ($this->history as $row) { if ((int) $row['id'] === $max) { return empty($row['end_time']) ? 0 : 1; } }
+            return 0;
+        }
+        if (strpos($sql, 'COUNT(*)') !== false) {
+            if ($table !== 'wp_nmkr_sync_stats') { return 0; }
+            if (strpos($sql, 'BINARY status IN') !== false && strpos($sql, "'processing'") !== false) { return count(array_filter($this->history, function($row) { return $this->active($row); })); }
+            if (strpos($sql, 'BINARY status IN') !== false) { return count($this->boundedRows($sql)); }
+            return count($this->history);
+        }
+        return '';
+    }
+}
+$wpdb = new NMKR16FakeWpdb();
+require getenv('NMKR_PHASE16A_STATE_HELPER');
+PHP
+state_helper_snapshot(){
+  local rows="$1" limit="${2-__unset__}" out="$3" options="${4:-{}}"
+  local optfile; optfile="$TMP/options-${name:-snapshot}-$RANDOM.json"
+  printf '%s' "$options" >"$optfile"
+  if [[ "$limit" == __unset__ ]]; then
+    env -u NMKR_PHASE16A_HISTORY_MAX_ID NMKR_PHASE16A_FAKE_HISTORY_JSON="$rows" NMKR_PHASE16A_FAKE_OPTIONS_JSON_FILE="$optfile" NMKR_PHASE16A_STATE_HELPER="$ROOT/scripts/nmkr-real-sync-phase16a-state.php" php "$STATE_HELPER_HARNESS" >"$out"
+  else
+    NMKR_PHASE16A_HISTORY_MAX_ID="$limit" NMKR_PHASE16A_FAKE_HISTORY_JSON="$rows" NMKR_PHASE16A_FAKE_OPTIONS_JSON_FILE="$optfile" NMKR_PHASE16A_STATE_HELPER="$ROOT/scripts/nmkr-real-sync-phase16a-state.php" php "$STATE_HELPER_HARNESS" >"$out"
+  fi
+}
+state_json_get(){ python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"; }
+EMPTY_ROWS='[]'
+ONE_ROW='[{"id":1,"sync_type":"manual","start_time":"2026-01-01 00:00:00","end_time":"2026-01-01 00:01:00","status":"completed","items_processed":1,"items_successful":1,"items_failed":0,"updated_at":"2026-01-01 00:01:00"}]'
+TWO_ROWS='[{"id":1,"sync_type":"manual","start_time":"2026-01-01 00:00:00","end_time":"2026-01-01 00:01:00","status":"completed","items_processed":1,"items_successful":1,"items_failed":0,"updated_at":"2026-01-01 00:01:00"},{"id":2,"sync_type":"manual","start_time":"2026-01-02 00:00:00","end_time":"2026-01-02 00:01:00","status":"completed","items_processed":2,"items_successful":2,"items_failed":0,"updated_at":"2026-01-02 00:01:00"}]'
+THREE_ROWS='[{"id":1,"sync_type":"manual","start_time":"2026-01-01 00:00:00","end_time":"2026-01-01 00:01:00","status":"completed","items_processed":1,"items_successful":1,"items_failed":0,"updated_at":"2026-01-01 00:01:00"},{"id":2,"sync_type":"manual","start_time":"2026-01-02 00:00:00","end_time":"2026-01-02 00:01:00","status":"completed","items_processed":2,"items_successful":2,"items_failed":0,"updated_at":"2026-01-02 00:01:00"},{"id":3,"sync_type":"manual","start_time":"2026-01-03 00:00:00","end_time":"2026-01-03 00:01:00","status":"completed","items_processed":3,"items_successful":3,"items_failed":0,"updated_at":"2026-01-03 00:01:00"}]'
+MUTATED_THREE_ROWS='[{"id":1,"sync_type":"manual","start_time":"2026-01-01 00:00:00","end_time":"2026-01-01 00:01:00","status":"completed","items_processed":1,"items_successful":1,"items_failed":0,"updated_at":"2026-01-01 00:01:00"},{"id":2,"sync_type":"manual","start_time":"2026-01-02 00:00:00","end_time":"2026-01-02 00:01:00","status":"completed","items_processed":99,"items_successful":2,"items_failed":0,"updated_at":"2026-01-02 00:01:00"},{"id":3,"sync_type":"manual","start_time":"2026-01-03 00:00:00","end_time":"2026-01-03 00:01:00","status":"completed","items_processed":3,"items_successful":3,"items_failed":0,"updated_at":"2026-01-03 00:01:00"}]'
+state_helper_snapshot "$EMPTY_ROWS" __unset__ "$TMP/state-empty-pre.json"
+state_helper_snapshot "$ONE_ROW" 0 "$TMP/state-one-bounded-zero.json"
+state_helper_snapshot "$ONE_ROW" __unset__ "$TMP/state-one-unbounded.json"
+[[ "$(state_json_get "$TMP/state-empty-pre.json" terminal_history_digest)" == "$(state_json_get "$TMP/state-one-bounded-zero.json" terminal_history_digest)" ]] || fail "zero history boundary did not preserve empty digest"
+[[ "$(state_json_get "$TMP/state-empty-pre.json" terminal_history_digest)" != "$(state_json_get "$TMP/state-one-unbounded.json" terminal_history_digest)" ]] || fail "unbounded digest did not include new history row"
+[[ "$(state_json_get "$TMP/state-one-bounded-zero.json" sync_history_total_count)" == 1 && "$(state_json_get "$TMP/state-one-bounded-zero.json" max_history_id)" == 1 && "$(state_json_get "$TMP/state-one-bounded-zero.json" latest_history_id)" == 1 ]] || fail "bounded zero snapshot hid post-run history counts"
+pass "state helper honors explicit zero history boundary"
+state_helper_snapshot "$TWO_ROWS" __unset__ "$TMP/state-two-pre.json"
+state_helper_snapshot "$THREE_ROWS" 2 "$TMP/state-three-bounded-two.json"
+state_helper_snapshot "$MUTATED_THREE_ROWS" 2 "$TMP/state-three-mutated-bounded-two.json"
+[[ "$(state_json_get "$TMP/state-two-pre.json" terminal_history_digest)" == "$(state_json_get "$TMP/state-three-bounded-two.json" terminal_history_digest)" ]] || fail "positive history boundary included new row"
+[[ "$(state_json_get "$TMP/state-two-pre.json" terminal_history_digest)" != "$(state_json_get "$TMP/state-three-mutated-bounded-two.json" terminal_history_digest)" ]] || fail "positive boundary did not detect pre-existing row change"
+pass "state helper honors positive history boundary and detects bounded row changes"
+state_helper_snapshot "$THREE_ROWS" __unset__ "$TMP/state-three-unset.json"
+[[ "$(state_json_get "$TMP/state-three-unset.json" terminal_history_digest)" != "$(state_json_get "$TMP/state-three-bounded-two.json" terminal_history_digest)" ]] || fail "unset history boundary did not include all rows"
+pass "state helper unset history boundary remains unbounded"
+for invalid_limit in -1 1.5 1e3 abc; do
+  if NMKR_PHASE16A_HISTORY_MAX_ID="$invalid_limit" NMKR_PHASE16A_FAKE_HISTORY_JSON="$ONE_ROW" NMKR_PHASE16A_STATE_HELPER="$ROOT/scripts/nmkr-real-sync-phase16a-state.php" php "$STATE_HELPER_HARNESS" >"$TMP/state-invalid-$invalid_limit.out" 2>&1; then
+    fail "invalid history boundary $invalid_limit unexpectedly passed"
+  fi
+  ! grep -En -- 'manual|completed|items_processed|2026-01' "$TMP/state-invalid-$invalid_limit.out" >/dev/null || fail "invalid history boundary leaked row content"
+done
+pass "state helper invalid history boundaries fail closed without row leaks"
+option_count_case(){
+  local name="$1" options="$2" expected="$3" out
+  out="$TMP/option-$name.json"
+  NMKR_PHASE16A_FAKE_OPTION_CASE="$name" state_helper_snapshot "$EMPTY_ROWS" __unset__ "$out" "$options"
+  local actual; actual="$(state_json_get "$out" option_active_marker_count)"
+  [[ "$actual" == "$expected" ]] || fail "option active marker case $name expected $expected got $actual"
+}
+option_count_case "near-terminal-residue" '{"nmkr_sync_near_completion":true}' 0
+option_count_case "near-in-progress" '{"nmkr_sync_in_progress":true,"nmkr_sync_near_completion":true}' 2
+option_count_case "near-active-status" '{"nmkr_sync_status":"processing","nmkr_sync_near_completion":true}' 2
+option_count_case "near-active-sync-data" '{"nmkr_sync_data":{"status":"processing"},"nmkr_sync_near_completion":true}' 2
+option_count_case "near-progress-only" '{"nmkr_sync_progress":50,"nmkr_sync_near_completion":true}' 1
+option_count_case "near-terminal-status-data" '{"nmkr_sync_status":"completed","nmkr_sync_data":{"status":"completed"},"nmkr_sync_near_completion":true}' 0
+pass "state helper gates near_completion on durable active sync state"
+ACTIVE_EMPTY_END='[{"id":4,"sync_type":"manual","start_time":"2026-01-04 00:00:00","end_time":"","status":"processing","items_processed":0,"items_successful":0,"items_failed":0,"updated_at":"2026-01-04 00:00:00"}]'
+ACTIVE_POPULATED_END='[{"id":5,"sync_type":"manual","start_time":"2026-01-05 00:00:00","end_time":"2026-01-05 00:01:00","status":"processing","items_processed":0,"items_successful":0,"items_failed":0,"updated_at":"2026-01-05 00:01:00"}]'
+TERMINAL_POPULATED_END='[{"id":6,"sync_type":"manual","start_time":"2026-01-06 00:00:00","end_time":"2026-01-06 00:01:00","status":"completed","items_processed":1,"items_successful":1,"items_failed":0,"updated_at":"2026-01-06 00:01:00"}]'
+MIXED_ACTIVE_POPULATED='[{"id":6,"sync_type":"manual","start_time":"2026-01-06 00:00:00","end_time":"2026-01-06 00:01:00","status":"completed","items_processed":1,"items_successful":1,"items_failed":0,"updated_at":"2026-01-06 00:01:00"},{"id":7,"sync_type":"manual","start_time":"2026-01-07 00:00:00","end_time":"2026-01-07 00:01:00","status":"processing","items_processed":0,"items_successful":0,"items_failed":0,"updated_at":"2026-01-07 00:01:00"}]'
+UNKNOWN_HISTORY='[{"id":8,"sync_type":"manual","start_time":"2026-01-08 00:00:00","end_time":"2026-01-08 00:01:00","status":"mystery","items_processed":0,"items_successful":0,"items_failed":0,"updated_at":"2026-01-08 00:01:00"}]'
+state_helper_snapshot "$ACTIVE_EMPTY_END" __unset__ "$TMP/history-active-empty.json"
+state_helper_snapshot "$ACTIVE_POPULATED_END" __unset__ "$TMP/history-active-populated.json"
+state_helper_snapshot "$TERMINAL_POPULATED_END" __unset__ "$TMP/history-terminal-populated.json"
+state_helper_snapshot "$MIXED_ACTIVE_POPULATED" __unset__ "$TMP/history-mixed-active.json"
+state_helper_snapshot "$UNKNOWN_HISTORY" __unset__ "$TMP/history-unknown.json"
+[[ "$(state_json_get "$TMP/history-active-empty.json" active_history_count)" == 1 ]] || fail "active empty end_time not counted"
+[[ "$(state_json_get "$TMP/history-active-populated.json" active_history_count)" == 1 ]] || fail "active populated end_time not counted"
+[[ "$(state_json_get "$TMP/history-terminal-populated.json" active_history_count)" == 0 ]] || fail "terminal row counted active"
+[[ "$(state_json_get "$TMP/history-mixed-active.json" active_history_count)" == 1 ]] || fail "mixed active populated end_time not counted"
+[[ "$(state_json_get "$TMP/history-unknown.json" active_history_count)" == 0 ]] || fail "unknown status counted active"
+pass "state helper counts active history regardless of end_time without counting terminal or unknown statuses"
+state_json_active_history(){ local history="$1" metrics="$2" maxh="$3" maxm="$4" digest="$5"; cat <<JSON
+{"schema_version":1,"required_tables_present":{"projects":true,"tokens":true,"token_details":true,"sync_stats":true,"sync_metrics":true},"project_count":1,"project_max_id":1,"token_count":1,"token_max_id":1,"token_detail_count":1,"token_detail_max_id":1,"sync_history_total_count":$history,"active_history_count":1,"terminal_history_count":$history,"max_history_id":$maxh,"metrics_total_count":$metrics,"max_metrics_id":$maxm,"duplicate_project_uid_count":0,"duplicate_token_uid_count":0,"duplicate_token_detail_uid_count":0,"invalid_relationship_count":0,"impossible_counter_count":0,"option_active_marker_count":0,"transient_active_marker_count":0,"stale_recovery_marker_count":0,"heartbeat_worker_evidence_count":0,"sync_data_classification":"absent","blocked_cron_hook_counts":{"nmkr_execute_sync_background":0,"nmkr_process_batch_hook":0,"nmkr_sync_cron_hook":0,"nmkr_install_sync_cron_hook":0},"blocked_sync_cron_count":0,"cron_inspectable":true,"light_profile_guard":true,"api_key_present":true,"last_sync_time_matches_latest_metrics":true,"terminal_history_digest":"$digest","latest_history_id":$maxh,"latest_history_status_classification":"active","latest_history_completed":false,"latest_history_end_time_valid":true,"snapshot_epoch":1}
+JSON
+}
+D="$TMP/active_history_authorization"; mkdir -m700 "$D"; mkdir -p "$D/runs/phase15"; chmod 700 "$D/runs" "$D/runs/phase15"; R="$D/runs/phase15/real-sync-preflight.receipt.json"; C="$D/runs/phase15/real-sync-preflight.receipt.consumed.json"; make_receipt "$R"
+PRE="$TMP/active-history-auth.pre.json"; POST="$TMP/active-history-auth.post.json"; LOG="$TMP/active-history-auth.driver"; state_json_active_history 1 1 1 1 abc >"$PRE"; state_json 2 2 2 2 abc >"$POST"; : >"$LOG"
+run_fail "active history with populated end_time blocks authorization" base_env "$D" NMKR_PHASE16A_RECEIPT="$R" NMKR_FAKE_PRE_STATE="$PRE" NMKR_FAKE_POST_STATE="$POST" NMKR_FAKE_DRIVER_LOG="$LOG" NMKR_FAKE_CONSUMED="$C" bash "$ROOT/scripts/nmkr-real-sync-phase16a.sh"
+grep -q "^before:unconsumed$" "$LOG" || fail "active history authorization did not reach final pre-state guard"
+! grep -q "^after:consumed$" "$LOG" || fail "active history authorization consumed receipt"
+[[ -f "$R" && ! -e "$C" ]] || fail "active history authorization consumed receipt artifact"
+pass "controller rejects active history snapshot before receipt consumption and synthetic Start"
+node --input-type=module <<'NODE' >"$TMP/driver-state.out"
+import {runExactlyOnceSync, actionFromRequestLike, routeDecisionForAction, frozenRouteDecisionForUrl, buildStartForm, buildProgressForm} from './scripts/nmkr-real-sync-phase16a-driver.mjs';
+const secret='nonce-fixture-value'; let starts=[], polls=[];
+const fakeClock = () => {
+  let fakeNow = 0;
+  return { now: () => fakeNow, sleep: async (ms) => { fakeNow += ms; } };
+};
+const sf=buildStartForm(secret), pf=buildProgressForm(secret);
+if(sf.action!=='nmkr_start_sync'||sf.nonce!==secret||Object.hasOwn(sf,'nmkr_sync_nonce')) throw Error('Start form shape failed');
+if(pf.action!=='nmkr_sync_progress'||pf.nonce!==secret||Object.hasOwn(pf,'nmkr_sync_nonce')) throw Error('Progress form shape failed');
+let result=await runExactlyOnceSync({nonce:secret,receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},sleep:async()=>{},transport:{start:async x=>{starts.push(x.nonce);return {status:200,json:{success:true}}},poll:async x=>{polls.push(x.nonce); return polls.length===1?{status:200,json:{data:{progress:10,in_progress:true,metrics:{api_requests:1}}}}:{status:200,json:{data:{progress:100,completed:true}}}}}});
+if(!result.ok||starts.length!==1||starts[0]!==secret||polls.some(n=>n!==secret)) throw Error('nonce propagation failed');
+if(JSON.stringify(result).includes(secret)) throw Error('nonce leaked in sanitized output');
+if(actionFromRequestLike({url:'https://x/wp-admin/admin-ajax.php',method:'POST',postData:'action=nmkr_start_sync'})!=='nmkr_start_sync') throw Error('POST action parse failed');
+if(routeDecisionForAction('nmkr_check_api_status','prepare')!=='synthetic-ok') throw Error('api status route failed');
+if(routeDecisionForAction('heartbeat','frozen')!=='block'||routeDecisionForAction('nmkr_get_sync_statistics','frozen')!=='block') throw Error('frozen blocking failed');
+if(routeDecisionForAction('nmkr_start_sync','after-start',true)!=='block') throw Error('second Start not blocked');
+const base='https://example.invalid';
+for (const path of ['/', '/?foo=bar', '/wp-json/', '/wp-json/example/v1/test', '/example-pretty-permalink/', '/index.php?rest_route=/example', '/wp-admin/admin.php?page=nmkr-connect-dashboard', '/wp-admin/admin-ajax.php', '/wp-content/plugins/nmkr-connect/example.js', '/wp-includes/css/example.css']) {
+  if (frozenRouteDecisionForUrl(new URL(path, base).toString(), base) !== 'block') throw Error(`same-origin frozen URL was not blocked: ${path}`);
+}
+if (frozenRouteDecisionForUrl('https://example.invalid.attacker.invalid/wp-admin/admin-ajax.php', base) !== 'allow') throw Error('hostname substring matched as origin');
+if (frozenRouteDecisionForUrl('https://user@example.invalid/wp-json/', base) !== 'block') throw Error('userinfo URL did not fail closed');
+if (frozenRouteDecisionForUrl('https://[malformed', base) !== 'block') throw Error('malformed HTTP-like URL did not fail closed');
+for (const url of ['about:blank', 'data:text/plain,ok', 'blob:https://example.invalid/token']) {
+  if (frozenRouteDecisionForUrl(url, base) !== 'allow') throw Error(`non-HTTP browser URL misclassified: ${url}`);
+}
+let clock=fakeClock();
+result=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},now:clock.now,sleep:clock.sleep,transport:{start:async()=>({status:200,json:{success:true}}),poll:async()=>({status:200,json:{data:{progress:10,in_progress:false}}})}}); if(!result.timeout) throw Error('explicit not in progress without terminal should not succeed');
+result=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},sleep:async()=>{},transport:{start:async()=>({timeout:true}),poll:async()=>{throw Error('no poll')}}}); if(!result.ambiguous||result.sanitized.startCount!==1) throw Error('ambiguous retry failed');
+
+for (const status of [301,400,401,403,409,500,503]) {
+  const r=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},sleep:async()=>{},transport:{start:async()=>({status,json:{success:true}}),poll:async()=>{throw Error('poll forbidden')}}});
+  if(!r.fatal || r.sanitized.startCount!==1) throw Error(`HTTP ${status} start was not fatal exactly once`);
+}
+clock=fakeClock();
+let lm=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},now:clock.now,sleep:clock.sleep,transport:{start:async()=>({status:200,json:{success:true}}),poll:async()=>({status:200,json:{data:{progress:5,in_progress:true,live_metrics:{api_requests:1}}}})}});
+if(!lm.timeout || !lm.sanitized.validLiveMetricsObserved) throw Error('live_metrics evidence failed');
+clock=fakeClock();
+let legacy=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},now:clock.now,sleep:clock.sleep,transport:{start:async()=>({status:200,json:{success:true}}),poll:async()=>({status:200,json:{data:{progress:5,in_progress:true,metrics:{api_requests:1}}}})}});
+if(!legacy.sanitized.validLiveMetricsObserved) throw Error('legacy metrics fallback failed');
+async function assertProgressSuccessFalse(json, label) {
+  let pollCount=0, sleeps=0;
+  const r=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},sleep:async()=>{sleeps++;},transport:{start:async()=>({status:200,json:{success:true}}),poll:async()=>{pollCount++; return {status:200,json};}}});
+  if(!r.fatal || r.timeout || r.ambiguous) throw Error(`${label} was not immediate fatal`);
+  if(r.sanitized.startCount!==1 || r.sanitized.pollCount!==1 || pollCount!==1 || sleeps!==0) throw Error(`${label} retried or counted incorrectly`);
+  if(JSON.stringify(r).includes('Synchronization failed') || JSON.stringify(r).includes('payload-secret')) throw Error(`${label} leaked response content`);
+}
+await assertProgressSuccessFalse({success:false,data:{message:'Synchronization failed',detail:'payload-secret'}}, 'success false object data');
+await assertProgressSuccessFalse({success:false,data:'Synchronization failed payload-secret'}, 'success false string data');
+await assertProgressSuccessFalse({success:false}, 'success false no data');
+let compatiblePolls=0;
+let compatible=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},sleep:async()=>{},transport:{start:async()=>({status:200,json:{success:true}}),poll:async()=>++compatiblePolls===1?{status:200,json:{success:true,data:{progress:10,in_progress:true,live_metrics:{api_requests:1}}}}:{status:200,json:{success:true,data:{progress:100,completed:true}}}}});
+if(!compatible.ok || compatible.sanitized.pollCount!==2) throw Error('success true progress compatibility failed');
+compatiblePolls=0;
+compatible=await runExactlyOnceSync({nonce:'n',receipt:{maxDurationSeconds:20,pollTimeoutSeconds:5},sleep:async()=>{},transport:{start:async()=>({status:200,json:{success:true}}),poll:async()=>++compatiblePolls===1?{status:200,json:{data:{progress:10,in_progress:true,live_metrics:{api_requests:1}}}}:{status:200,json:{data:{progress:100,completed:true}}}}});
+if(!compatible.ok || compatible.sanitized.pollCount!==2) throw Error('missing success key progress compatibility failed');
+console.log('driver route and nonce synthetic checks passed');
+NODE
+pass "driver nonce, POST routing, frozen same-origin blocking, progress success false, second Start, and ambiguous/no-terminal regressions"
+find "$TMP" \( -path '*/playwright-report' -o -path '*/test-results' -o -path '*/blob-report' -o -path '*/playwright/.cache' -o -name '*.webm' -o -name 'trace.zip' \) -print -quit | grep -q . && fail "Playwright artifacts created"
+if find "$TMP" -maxdepth 1 -type f -print0 | xargs -0 --no-run-if-empty grep -En -- 'nonce-fixture-value|private-token-fixture|cookie-fixture' >/dev/null 2>&1; then fail "fixture secret value appeared in output"; fi
+npx playwright test --list --reporter=list 2>/dev/null | grep -E -- 'nmkr-real-sync-phase16a-driver' && fail "private driver discovered by Playwright"
+pass "no external network, no browser artifacts, no nonce leak, and no private driver discovery"

--- a/scripts/nmkr-real-sync-phase16a-state.php
+++ b/scripts/nmkr-real-sync-phase16a-state.php
@@ -1,0 +1,245 @@
+<?php
+/** Phase 16A read-only aggregate state snapshot. */
+if (!defined('ABSPATH')) {
+    fwrite(STDERR, "WordPress must be loaded.\n");
+    exit(1);
+}
+
+global $wpdb;
+
+function nmkr16_sql_ident($name) {
+    return '`' . str_replace('`', '``', $name) . '`';
+}
+function nmkr16_table_exists($table) {
+    global $wpdb;
+    return $wpdb->get_var($wpdb->prepare('SHOW TABLES LIKE %s', $table)) === $table;
+}
+function nmkr16_count_sql($sql) {
+    global $wpdb;
+    $value = $wpdb->get_var($sql);
+    return is_numeric($value) ? (int) $value : 0;
+}
+function nmkr16_max_id($table) {
+    if (!nmkr16_table_exists($table)) {
+        return 0;
+    }
+    return nmkr16_count_sql('SELECT COALESCE(MAX(id),0) FROM ' . nmkr16_sql_ident($table));
+}
+function nmkr16_has_column($table, $column) {
+    global $wpdb;
+    if (!nmkr16_table_exists($table)) {
+        return false;
+    }
+    return (bool) $wpdb->get_var($wpdb->prepare('SHOW COLUMNS FROM ' . nmkr16_sql_ident($table) . ' LIKE %s', $column));
+}
+function nmkr16_truthy($value) {
+    if (is_bool($value)) {
+        return $value;
+    }
+    if (is_int($value) || is_float($value)) {
+        return ((float) $value) > 0;
+    }
+    if (is_string($value)) {
+        return in_array(strtolower(trim($value)), array('1', 'true', 'yes', 'on', 'running', 'in_progress', 'processing', 'processing_projects', 'processing_tokens', 'initializing', 'pending'), true);
+    }
+    return !empty($value);
+}
+function nmkr16_progress_active($value) {
+    return is_numeric($value) && (float) $value > 0 && (float) $value < 100;
+}
+function nmkr16_active_statuses() {
+    return array('initializing', 'processing', 'processing_projects', 'processing_tokens', 'in_progress', 'running', 'pending', 'active', 'started');
+}
+function nmkr16_terminal_statuses() {
+    return array('completed', 'success', 'failed', 'error', 'stopped', 'cancelled', 'aborted');
+}
+function nmkr16_sql_list($values) {
+    return "'" . implode("','", array_map('esc_sql', $values)) . "'";
+}
+function nmkr16_is_active_status($value) {
+    return is_scalar($value) && in_array(strtolower(trim((string) $value)), nmkr16_active_statuses(), true);
+}
+function nmkr16_sync_data_classification($value) {
+    if (!is_array($value) || empty($value)) {
+        return 'absent';
+    }
+    foreach (array('status', 'sync_status', 'state') as $key) {
+        if (array_key_exists($key, $value) && nmkr16_is_active_status($value[$key])) {
+            return 'active';
+        }
+        if (array_key_exists($key, $value) && in_array(strtolower(trim((string) $value[$key])), nmkr16_terminal_statuses(), true)) {
+            return 'terminal';
+        }
+    }
+    foreach (array('in_progress', 'is_running', 'running', 'pending', 'active') as $key) {
+        if (array_key_exists($key, $value) && $value[$key] === true) {
+            return 'active';
+        }
+    }
+    if (array_key_exists('completed', $value) && $value['completed'] === false) {
+        return 'active';
+    }
+    return 'unknown';
+}
+function nmkr16_terminal_digest($table) {
+    global $wpdb;
+    if (!nmkr16_table_exists($table)) {
+        return hash('sha256', 'missing');
+    }
+    $limit = getenv('NMKR_PHASE16A_HISTORY_MAX_ID');
+    $limit_sql = '';
+    if ($limit !== false) {
+        if (!is_string($limit) || !preg_match('/^(0|[1-9][0-9]*)$/', $limit)) {
+            exit(1);
+        }
+        $limit_sql = ' AND id <= ' . (int) $limit;
+    }
+    $rows = $wpdb->get_results('SELECT id,sync_type,start_time,end_time,status,items_processed,items_successful,items_failed,updated_at FROM ' . nmkr16_sql_ident($table) . ' WHERE BINARY status IN (' . nmkr16_sql_list(nmkr16_terminal_statuses()) . ')' . $limit_sql . ' ORDER BY id ASC', ARRAY_A);
+    $ctx = hash_init('sha256');
+    foreach ((array) $rows as $row) {
+        hash_update($ctx, hash('sha256', wp_json_encode($row)) . "\n");
+    }
+    return hash_final($ctx);
+}
+function nmkr16_option_active_count() {
+    $count = 0;
+    $in_progress_active = nmkr16_truthy(get_option('nmkr_sync_in_progress', false));
+    $progress_active = nmkr16_progress_active(get_option('nmkr_sync_progress', 0));
+    $status_active = nmkr16_is_active_status(get_option('nmkr_sync_status', ''));
+    $sync_data_active = nmkr16_sync_data_classification(get_option('nmkr_sync_data', array())) === 'active';
+    $durable_sync_active = $in_progress_active || $status_active || $sync_data_active;
+    if ($in_progress_active) { $count++; }
+    if ($progress_active) { $count++; }
+    if ($status_active) { $count++; }
+    if ($sync_data_active) { $count++; }
+    if ($durable_sync_active && nmkr16_truthy(get_option('nmkr_sync_near_completion', false))) { $count++; }
+    return $count;
+}
+function nmkr16_transient_active_count() {
+    if (!wp_using_ext_object_cache()) {
+        return 0;
+    }
+    $count = 0;
+    if (nmkr16_truthy(get_transient('nmkr_sync_in_progress'))) { $count++; }
+    if (nmkr16_progress_active(get_transient('nmkr_sync_progress'))) { $count++; }
+    if (nmkr16_is_active_status(get_transient('nmkr_sync_status'))) { $count++; }
+    if (nmkr16_truthy(get_transient('nmkr_stale_recovery_running'))) { $count++; }
+    return $count;
+}
+function nmkr16_stale_recovery_count() {
+    $count = 0;
+    if (nmkr16_truthy(get_option('nmkr_stale_recovery_running', false))) { $count++; }
+    if (wp_using_ext_object_cache() && nmkr16_truthy(get_transient('nmkr_stale_recovery_running'))) { $count++; }
+    return $count;
+}
+function nmkr16_heartbeat_worker_count() {
+    $count = 0;
+    foreach (array('nmkr_sync_heartbeat', 'nmkr_sync_worker_started_at', 'nmkr_sync_worker_lock') as $key) {
+        if (nmkr16_truthy(get_option($key, false))) { $count++; }
+    }
+    return $count;
+}
+function nmkr16_cron_state() {
+    $blocked = array('nmkr_execute_sync_background', 'nmkr_process_batch_hook', 'nmkr_sync_cron_hook', 'nmkr_install_sync_cron_hook');
+    $counts = array_fill_keys($blocked, 0);
+    $inspectable = true;
+    $cron = get_option('cron', array());
+    if (!is_array($cron) || !isset($cron['version']) || (int) $cron['version'] !== 2) {
+        return array($counts, false, 0);
+    }
+    foreach ($cron as $timestamp => $events) {
+        if ($timestamp === 'version') { continue; }
+        if (!is_scalar($timestamp) || !ctype_digit((string) $timestamp) || !is_array($events)) { $inspectable = false; break; }
+        foreach ($events as $hook => $hook_events) {
+            if (!is_string($hook) || !is_array($hook_events)) { $inspectable = false; break 2; }
+            if (array_key_exists($hook, $counts)) { $counts[$hook] += count($hook_events); }
+        }
+    }
+    return array($counts, $inspectable, array_sum($counts));
+}
+function nmkr16_light_profile_ok() {
+    $options = get_option('nmkr_connect_options', array());
+    if (!is_array($options)) { return false; }
+    $profile = isset($options['sync_profile']) ? (string) $options['sync_profile'] : '';
+    $batch_size = isset($options['sync_batch_size']) ? $options['sync_batch_size'] : null;
+    $batch_delay = isset($options['sync_batch_delay']) ? $options['sync_batch_delay'] : null;
+    return $profile === 'light' && is_numeric($batch_size) && (int) $batch_size >= 1 && (int) $batch_size <= 3 && is_numeric($batch_delay) && (int) $batch_delay >= 3 && (int) $batch_delay <= 10;
+}
+function nmkr16_api_key_present() {
+    $options = get_option('nmkr_connect_options', array());
+    return is_array($options) && isset($options['api_key']) && is_string($options['api_key']) && trim($options['api_key']) !== '';
+}
+
+$prefix = $wpdb->prefix;
+$projects = $prefix . 'nmkr_projects';
+$tokens = $prefix . 'nmkr_tokens';
+$details = $prefix . 'nmkr_token_details';
+$history = $prefix . 'nmkr_sync_stats';
+$metrics = $prefix . 'nmkr_sync_metrics';
+$present = array(
+    'projects' => nmkr16_table_exists($projects),
+    'tokens' => nmkr16_table_exists($tokens),
+    'token_details' => nmkr16_table_exists($details),
+    'sync_stats' => nmkr16_table_exists($history),
+    'sync_metrics' => nmkr16_table_exists($metrics),
+);
+$active_sql = nmkr16_sql_list(nmkr16_active_statuses());
+$terminal_sql = nmkr16_sql_list(nmkr16_terminal_statuses());
+$history_total = $present['sync_stats'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($history)) : 0;
+$active_history = $present['sync_stats'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($history) . ' WHERE BINARY status IN (' . $active_sql . ')') : 0;
+$terminal_history = $present['sync_stats'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($history) . ' WHERE BINARY status IN (' . $terminal_sql . ')') : 0;
+$metrics_total = $present['sync_metrics'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($metrics)) : 0;
+$latest_metric_time = $present['sync_metrics'] ? (string) $wpdb->get_var('SELECT last_sync_time FROM ' . nmkr16_sql_ident($metrics) . ' ORDER BY last_sync_time DESC, id DESC LIMIT 1') : '';
+$last_sync_time = (string) get_option('nmkr_last_sync_time', '');
+list($blocked_cron_hook_counts, $cron_inspectable, $blocked_sync_cron_count) = nmkr16_cron_state();
+$latest_status = $present['sync_stats'] ? (string) $wpdb->get_var('SELECT status FROM ' . nmkr16_sql_ident($history) . ' ORDER BY id DESC LIMIT 1') : '';
+$latest_end_valid = $present['sync_stats'] ? (bool) $wpdb->get_var('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($history) . ' WHERE id = (SELECT MAX(id) FROM ' . nmkr16_sql_ident($history) . ') AND end_time IS NOT NULL AND end_time <> ""') : false;
+$duplicate_project = ($present['projects'] && nmkr16_has_column($projects, 'project_uid')) ? nmkr16_count_sql('SELECT COUNT(*) FROM (SELECT project_uid FROM ' . nmkr16_sql_ident($projects) . ' WHERE project_uid IS NOT NULL AND project_uid <> "" GROUP BY project_uid HAVING COUNT(*) > 1) d') : 0;
+$duplicate_token = ($present['tokens'] && nmkr16_has_column($tokens, 'token_uid')) ? nmkr16_count_sql('SELECT COUNT(*) FROM (SELECT token_uid FROM ' . nmkr16_sql_ident($tokens) . ' WHERE token_uid IS NOT NULL AND token_uid <> "" GROUP BY token_uid HAVING COUNT(*) > 1) d') : 0;
+$duplicate_detail = ($present['token_details'] && nmkr16_has_column($details, 'token_uid')) ? nmkr16_count_sql('SELECT COUNT(*) FROM (SELECT token_uid FROM ' . nmkr16_sql_ident($details) . ' WHERE token_uid IS NOT NULL AND token_uid <> "" GROUP BY token_uid HAVING COUNT(*) > 1) d') : 0;
+$invalid_relationship = ($present['tokens'] && $present['projects']) ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($tokens) . ' t LEFT JOIN ' . nmkr16_sql_ident($projects) . ' p ON t.project_uid = p.project_uid WHERE t.project_uid IS NOT NULL AND t.project_uid <> "" AND p.project_uid IS NULL') : 0;
+$invalid_relationship += ($present['token_details'] && $present['tokens']) ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($details) . ' d LEFT JOIN ' . nmkr16_sql_ident($tokens) . ' t ON d.token_uid = t.token_uid WHERE d.token_uid IS NOT NULL AND d.token_uid <> "" AND t.token_uid IS NULL') : 0;
+$impossible = 0;
+if ($present['sync_stats']) { $impossible += nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($history) . ' WHERE start_time IS NULL OR items_processed < 0 OR items_successful < 0 OR items_failed < 0 OR (end_time IS NOT NULL AND end_time < start_time)'); }
+if ($present['sync_metrics']) { $impossible += nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($metrics) . ' WHERE total_projects < 0 OR total_tokens < 0 OR total_sync_duration < 0 OR total_api_time < 0 OR average_response_time < 0 OR api_requests < 0 OR memory_usage < 0 OR last_sync_time IS NULL'); }
+
+$output = array(
+    'schema_version' => 1,
+    'required_tables_present' => $present,
+    'project_count' => $present['projects'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($projects)) : 0,
+    'project_max_id' => nmkr16_max_id($projects),
+    'token_count' => $present['tokens'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($tokens)) : 0,
+    'token_max_id' => nmkr16_max_id($tokens),
+    'token_detail_count' => $present['token_details'] ? nmkr16_count_sql('SELECT COUNT(*) FROM ' . nmkr16_sql_ident($details)) : 0,
+    'token_detail_max_id' => nmkr16_max_id($details),
+    'sync_history_total_count' => $history_total,
+    'active_history_count' => $active_history,
+    'terminal_history_count' => $terminal_history,
+    'max_history_id' => nmkr16_max_id($history),
+    'metrics_total_count' => $metrics_total,
+    'max_metrics_id' => nmkr16_max_id($metrics),
+    'duplicate_project_uid_count' => $duplicate_project,
+    'duplicate_token_uid_count' => $duplicate_token,
+    'duplicate_token_detail_uid_count' => $duplicate_detail,
+    'invalid_relationship_count' => $invalid_relationship,
+    'impossible_counter_count' => $impossible,
+    'option_active_marker_count' => nmkr16_option_active_count(),
+    'transient_active_marker_count' => nmkr16_transient_active_count(),
+    'stale_recovery_marker_count' => nmkr16_stale_recovery_count(),
+    'heartbeat_worker_evidence_count' => nmkr16_heartbeat_worker_count(),
+    'sync_data_classification' => nmkr16_sync_data_classification(get_option('nmkr_sync_data', array())),
+    'blocked_cron_hook_counts' => $blocked_cron_hook_counts,
+    'blocked_sync_cron_count' => $blocked_sync_cron_count,
+    'cron_inspectable' => $cron_inspectable,
+    'light_profile_guard' => nmkr16_light_profile_ok(),
+    'api_key_present' => nmkr16_api_key_present(),
+    'last_sync_time_matches_latest_metrics' => ($last_sync_time === '' && $latest_metric_time === '') || ($last_sync_time !== '' && $last_sync_time === $latest_metric_time),
+    'terminal_history_digest' => nmkr16_terminal_digest($history),
+    'latest_history_id' => nmkr16_max_id($history),
+    'latest_history_status_classification' => in_array(strtolower($latest_status), nmkr16_terminal_statuses(), true) ? strtolower($latest_status) : (nmkr16_is_active_status($latest_status) ? 'active' : 'unknown'),
+    'latest_history_completed' => strtolower($latest_status) === 'completed' || strtolower($latest_status) === 'success',
+    'latest_history_end_time_valid' => $latest_end_valid,
+    'snapshot_epoch' => time(),
+);
+
+echo wp_json_encode($output, JSON_UNESCAPED_SLASHES) . "\n";

--- a/scripts/nmkr-real-sync-phase16a.sh
+++ b/scripts/nmkr-real-sync-phase16a.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+if REPO_ROOT_FROM_GIT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel 2>/dev/null)"; then
+  REPO_ROOT="$REPO_ROOT_FROM_GIT"
+else
+  REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+fi
+FINAL_MIN_REMAINING_SECONDS=30
+REQUIRED_HEAD="${NMKR_PHASE16A_EXPECTED_HEAD:-}"
+
+ci_active() { [[ -n "${1:-}" && "${1:-}" != "0" && "${1:-}" != "false" ]]; }
+summary() { printf '\nPhase 16A controlled real-sync summary\n  result: %s\n' "$1"; [[ -n "${2:-}" ]] && printf '  failed gate: %s\n' "$2"; [[ -n "${RUN_DIR:-}" ]] && printf '  private diagnostic path: %s\n' "$RUN_DIR"; }
+fail() { summary FAIL "$1"; exit 1; }
+require_tool() { command -v "$1" >/dev/null 2>&1 || fail required-tools; }
+wp_cli() { local bin="${WP_CLI_BIN:-wp}"; "$bin" --path="$WP_PATH" "$@"; }
+json_get() { python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])' "$1" "$2"; }
+inside_or_equal() { python3 - "$1" "$2" <<'PY'
+import os,sys
+a=os.path.realpath(sys.argv[1]); b=os.path.realpath(sys.argv[2])
+raise SystemExit(0 if a == b or a.startswith(b.rstrip(os.sep) + os.sep) else 1)
+PY
+}
+
+validate_private_state() {
+  python3 - "${NMKR_PHASE2_LOG_DIR:-}" "$REPO_ROOT" "${WP_PATH:-}" <<'PY'
+import os, stat, sys
+state, repo, wp = sys.argv[1:4]
+uid = os.getuid()
+def bad(): raise SystemExit(1)
+def inside(a,b):
+    a=os.path.realpath(a); b=os.path.realpath(b)
+    return a == b or a.startswith(b.rstrip(os.sep) + os.sep)
+if not state or not os.path.isabs(state) or not wp or not os.path.isabs(wp): bad()
+if any(part in ('.','..') for part in state.split(os.sep)): bad()
+if any(inside(state, root) or inside(root, state) for root in (repo, wp)): bad()
+probe = state
+missing=[]
+while not os.path.exists(probe):
+    missing.append(os.path.basename(probe)); parent=os.path.dirname(probe)
+    if parent == probe: bad()
+    probe=parent
+cur = os.sep
+for part in [p for p in state.split(os.sep) if p]:
+    cur=os.path.join(cur, part)
+    if os.path.exists(cur):
+        if cur in ('/tmp','/var/tmp','/private/tmp','/'):
+            continue
+        st=os.stat(cur)
+        if os.path.islink(cur) or st.st_uid != uid or (stat.S_IMODE(st.st_mode) & 0o077): bad()
+    else:
+        break
+os.makedirs(os.path.join(state, 'runs'), mode=0o700, exist_ok=True)
+for p in (state, os.path.join(state, 'runs')):
+    st=os.stat(p)
+    if os.path.islink(p) or st.st_uid != uid or (stat.S_IMODE(st.st_mode) & 0o077): bad()
+PY
+}
+
+origin_digest() {
+  python3 - "$1" "$2" "$3" "$4" <<'PY'
+import hashlib, sys, urllib.parse
+values = sys.argv[1:5]
+def norm(value):
+    p = urllib.parse.urlsplit(value.strip())
+    try: port = p.port
+    except ValueError: raise SystemExit(1)
+    if p.scheme != 'https' or not p.hostname or p.username or p.password or p.query or p.fragment or p.path not in ('','/') or port is not None:
+        raise SystemExit(1)
+    host = p.hostname.lower().rstrip('.')
+    if '*' in host or not host:
+        raise SystemExit(1)
+    return 'https://' + host
+normalized = [norm(v) for v in values]
+if any(v != normalized[0] for v in normalized):
+    raise SystemExit(1)
+print(hashlib.sha256(normalized[0].encode()).hexdigest())
+PY
+}
+
+validate_origin_guard() {
+  local home siteurl digest
+  home="$(wp_cli option get home 2>>"$DIAGNOSTIC_FILE")" || fail origin-guard
+  siteurl="$(wp_cli option get siteurl 2>>"$DIAGNOSTIC_FILE")" || fail origin-guard
+  digest="$(origin_digest "${NMKR_REAL_SYNC_ALLOWED_ORIGIN:-}" "${WP_BASE_URL:-}" "$home" "$siteurl")" || fail origin-guard
+  [[ -z "${1:-}" || "$digest" == "$1" ]] || fail origin-guard
+  printf '%s\n' "$digest"
+}
+
+validate_admin_capability() {
+  [[ -n "${WP_ADMIN_USER:-}" ]] || fail capability
+  WP_ADMIN_USER="$WP_ADMIN_USER" wp_cli eval ' $i = getenv("WP_ADMIN_USER"); $u = get_user_by("login", $i); if (!$u && is_email($i)) { $u = get_user_by("email", $i); } exit(($u instanceof WP_User && user_can($u, "nmkr_manage_sync")) ? 0 : 1); ' >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail capability
+}
+
+validate_target_integrity() {
+  local expected_digest="${1:-}"
+  validate_origin_guard "$expected_digest" >/dev/null
+  wp_cli core is-installed >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail wordpress-ready
+  wp_cli plugin is-active "${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}" >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail plugin-active
+  validate_admin_capability
+  validate_target_git >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail deployment-integrity
+}
+
+resolve_deployed_real() {
+  python3 - "$REPO_ROOT" "${WP_PATH:-}" "${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}" "${NMKR_DEPLOYED_PLUGIN_PATH:-}" <<'PY'
+import os, sys
+repo, wp, slug, override = sys.argv[1:5]
+def bad(): raise SystemExit(1)
+if not wp or not os.path.isabs(wp) or '/' not in slug or slug.startswith('/') or '..' in slug.split('/'):
+    bad()
+plugin_dir = slug.split('/')[0]
+active = os.path.realpath(os.path.join(wp.rstrip(os.sep), 'wp-content', 'plugins', plugin_dir))
+if not os.path.isdir(active):
+    bad()
+selected = active
+if override:
+    if not os.path.isabs(override):
+        bad()
+    selected = os.path.realpath(override)
+    if selected != active:
+        bad()
+repo_real = os.path.realpath(repo)
+def inside_or_equal(a, b):
+    return a == b or a.startswith(b.rstrip(os.sep) + os.sep)
+if inside_or_equal(selected, repo_real) or inside_or_equal(repo_real, selected):
+    bad()
+print(selected)
+PY
+}
+
+validate_target_git() {
+  python3 - "$REPO_ROOT" "$DEPLOYED_REAL" "${REQUIRED_HEAD:-}" <<'PY'
+import os, re, subprocess, sys
+src, dep, required = sys.argv[1:4]
+def bad(): raise SystemExit(1)
+def git(repo, *args): return subprocess.check_output(['git','-C',repo,*args], text=True, stderr=subprocess.DEVNULL).strip()
+def clean(repo): return git(repo,'status','--porcelain=v1','--untracked-files=all') == ''
+def inside_or_equal(a, b):
+    a=os.path.realpath(a); b=os.path.realpath(b)
+    return a == b or a.startswith(b.rstrip(os.sep) + os.sep)
+src=os.path.realpath(src); dep=os.path.realpath(dep)
+if inside_or_equal(src, dep) or inside_or_equal(dep, src): bad()
+for repo in (src, dep):
+    if git(repo,'rev-parse','--is-inside-work-tree') != 'true': bad()
+    top=os.path.realpath(git(repo,'rev-parse','--show-toplevel'))
+    if top != os.path.realpath(repo): bad()
+src_head=git(src,'rev-parse','HEAD'); dep_head=git(dep,'rev-parse','HEAD')
+if not re.fullmatch(r'[0-9a-f]{40}', src_head) or not re.fullmatch(r'[0-9a-f]{40}', dep_head): bad()
+if src_head != dep_head: bad()
+if required and src_head != required: bad()
+if not clean(src) or not clean(dep): bad()
+PY
+}
+
+validate_receipt_path() {
+  python3 - "${NMKR_PHASE16A_RECEIPT:-}" "$NMKR_PHASE2_LOG_DIR" "$REPO_ROOT" "$WP_PATH" <<'PY'
+import os, stat, sys
+receipt, state, repo, wp = sys.argv[1:5]
+uid=os.getuid()
+def bad(): raise SystemExit(1)
+def inside(a,b):
+    a=os.path.realpath(a); b=os.path.realpath(b)
+    return a == b or a.startswith(b.rstrip(os.sep)+os.sep)
+if not receipt or not os.path.isabs(receipt): bad()
+if os.path.basename(receipt) != 'real-sync-preflight.receipt.json': bad()
+if os.path.islink(receipt) or not os.path.isfile(receipt): bad()
+st=os.stat(receipt)
+if st.st_uid != uid or stat.S_IMODE(st.st_mode) != 0o600: bad()
+state_real=os.path.realpath(state); repo_real=os.path.realpath(repo); wp_real=os.path.realpath(wp); receipt_real=os.path.realpath(receipt)
+if inside(receipt_real, repo_real) or inside(receipt_real, wp_real): bad()
+run_dir=os.path.dirname(receipt_real); runs_dir=os.path.dirname(run_dir)
+if os.path.basename(runs_dir) != 'runs' or os.path.dirname(runs_dir) != state_real: bad()
+if run_dir == runs_dir or os.path.dirname(receipt_real) == state_real: bad()
+cur=state_real
+while True:
+    st=os.stat(cur)
+    if os.path.islink(cur) or st.st_uid != uid or (stat.S_IMODE(st.st_mode)&0o077): bad()
+    if cur == run_dir: break
+    nxt = runs_dir if cur == state_real else run_dir if cur == runs_dir else None
+    if not nxt: bad()
+    cur=nxt
+PY
+}
+
+validate_receipt() {
+  local phase="$1" receipt="$2" consumed="$3" deployed="$4" fingerprint_out="$5"
+  python3 - "$phase" "$receipt" "$consumed" "$REPO_ROOT" "$deployed" "$fingerprint_out" "$FINAL_MIN_REMAINING_SECONDS" "$REQUIRED_HEAD" <<'PY'
+import hashlib, json, os, stat, subprocess, sys, time
+phase, receipt, consumed, src, deployed, fingerprint_out, min_remaining, required_head = sys.argv[1:9]
+min_remaining = int(min_remaining)
+required = {
+ 'receipt_version': int, 'purpose': str, 'created_at_epoch': int, 'expires_at_epoch': int,
+ 'source_commit': str, 'deployed_commit': str, 'origin_sha256': str,
+ 'plugin_active': bool, 'admin_capability_ok': bool, 'db_state_clean': bool,
+ 'api_key_present': bool, 'runtime_state_clean': bool, 'cron_state_clean': bool,
+ 'object_cache_state_clean': bool, 'profile_guard_passed': bool, 'backup_confirmed': bool,
+ 'backup_confirmed_at_epoch': int, 'max_duration_seconds': int,
+ 'poll_timeout_seconds': int, 'receipt_ttl_seconds': int,
+}
+def bad(): raise SystemExit(1)
+def clean(repo):
+    return subprocess.check_output(['git','-C',repo,'status','--porcelain=v1','--untracked-files=all'], text=True).strip() == ''
+def head(repo):
+    return subprocess.check_output(['git','-C',repo,'rev-parse','HEAD'], text=True).strip()
+def parent_private(path):
+    uid=os.getuid(); cur=os.path.dirname(os.path.realpath(path)); root=os.path.parse if False else None
+    while cur and cur != os.path.dirname(cur):
+        if cur in ('/tmp','/var/tmp','/private/tmp','/'):
+            break
+        st=os.stat(cur)
+        if os.path.islink(cur) or st.st_uid != uid or (stat.S_IMODE(st.st_mode) & 0o077): bad()
+        cur=os.path.dirname(cur)
+try: st=os.lstat(receipt)
+except OSError: bad()
+if not stat.S_ISREG(st.st_mode) or stat.S_ISLNK(st.st_mode) or st.st_uid != os.getuid() or stat.S_IMODE(st.st_mode) != 0o600: bad()
+parent_private(receipt)
+if os.path.exists(consumed): bad()
+raw=open(receipt,'rb').read()
+try: data=json.loads(raw.decode('utf-8'))
+except Exception: bad()
+if set(data) != set(required): bad()
+for key, typ in required.items():
+    if type(data[key]) is not typ: bad()
+if data['receipt_version'] != 1 or data['purpose'] != 'nmkr-real-sync-preflight': bad()
+now=int(time.time())
+if data['created_at_epoch'] > now + 300 or data['created_at_epoch'] <= 0: bad()
+if data['expires_at_epoch'] <= now: bad()
+if phase == 'final' and data['expires_at_epoch'] - now < min_remaining: bad()
+if now - data['backup_confirmed_at_epoch'] > 86400 or data['backup_confirmed_at_epoch'] > now + 300: bad()
+if not (300 <= data['max_duration_seconds'] <= 3600 and 10 <= data['poll_timeout_seconds'] <= 60 and 60 <= data['receipt_ttl_seconds'] <= 300): bad()
+if data['expires_at_epoch'] != data['created_at_epoch'] + data['receipt_ttl_seconds']: bad()
+for key in ['plugin_active','admin_capability_ok','db_state_clean','api_key_present','runtime_state_clean','cron_state_clean','object_cache_state_clean','profile_guard_passed','backup_confirmed']:
+    if data[key] is not True: bad()
+if not isinstance(data['origin_sha256'], str) or len(data['origin_sha256']) != 64 or any(c not in '0123456789abcdef' for c in data['origin_sha256']): bad()
+expected_origin=os.environ.get('NMKR_PHASE16A_CURRENT_ORIGIN_DIGEST','')
+if expected_origin and data['origin_sha256'] != expected_origin: bad()
+src_head=head(src); dep_head=head(deployed)
+if src_head != data['source_commit'] or dep_head != data['deployed_commit'] or src_head != dep_head: bad()
+if required_head and src_head != required_head: bad()
+if not clean(src) or not clean(deployed): bad()
+fingerprint=hashlib.sha256(raw).hexdigest()
+if fingerprint_out:
+    if phase == 'initial': open(fingerprint_out,'w').write(fingerprint+'\n')
+    else:
+        if open(fingerprint_out).read().strip() != fingerprint: bad()
+print(json.dumps({'ok': True, 'fingerprint': fingerprint, 'source_commit': src_head, 'deployed_commit': dep_head, 'max_duration_seconds': data['max_duration_seconds'], 'poll_timeout_seconds': data['poll_timeout_seconds']}, separators=(',',':')))
+PY
+}
+
+capture_state() {
+  local out="$1" max_id="${2:-}"
+  if [[ -n "$max_id" ]]; then
+    NMKR_PHASE16A_HISTORY_MAX_ID="$max_id" wp_cli eval-file "$REPO_ROOT/scripts/nmkr-real-sync-phase16a-state.php" >"$out" 2>>"$DIAGNOSTIC_FILE"
+  else
+    wp_cli eval-file "$REPO_ROOT/scripts/nmkr-real-sync-phase16a-state.php" >"$out" 2>>"$DIAGNOSTIC_FILE"
+  fi
+  chmod 600 "$out"
+}
+
+final_authorize() {
+  RUN_DIR="$1"; DIAGNOSTIC_FILE="$RUN_DIR/phase16a.log"
+  source "$RUN_DIR/controller.env"
+  [[ -d "$LOCK" ]] || fail controller-lock
+  CURRENT_ORIGIN_DIGEST="$(validate_origin_guard)"
+  NMKR_PHASE16A_CURRENT_ORIGIN_DIGEST="$CURRENT_ORIGIN_DIGEST" validate_receipt final "$RECEIPT" "$CONSUMED" "$DEPLOYED_REAL" "$RUN_DIR/receipt.sha256" >"$RUN_DIR/final-receipt.json" || fail receipt
+  wp_cli core is-installed >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail wordpress-ready
+  wp_cli plugin is-active "${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}" >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail plugin-active
+  validate_admin_capability
+  capture_state "$RUN_DIR/pre.json"
+  python3 - "$RUN_DIR/pre.json" <<'PY' || fail pre-state
+import json,sys
+d=json.load(open(sys.argv[1]))
+if not all(d['required_tables_present'].values()): raise SystemExit(1)
+for k in ['active_history_count','option_active_marker_count','transient_active_marker_count','stale_recovery_marker_count','heartbeat_worker_evidence_count','blocked_sync_cron_count','duplicate_project_uid_count','duplicate_token_uid_count','duplicate_token_detail_uid_count','invalid_relationship_count','impossible_counter_count']:
+    if d.get(k) != 0: raise SystemExit(1)
+if not d['cron_inspectable'] or not d['light_profile_guard'] or not d['api_key_present']: raise SystemExit(1)
+if d['sync_data_classification'] not in ('absent','terminal'): raise SystemExit(1)
+PY
+  [[ ! -e "$CONSUMED" ]] || fail receipt
+  mv "$RECEIPT" "$CONSUMED" || fail receipt
+  chmod 600 "$CONSUMED"
+  printf '{"ok":true}\n'
+}
+
+if [[ "${1:-}" == "--final-authorize" ]]; then final_authorize "$2"; exit 0; fi
+
+for n in CI GITHUB_ACTIONS GITLAB_CI CIRCLECI BUILDKITE TF_BUILD; do ci_active "${!n:-}" && fail ci-refusal; done
+[[ "${RUN_REAL_SYNC:-false}" == true ]] || fail confirmations
+[[ "${PW_SAVE_ARTIFACTS:-false}" == false ]] || fail confirmations
+[[ "${NMKR_REAL_SYNC_CONFIRM:-}" == I_UNDERSTAND_THIS_MUTATES_DEV ]] || fail confirmations
+[[ "${NMKR_PHASE16A_CONFIRM:-}" == I_AUTHORIZE_EXACTLY_ONE_START ]] || fail confirmations
+[[ -n "${WP_PATH:-}" && "$WP_PATH" = /* ]] || fail env-file
+
+if [[ -n "${NMKR_PHASE2_ENV_FILE:-}" ]]; then
+  [[ "$NMKR_PHASE2_ENV_FILE" = /* && -f "$NMKR_PHASE2_ENV_FILE" && ! -L "$NMKR_PHASE2_ENV_FILE" ]] || fail env-file
+  inside_or_equal "$NMKR_PHASE2_ENV_FILE" "$REPO_ROOT" && fail env-file
+  inside_or_equal "$NMKR_PHASE2_ENV_FILE" "$WP_PATH" && fail env-file
+  WP_PATH_PRE="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$WP_PATH")"
+  set -a; source "$NMKR_PHASE2_ENV_FILE" >/dev/null 2>/dev/null || fail env-file; set +a
+  [[ "$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$WP_PATH")" == "$WP_PATH_PRE" ]] || fail env-file
+fi
+
+for tool in bash git python3 node; do require_tool "$tool"; done
+validate_private_state || fail private-state
+mkdir -p "$NMKR_PHASE2_LOG_DIR/runs"
+RUN_DIR="$NMKR_PHASE2_LOG_DIR/runs/phase16a-$(date -u +%Y%m%dT%H%M%SZ)-$$"; mkdir -m 700 "$RUN_DIR" || fail private-state
+DIAGNOSTIC_FILE="$RUN_DIR/phase16a.log"; : >"$DIAGNOSTIC_FILE"; chmod 600 "$DIAGNOSTIC_FILE"
+LOCK="$NMKR_PHASE2_LOG_DIR/phase16a-controller.lock"; OWN_LOCK=0
+cleanup(){ if [[ "$OWN_LOCK" == 1 && -d "$LOCK" ]]; then rmdir "$LOCK" 2>/dev/null || true; fi; }
+trap 'printf '\''{"result":"interrupted"}\n'\'' >"$RUN_DIR/result.json"; cleanup; exit 130' INT TERM
+trap cleanup EXIT
+mkdir -m 700 "$LOCK" || fail controller-lock; OWN_LOCK=1
+
+RECEIPT="${NMKR_PHASE16A_RECEIPT:-}"
+validate_receipt_path || fail receipt-path
+CONSUMED="${RECEIPT%.json}.consumed.json"
+DEPLOYED_REAL="$(resolve_deployed_real)" || fail deployment-integrity
+validate_target_git >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail deployment-integrity
+CURRENT_ORIGIN_DIGEST="$(validate_origin_guard)"
+NMKR_PHASE16A_CURRENT_ORIGIN_DIGEST="$CURRENT_ORIGIN_DIGEST" validate_receipt initial "$RECEIPT" "$CONSUMED" "$DEPLOYED_REAL" "$RUN_DIR/receipt.sha256" >"$RUN_DIR/initial-receipt.json" || fail receipt
+
+wp_cli core is-installed >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail wordpress-ready
+wp_cli plugin is-active "${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}" >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail plugin-active
+validate_admin_capability
+
+cat >"$RUN_DIR/controller.env" <<ENV
+WP_PATH=$(printf '%q' "$WP_PATH")
+WP_CLI_BIN=$(printf '%q' "${WP_CLI_BIN:-wp}")
+RECEIPT=$(printf '%q' "$RECEIPT")
+CONSUMED=$(printf '%q' "$CONSUMED")
+DEPLOYED_REAL=$(printf '%q' "$DEPLOYED_REAL")
+LOCK=$(printf '%q' "$LOCK")
+NMKR_PLUGIN_SLUG=$(printf '%q' "${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}")
+WP_BASE_URL=$(printf '%q' "${WP_BASE_URL:-}")
+NMKR_REAL_SYNC_ALLOWED_ORIGIN=$(printf '%q' "${NMKR_REAL_SYNC_ALLOWED_ORIGIN:-}")
+WP_ADMIN_USER=$(printf '%q' "${WP_ADMIN_USER:-}")
+ENV
+chmod 600 "$RUN_DIR/controller.env"
+
+DRIVER_BIN="${NMKR_PHASE16A_TEST_DRIVER_BIN:-$REPO_ROOT/scripts/nmkr-real-sync-phase16a-driver.mjs}"
+export NMKR_PHASE16A_FINAL_AUTH_RUN_DIR="$RUN_DIR"
+export NMKR_PHASE16A_FINAL_AUTH_SCRIPT="$REPO_ROOT/scripts/nmkr-real-sync-phase16a.sh"
+export NMKR_REAL_SYNC_MAX_DURATION_SECONDS="$(json_get "$RUN_DIR/initial-receipt.json" max_duration_seconds)"
+export NMKR_REAL_SYNC_POLL_TIMEOUT_SECONDS="$(json_get "$RUN_DIR/initial-receipt.json" poll_timeout_seconds)"
+node "$DRIVER_BIN" >"$RUN_DIR/driver.json" 2>"$RUN_DIR/driver.err" || fail driver
+[[ -f "$RUN_DIR/pre.json" && -f "$CONSUMED" ]] || fail authorization-sequence
+PRE_MAX_ID="$(json_get "$RUN_DIR/pre.json" max_history_id)"
+capture_state "$RUN_DIR/post.json" "$PRE_MAX_ID" || fail post-state
+python3 - "$RUN_DIR/pre.json" "$RUN_DIR/post.json" "$RUN_DIR/driver.json" <<'PY' || fail final-state
+import json,sys
+pre,post,drv=[json.load(open(p)) for p in sys.argv[1:4]]
+if drv.get('startCount') != 1: raise SystemExit(1)
+if post['sync_history_total_count'] - pre['sync_history_total_count'] != 1: raise SystemExit(1)
+if post['max_history_id'] <= pre['max_history_id']: raise SystemExit(1)
+if not post['latest_history_completed'] or not post['latest_history_end_time_valid']: raise SystemExit(1)
+if post['metrics_total_count'] - pre['metrics_total_count'] != 1: raise SystemExit(1)
+if post['max_metrics_id'] <= pre['max_metrics_id']: raise SystemExit(1)
+if post['terminal_history_digest'] != pre['terminal_history_digest']: raise SystemExit(1)
+for k in ['active_history_count','option_active_marker_count','transient_active_marker_count','stale_recovery_marker_count','heartbeat_worker_evidence_count','blocked_sync_cron_count','duplicate_project_uid_count','duplicate_token_uid_count','duplicate_token_detail_uid_count','invalid_relationship_count','impossible_counter_count']:
+    if post.get(k) != 0: raise SystemExit(1)
+if not all(post['required_tables_present'].values()): raise SystemExit(1)
+if not post['cron_inspectable'] or not post['light_profile_guard'] or not post['api_key_present']: raise SystemExit(1)
+if post['sync_data_classification'] not in ('absent', 'terminal'): raise SystemExit(1)
+if not post['last_sync_time_matches_latest_metrics']: raise SystemExit(1)
+for k in ['project_count','token_count','token_detail_count']:
+    if post[k] < pre[k]: raise SystemExit(1)
+PY
+if [[ "${NMKR_PHASE16A_PUBLIC_REGRESSION:-false}" != true ]]; then
+  NMKR_DB_STATE_ALLOW_ACTIVE_SYNC=false bash "$REPO_ROOT/scripts/nmkr-wpcli-db-state.sh" >/dev/null 2>>"$DIAGNOSTIC_FILE" || fail db-state
+fi
+validate_target_integrity "$CURRENT_ORIGIN_DIGEST"
+summary PASS


### PR DESCRIPTION
### Motivation

- GitHub Actions Phase 4 CI failed because the regression harness used the `rg` (ripgrep) binary which is not available on the runner, so the public-safe checks aborted early.  

### Description

- Replaced every executable `rg` invocation in `scripts/nmkr-real-sync-phase16a-regression.sh` with portable GNU `grep` equivalents.  
- Preserved original success/failure semantics and pipeline behavior under `set -Eeuo pipefail` by mapping `rg -q` to `grep -Eq --`, `rg -n` to `grep -En --`, and using `grep -E --` for pattern-only pipelines.  
- Change is narrowly focused on search-command portability; no controller behavior or assertion logic was removed or weakened.  
- Changed file: `scripts/nmkr-real-sync-phase16a-regression.sh` (search-command portability only).  

### Testing

- `bash -n scripts/nmkr-real-sync-phase16a-regression.sh` passed with no syntax errors.  
- Verified no remaining executable `rg` occurrences via `grep -En` check against the script.  
- `npm run test:real-sync:phase16a:regression` completed and all regression assertions passed.  
- `npm run test:public` and `npm run test:php74` completed successfully and reported no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57b79682e08333970fa2a54c01f649)