### PR TITLE
docs: consolidate Playwright testing guidance

### DIFF
--- a/docs/testing-phase-1.md
+++ b/docs/testing-phase-1.md
@@ -1,98 +1,48 @@
-# Phase 1 Automated Testing Proof of Concept
+# Phase 1 automated testing proof of concept (historical)
 
-Phase 1 provides a small, VM-local smoke-test workflow for the NMKR Connect WordPress plugin.
-It is intended to prove that Playwright and WP-CLI can quickly verify a prepared WordPress test site without mutating plugin runtime behavior.
+> **Historical implementation record.** Phase 1 established the original VM-local Playwright smoke test and WP-CLI checks. Deeper Playwright coverage now exists, and [`testing-playwright.md`](testing-playwright.md) is the authoritative operational guide.
 
-## Purpose
+## Original purpose
 
-Use these checks before deeper automated coverage exists.
-They confirm that a known local WordPress install can load the plugin admin screens and expose the expected safe controls.
-They also create a Playwright HTML report that can be shared without screenshots, traces, videos, logs, or secrets.
+Phase 1 proved that Playwright and WP-CLI could quickly verify a prepared WordPress test site without changing plugin runtime behavior. Its browser spec confirms that an administrator can authenticate, that the plugin is active, that the dashboard and settings pages load, and that basic safe controls are present. Its WP-CLI checks confirm WordPress/plugin availability, required tables, selected database-state relationships, and the absence of fresh matching errors in a bounded log tail.
 
-## What Phase 1 Checks
+At the time, this was intentionally a small smoke-test workflow. The repository now also contains focused settings, dashboard, projects, shortcodes, analytics, synchronization-state, synchronization-resilience, synchronization-final-state, and run-authority specs. Those later specs do not turn the suite into comprehensive product coverage.
 
-- WordPress admin login works with credentials supplied through environment variables.
-- The WordPress admin area loads after login.
-- The NMKR Connect plugin appears active in the plugin list.
-- The NMKR dashboard page loads.
-- The NMKR settings page loads.
-- The API key field exists and is non-empty when configured, without printing the value.
-- A sync profile control exists.
-- WP-CLI can confirm that WordPress is installed.
-- WP-CLI can confirm that the plugin is active.
-- WP-CLI can confirm that required NMKR tables exist.
-- WP-CLI can compare the latest sync timestamp option with metrics when metrics exist.
-- WP-CLI can scan recent debug log tails for fresh PHP or plugin errors without dumping full logs.
+## Phase 1 boundaries that still apply
 
-## What Phase 1 Does Not Check
+- The smoke spec does not perform a real NMKR synchronization or require live NMKR API calls.
+- It does not verify Cardano transaction data, mutate WordPress options or database tables, or clear/rotate logs.
+- Screenshots, traces, and videos are disabled by default.
+- These checks do not replace unit, integration, server-side, or broader end-to-end coverage.
+- Credentials, URLs, API keys, environment files, logs, reports, and browser artifacts from a private environment must not be committed or published.
 
-- It does not perform a real NMKR API sync by default.
-- It does not require live NMKR API calls.
-- It does not verify Cardano transaction data.
-- It does not mutate WordPress options.
-- It does not mutate database tables.
-- It does not clear or rotate logs.
-- It does not collect screenshots, videos, or traces by default.
-- It does not replace dedicated unit, integration, or end-to-end test coverage.
+## Current setup and execution
 
-## Public-Safety Notes
-
-This repository is public and open source.
-Do not commit real credentials, private URLs, API keys, backup metadata, screenshots, traces, videos, or private server logs.
-Keep secrets in the VM-local `.env.tests` file only.
-Use blank placeholders in examples and redact operational output before sharing it.
-
-## Install Dependencies
-
-From the repository root, install Node dependencies and the Chromium browser used by Phase 1:
+Use the lockfile for repeatable dependency installation:
 
 ```bash
-npm install
+npm ci
 npx playwright install chromium
 ```
 
-## Configure VM-Local Environment
-
-Copy the example file and edit the VM-local copy:
+For a private VM, copy `.env.tests.example` to the ignored `.env.tests` file and supply private values locally. Keep `RUN_REAL_SYNC=false` and `PW_SAVE_ARTIFACTS=false` for ordinary execution.
 
 ```bash
 cp .env.tests.example .env.tests
 $EDITOR .env.tests
 ```
 
-Set the following values for your local WordPress VM only:
-
-```bash
-WP_BASE_URL=https://example.test
-WP_ADMIN_USER=
-WP_ADMIN_PASSWORD=
-WP_PATH=/path/to/wordpress
-```
-
-Leave `RUN_REAL_SYNC=false` for Phase 1 unless you are intentionally testing real sync behavior in a private environment.
-Leave `PW_SAVE_ARTIFACTS=false` unless you need local debugging artifacts.
-Do not commit `.env.tests`.
-
-## Run the Playwright Smoke Test
-
-Run the Phase 1 browser smoke test:
+`npm run test:e2e` no longer means only the original Phase 1 smoke spec. It runs the **current default Playwright suite**, including authentication setup/cleanup and all implemented specs:
 
 ```bash
 npm run test:e2e
 ```
 
-Open the HTML report after a run:
+For current targeted commands, environment handling, and troubleshooting, use the [Playwright testing guide](testing-playwright.md).
 
-```bash
-npm run test:e2e:report
-```
+## Historical WP-CLI component
 
-The report is written to `playwright-report/` and test output is written to `test-results/`.
-Both directories are ignored so local artifacts do not get committed.
-
-## Run the WP-CLI Smoke Script
-
-Run the read-only WP-CLI checks against the same VM-local WordPress install:
+The read-only WP-CLI smoke script remains available against a prepared private WordPress test environment:
 
 ```bash
 WP_PATH=/path/to/wordpress \
@@ -103,23 +53,10 @@ NMKR_DEBUG_LOG_LOOKBACK_MINUTES=30 \
 bash scripts/nmkr-wpcli-smoke.sh
 ```
 
-The script prints status messages only.
-It does not print API keys or full logs.
-It fails fast if required checks are not satisfied.
+Use only generic placeholders in shared material. Review any failure details locally and redact sensitive context rather than sharing raw logs.
 
-## HTML Report Usage
+## Reports and troubleshooting
 
-Use the HTML report as a quick demo artifact for Phase 1.
-Before sharing any report, verify that it does not contain secrets or private operational details.
-By default screenshots, videos, and traces are disabled.
-If you enable artifacts locally with `PW_SAVE_ARTIFACTS=true`, do not commit or publish them.
+`npm run test:e2e:report` opens an already-generated HTML report. Although screenshots, traces, and videos are off by default, an HTML report from authenticated private-environment execution can still contain private URLs, test names, errors, and operational context. Treat it as private diagnostic output; do not assume it is safe to share or publish.
 
-## Troubleshooting
-
-- If Playwright cannot log in, verify `WP_BASE_URL`, `WP_ADMIN_USER`, and `WP_ADMIN_PASSWORD` in `.env.tests`.
-- If the plugin row is missing, confirm the plugin is installed and active in the VM.
-- If settings controls are missing, confirm the configured admin paths match the plugin pages in that WordPress install.
-- If WP-CLI cannot find WordPress, set `WP_PATH` to the WordPress document root.
-- If table checks fail, confirm that the plugin has been activated and initialized in the VM.
-- If debug-log checks fail, inspect the VM-local `debug.log` manually and redact details before sharing.
-- If you need screenshots, traces, or videos for local debugging, set `PW_SAVE_ARTIFACTS=true` and keep artifacts private.
+Begin troubleshooting with non-mutating checks: discover tests with `npm run test:e2e -- --list --reporter=list`, verify required variable names without printing their values, confirm the intended private target, and then run the smallest relevant targeted spec. If WP-CLI fails, confirm `WP_PATH`, plugin activation, and initialization locally without dumping database contents or full logs.

--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -1,157 +1,86 @@
-# Phase 2 VM test runner
+# Phase 2 private VM test runner
 
-Phase 2 adds a VM-local orchestration runner around the existing Phase 1 automated checks. It is intended for maintainers who validate a deployed WordPress NMKR Connect installation from a private, user-owned checkout.
+Phase 2 orchestrates validation of a deployed NMKR Connect installation from a private, user-owned checkout. For Playwright-only guidance and the current coverage map, see [`testing-playwright.md`](testing-playwright.md).
 
-The runner does not change plugin runtime behavior. It coordinates deployment, dependency and browser setup, a WordPress readiness gate, Playwright admin smoke checks, WP-CLI smoke checks, and WP-CLI database-state validation, then writes detailed output to private local files while printing only a concise public-safe summary.
+The runner combines optional deployment, dependency/browser preparation, WordPress readiness, the complete Playwright suite, WP-CLI smoke checks, and WP-CLI database-state checks. It does not change the implementations of those checks, and real NMKR synchronization remains outside this workflow.
 
-## Public-safety rules
+## Private inputs and external state
 
-Do not commit or paste secrets, API keys, WordPress admin passwords, Basic Auth credentials, private token URLs, private screenshots, traces, videos, `.env.tests`, private environment files, private VM output, or sensitive logs.
-
-The Phase 2 runner captures command output in a private run directory and never tails logs automatically. If a step fails, it prints only the failed step, the private local log path, and one diagnostic command for local use.
-
-## Recommended VM layout
-
-Run Phase 2 from a user-owned checkout, for example:
+Provide `WP_BASE_URL`, `WP_ADMIN_USER`, `WP_ADMIN_PASSWORD`, and `WP_PATH` through an owner-private environment file outside both the repository and WordPress root. Use `NMKR_PHASE2_ENV_FILE` to select it explicitly:
 
 ```bash
-~/src/WordPress-NMKR-Connect
+NMKR_PHASE2_ENV_FILE=/path/to/private/phase2.env npm run test:phase2
 ```
 
-Do not run dependency installation from the webserver-owned deployed plugin directory. The runner may need to run `npm ci`; if dependencies are needed and the checkout is not writable, it fails with guidance to use a user-owned checkout.
+Never commit or print the populated file. The checkout-local `.env.tests` fallback is supported, but an external file is preferred because it establishes a clearer private-input boundary.
 
-## Private env file setup
+Private output defaults to `${XDG_STATE_HOME}/nmkr-connect`, or `${HOME}/.local/state/nmkr-connect` when `XDG_STATE_HOME` is unset. `NMKR_PHASE2_LOG_DIR` may select another owner-private external state directory. The runner rejects a private root located under the repository, the WordPress root, or the repository's Playwright output trees; do not configure private run output anywhere beneath the checkout or deployed web root.
 
-Recommended Linux/private-VM layout: create `$HOME/.config/nmkr-connect` with owner-only permissions, store `phase2.env` there owned by the invoking user with mode `600`, and make the ignored checkout `.env.tests` a symlink to it. Verify the link resolves to the intended external file. No populated env file belongs in Git or in the deployed plugin directory. Systems without safe symlink support should use `NMKR_PHASE2_ENV_FILE`; it remains fully supported.
+The root and its `runs` directory must be real, owner-controlled directories rather than symlinks, and must not be group- or world-writable. The runner creates them with restrictive permissions where needed. Each invocation creates:
 
-Use placeholders like this and replace values only on your VM:
-
-```bash
-WP_BASE_URL=https://example.test
-WP_ADMIN_USER=wordpress-admin-user
-WP_ADMIN_PASSWORD=wordpress-admin-password
-WP_PATH=/path/to/wordpress
-
-NMKR_PHASE2_SKIP_DEPLOY=true
-NMKR_PHASE2_INSTALL_DEPS=false
-NMKR_PHASE2_INSTALL_BROWSER=false
+```text
+<external-state-root>/
+└── runs/
+    └── <YYYYmmddTHHMMSSZ>-<pid>/
+        ├── preflight.log
+        ├── step-specific private logs
+        ├── playwright-report/
+        └── test-results/
 ```
 
-Never commit the populated file.
+The run directory also serves as the private parent for a fresh wrapper-owned authentication-state directory. File presence varies with the stages executed and their outcome.
 
-## Required variables
+## General profile
 
-After loading the private env file, these variables must be non-empty:
+The default profile accepts these preparation controls:
 
-- `WP_BASE_URL`
-- `WP_ADMIN_USER`
-- `WP_ADMIN_PASSWORD`
-- `WP_PATH`
+- `NMKR_PHASE2_SKIP_DEPLOY=false`; otherwise `NMKR_DEPLOY_COMMAND` is required and executed without printing the command value.
+- `NMKR_PHASE2_INSTALL_DEPS=auto`, which runs `npm ci` only when `node_modules` is absent. `true` always installs and `false` skips installation.
+- `NMKR_PHASE2_INSTALL_BROWSER=false`; set it to `true` to run `npx playwright install chromium`.
+- `RUN_REAL_SYNC=false` and `PW_SAVE_ARTIFACTS=false`.
+- Readiness defaults of 120 seconds overall, 5 seconds between attempts, and 10 seconds per HTTP request; the corresponding `NMKR_PHASE2_WP_READY_*` values must be positive integers.
 
-## Optional variables
+Run dependency installation from a writable, user-owned checkout, not the deployed webserver-owned plugin directory. The runner requires its command-line prerequisites, and `WP_CLI_BIN` must resolve when specified as a simple command name.
 
-The runner supplies safe defaults when these are unset:
+Stages run in this order:
 
-- `RUN_REAL_SYNC=false`
-- `PW_SAVE_ARTIFACTS=false`
-- `WP_CLI_BIN=wp`
-- `NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php`
-- `NMKR_DEBUG_LOG_RELATIVE_PATH=wp-content/debug.log`
-- `NMKR_DEBUG_LOG_LOOKBACK_MINUTES=30`
-- `NMKR_PHASE2_INSTALL_DEPS=auto`
-- `NMKR_PHASE2_INSTALL_BROWSER=false`
-- `NMKR_PHASE2_WP_READY_TIMEOUT_SECONDS=120`
-- `NMKR_PHASE2_WP_READY_INTERVAL_SECONDS=5`
-- `NMKR_PHASE2_WP_READY_HTTP_TIMEOUT_SECONDS=10`
-- `NMKR_PHASE2_LOG_DIR=$XDG_STATE_HOME/nmkr-connect` (or `$HOME/.local/state/nmkr-connect`; it must be outside the checkout and WordPress root)
+1. Deployment, unless skipped.
+2. Dependency installation, when selected or needed.
+3. Chromium installation, when selected.
+4. WordPress readiness.
+5. The complete Playwright suite.
+6. WP-CLI smoke checks.
+7. WP-CLI database-state checks.
 
-`NMKR_PHASE2_INSTALL_DEPS` accepts `auto`, `true`, or `false`. `auto` runs `npm ci` only when `node_modules` is missing.
+The readiness gate checks `WP_PATH/.maintenance` without removing it and requests the private site's login page until it receives an HTTP 200 response containing the login-form marker and no recognized maintenance response. It does not retry the whole Playwright suite.
 
-`NMKR_PHASE2_INSTALL_BROWSER=true` runs `npx playwright install chromium`; otherwise browser installation is skipped.
+## `existing-readonly` profile
 
-The WordPress readiness timeout, retry interval, and per-request HTTP timeout can be tuned with the `NMKR_PHASE2_WP_READY_*` variables. They must be positive integers.
-
-## Running Phase 2
-
-From the user-owned checkout:
+Use `existing-readonly` to validate an already deployed exact commit without runner-driven deployment or installation:
 
 ```bash
-NMKR_PHASE2_ENV_FILE=/path/to/private-phase2.env npm run test:phase2
-```
-
-The npm script runs:
-
-```bash
-bash scripts/nmkr-phase2-test-runner.sh
-```
-
-### Existing deployed commit (readonly)
-
-`existing-readonly` is for validating an already deployed exact commit. The caller-selected profile is captured before the private env file is sourced; a conflicting file profile is rejected. After sourcing, readonly authority overrides mutable values: deployment, dependency/browser installation, real synchronization, and browser artifacts are disabled, and any deploy command is ignored. A full SHA is deliberately required from the maintainer and is not derived by the command.
-
-```bash
-NMKR_PHASE2_ENV_FILE="$HOME/.config/nmkr-connect/phase2.env" \
-NMKR_PHASE2_EXPECTED_SOURCE_SHA=<40-character-commit-sha> \
+NMKR_PHASE2_ENV_FILE=/path/to/private/phase2.env \
+NMKR_PHASE2_EXPECTED_SOURCE_SHA=<40-character-reviewed-sha> \
 npm run test:phase2:existing-readonly
 ```
 
-Use the same placeholder form for exact-main, pre-merge, and post-merge checks after supplying the reviewed 40-character SHA. Stop before live validation if the profile, booleans, source/deployed worktree integrity, Node dependencies, or Chromium prerequisite fails.
+The profile requires a maintainer-supplied full 40-character SHA. It verifies that checkout `HEAD` equals that exact SHA and that the source worktree is clean. It forces deployment, dependency installation, Chromium installation, real synchronization, and artifact retention off, and discards any deploy command. A caller-selected profile cannot be replaced by a conflicting value from the environment file.
 
-The runner performs these validation stages in order:
+Because installation is prohibited in this profile, the Node dependencies and a launchable Playwright Chromium must already be present; preflight checks both before browser execution. Prepare them before switching to the exact clean commit if necessary.
 
-1. Deployment, unless `NMKR_PHASE2_SKIP_DEPLOY=true`.
-2. Dependency installation, when enabled or needed.
-3. Browser installation, when enabled.
-4. WordPress readiness gate.
-5. Playwright admin smoke checks.
-6. WP-CLI smoke checks.
-7. WP-CLI database-state validation via `scripts/nmkr-wpcli-db-state.sh`.
+Source integrity is reported as `PASS` only after the exact-SHA and clean-worktree checks pass. If `NMKR_DEPLOYED_PLUGIN_PATH` is provided, the runner also requires that path to be a Git worktree at the same exact SHA with a clean worktree and reports deployed integrity as `PASS`. If no deployed path is provided, deployed integrity remains `SKIPPED`; the runner does not infer equivalence.
 
-## WordPress readiness gate
+`existing-readonly` prevents runner-driven deployment and package/browser installation. The Playwright suite still authenticates and executes browser behavior, and the orchestration still runs readiness and WP-CLI/database-state checks, so use only a private test environment prepared for those checks.
 
-Before Playwright starts, the runner checks that WordPress is ready to serve the admin login page. The `wordpress-ready` gate runs after deployment, dependency setup, and optional browser installation, and before the Playwright suite.
+## Authentication and output handling
 
-The readiness gate detects temporary WordPress maintenance mode by checking for `WP_PATH/.maintenance` and known maintenance-page text from `wp-login.php`. It also verifies that `wp-login.php` returns HTTP 200 and contains the login form marker. If WordPress is still in maintenance mode or not ready, the runner waits and retries until the configured timeout, then fails the `wordpress-ready` step instead of reporting a misleading Playwright regression.
+Phase 2 redirects `PLAYWRIGHT_HTML_REPORT` and `PLAYWRIGHT_TEST_OUTPUT_DIR` into the private run directory and supplies that directory as `NMKR_AUTH_STATE_ROOT`. The Playwright wrapper creates a unique owner-only child directory and normally removes it after the run. The authentication cleanup project removes the state file as well. The runner records authentication-state cleanup as `MANAGED_BY_WRAPPER`; `NMKR_RETAIN_AUTH_STATE=true` changes the summary to `RETAINED` and is appropriate only for exceptional private diagnostics.
 
-The gate writes detailed diagnostics to `wordpress-ready.log` in the private run directory. Public console output remains concise and safe: it does not print private URLs, response bodies, cookies, nonces, secrets, screenshots, traces, videos, or private logs.
+Treat authentication state, HTML reports, screenshots, traces, videos, logs, response material, nonces, credentials, URLs, and environment files as private. Screenshots, traces, and videos remain off unless explicitly enabled outside the readonly profile. Do not upload run directories or paste their contents into public issues or pull requests.
 
-The readiness gate only detects and waits for `.maintenance`; it does not remove `.maintenance`. It also does not retry the full Playwright suite. Bad credentials and real UI regressions still fail in Playwright.
+## Success summary
 
-## Deployment wiring
-
-When `NMKR_PHASE2_SKIP_DEPLOY` is not `true`, the runner requires `NMKR_DEPLOY_COMMAND` and runs it with:
-
-```bash
-bash -lc "$NMKR_DEPLOY_COMMAND"
-```
-
-The command value is never printed. Deploy output is written only to the private deploy log.
-
-To skip deployment:
-
-```bash
-NMKR_PHASE2_SKIP_DEPLOY=true npm run test:phase2
-```
-
-## Private logs and reports
-
-By default, private logs and reports are stored under:
-
-```text
-an owner-private external state directory: `runs/<YYYYmmddTHHMMSSZ>-<pid>/`
-```
-
-The runner sets Playwright paths inside the private run directory:
-
-- `PLAYWRIGHT_HTML_REPORT=<run-dir>/playwright-report`
-- `PLAYWRIGHT_TEST_OUTPUT_DIR=<run-dir>/test-results`
-- `NMKR_AUTH_STATE_ROOT=<private-run-dir>` (the Playwright wrapper creates a fresh private child directory and its `auth-state.json` itself)
-
-Authentication state is sensitive session material. It is mode-restricted where supported, is not printed, reported, committed, or uploaded, and is removed after each run (including ordinary interruption). The Playwright wrapper creates and owns a fresh private child directory for every invocation; callers can provide only its private parent through `NMKR_AUTH_STATE_ROOT`, not an exact state file. Direct Playwright runs use a wrapper-created temporary root. `NMKR_RETAIN_AUTH_STATE=true` is private-diagnostics-only and should be avoided.
-
-## Expected success summary shape
-
-A successful run prints a concise summary like:
+A successful general run prints these current fields (individual status values depend on the selected options):
 
 ```text
 Phase 2 summary
@@ -162,27 +91,17 @@ Phase 2 summary
   playwright: PASS
   wpcli: PASS
   db-state: PASS
+  profile: general
+  source-integrity: SKIPPED
+  deployed-integrity: SKIPPED
+  readonly-policy: SKIPPED
+  authentication-state-cleanup: MANAGED_BY_WRAPPER
   result: PASS
   commit: abc1234
-  private run dir: /path/to/checkout/.phase2-private/runs/20260708T120000Z-12345
 ```
 
-## Failure handling
+The console does **not** print the private run-directory path. On failure it adds `failed step` and `private diagnostics: available locally`; inspect the appropriate step log directly inside the external state directory. Begin with non-mutating checks and do not copy private diagnostics into a public channel.
 
-On failure, the runner exits non-zero and prints the failed step, the private log path, and one local diagnostic command, for example:
+## Safety boundary
 
-```text
-  failed step: playwright
-  private log: /path/to/private/playwright.log
-  next diagnostic command: less /path/to/private/playwright.log
-```
-
-Review the private log locally. Do not paste sensitive log contents into public issues or pull requests.
-
-## Real NMKR sync note
-
-Real NMKR sync remains disabled by default with `RUN_REAL_SYNC=false`. The current Playwright smoke test does not implement real NMKR sync even if `RUN_REAL_SYNC=true`.
-
-## Do not commit private artifacts
-
-Do not commit `.env.tests`, private env files, `.phase2-private/`, Playwright reports, traces, screenshots, videos, logs, or VM output.
+Keep `RUN_REAL_SYNC=false`. Neither the Playwright route simulations nor Phase 2 orchestration executes a real NMKR synchronization. Do not commit `.env.tests`, populated environment files, private state directories, reports, test output, authentication state, screenshots, traces, videos, or logs.

--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -34,7 +34,7 @@ The run directory also serves as the private parent for a fresh wrapper-owned au
 
 The default profile accepts these preparation controls:
 
-- `NMKR_PHASE2_SKIP_DEPLOY=false`; otherwise `NMKR_DEPLOY_COMMAND` is required and executed without printing the command value.
+- `NMKR_PHASE2_SKIP_DEPLOY=false` by default. When it is `false`, `NMKR_DEPLOY_COMMAND` is required and executed without printing the command value; set it to `true` to skip deployment.
 - `NMKR_PHASE2_INSTALL_DEPS=auto`, which runs `npm ci` only when `node_modules` is absent. `true` always installs and `false` skips installation.
 - `NMKR_PHASE2_INSTALL_BROWSER=false`; set it to `true` to run `npx playwright install chromium`.
 - `RUN_REAL_SYNC=false` and `PW_SAVE_ARTIFACTS=false`.

--- a/docs/testing-phase-3.md
+++ b/docs/testing-phase-3.md
@@ -1,6 +1,10 @@
-# Phase 3 Playwright regression coverage
+# Phase 3 Playwright regression coverage (historical implementation record)
 
-Phase 3 adds safe Playwright regression checks for the NMKR Connect WordPress admin pages. These tests verify page structure and important controls without mutating WordPress options, starting synchronization, clearing logs, or exposing private configuration.
+> **Current guidance:** See [`testing-playwright.md`](testing-playwright.md) for setup, the complete command list, current coverage, authentication handling, and troubleshooting. This document preserves the detailed Phase 3 implementation and safety boundaries.
+
+Phase 3 introduced the settings, dashboard-structure, projects, shortcodes, and analytics page regressions. These specs verify page structure and important controls without mutating WordPress options, starting synchronization, clearing logs, or exposing private configuration.
+
+Later phases added the synchronization-state, synchronization-resilience, synchronization-final-state, and run-authority Playwright specs now present in the default suite. Their current scope and targeted npm commands are summarized in the [Playwright testing guide](testing-playwright.md); they are not Phase 3 coverage.
 
 ## Settings-page regression
 
@@ -195,21 +199,17 @@ npm run test:e2e:analytics -- --list
 npm run test:e2e:analytics
 ```
 
-Direct targeted Playwright scripts do not automatically load `NMKR_PHASE2_ENV_FILE`. For direct targeted runs on the VM, source the private environment first, then run the targeted script:
+Direct targeted Playwright scripts load the ignored `.env.tests` file by default. When `NMKR_PHASE2_ENV_FILE` is explicitly set, Playwright loads that file instead and does not fall back to `.env.tests`. For a targeted private-VM run, select the external environment file without printing or sourcing its contents:
 
 ```bash
-set -a
-source "$HOME/.config/nmkr-connect/phase2.env"
-set +a
-
-npm run test:e2e:analytics
+NMKR_PHASE2_ENV_FILE=/path/to/private/phase2.env npm run test:e2e:analytics
 ```
 
 Because the Phase 2 runner executes `npm run test:e2e`, the Phase 3 regressions are automatically included in Phase 2 VM validation. Full Phase 2 validation should continue to use:
 
 ```bash
-NMKR_PHASE2_ENV_FILE="$HOME/.config/nmkr-connect/phase2.env" \
-NMKR_PHASE2_LOG_DIR="$HOME/.local/state/nmkr-connect-phase2" \
+NMKR_PHASE2_ENV_FILE=/path/to/private/phase2.env \
+NMKR_PHASE2_LOG_DIR=/path/to/private/state \
 npm run test:phase2
 ```
 

--- a/docs/testing-playwright.md
+++ b/docs/testing-playwright.md
@@ -96,7 +96,7 @@ Authentication state is sensitive session material. Browser execution must stay 
 ## Troubleshooting: start with non-mutating checks
 
 1. Confirm the checkout and dependencies without contacting WordPress: `git status --short`, `npm ci`, then `npm run test:e2e -- --list --reporter=list`.
-2. Confirm Chromium is installed with a discovery command first; install it with `npx playwright install chromium` if the browser executable is absent.
+2. Use discovery to validate the Playwright configuration and test discovery; it does not launch Chromium. If private browser execution reports a missing browser, run `npx playwright install chromium`. The Phase 2 `existing-readonly` preflight separately performs an explicit Chromium launch probe.
 3. Check that required variable names are populated without printing their values. Confirm the target is the intended private WordPress test environment before browser execution.
 4. Verify the configured WordPress and NMKR admin paths by read-only navigation. Do not begin by saving settings, clearing logs, selecting customer data, or starting synchronization.
 5. Run one targeted Playwright spec to isolate a UI failure. Keep `PW_SAVE_ARTIFACTS=false` initially.

--- a/docs/testing-playwright.md
+++ b/docs/testing-playwright.md
@@ -1,0 +1,104 @@
+# Playwright testing guide
+
+This is the authoritative operational overview of the repository's Playwright suite. The numbered phase documents remain implementation records and contain the detailed safety rationale for the coverage introduced at each stage.
+
+## Purpose and architecture
+
+The suite checks the NMKR Connect WordPress admin UI in Chromium. It is a focused regression suite, not comprehensive product coverage: it does not exercise a real NMKR synchronization, frontend shortcode rendering, every project/token state, or every WordPress and license configuration.
+
+There are three distinct ways maintainers encounter these checks:
+
+1. **Public-safe discovery**: public CI installs dependencies and runs `npm run test:public`. Its Playwright portion invokes the suite with `--list`; Playwright discovers configuration, projects, specifications, and tests, but does not launch a browser, authenticate, or contact WordPress.
+2. **Playwright-only execution**: `npm run test:e2e` (or a targeted script below) launches Chromium against a prepared **private WordPress test environment**. This authenticates and executes browser assertions, but it does not run the Phase 2 readiness or WP-CLI checks.
+3. **Phase 2 orchestration**: `npm run test:phase2` runs deployment when configured, dependency/browser preparation, the WordPress readiness gate, the complete Playwright suite, WP-CLI smoke checks, and database-state checks. This is private-environment orchestration, not merely a Playwright command.
+
+See [Phase 1](testing-phase-1.md), [Phase 2](testing-phase-2.md), and [Phase 3](testing-phase-3.md) for historical and detailed implementation notes. [Phase 4](testing-phase-4.md) records the public CI boundary.
+
+## Setup
+
+From a user-owned checkout, install the locked Node dependencies and Chromium:
+
+```bash
+npm ci
+npx playwright install chromium
+```
+
+For private Playwright-only work, copy `.env.tests.example` to the ignored `.env.tests` file and supply environment-specific values there, or export the variables without writing them to the checkout:
+
+```bash
+cp .env.tests.example .env.tests
+$EDITOR .env.tests
+```
+
+The required browser-execution values are `WP_BASE_URL`, `WP_ADMIN_USER`, and `WP_ADMIN_PASSWORD`. Phase 2 additionally requires `WP_PATH`. Keep `RUN_REAL_SYNC=false` and `PW_SAVE_ARTIFACTS=false` for ordinary runs. Optional page-path variables in the example file allow a private environment to override repository defaults.
+
+An explicit `NMKR_PHASE2_ENV_FILE` is loaded by the Playwright configuration when present. Use it for Phase 2 as documented in [the Phase 2 guide](testing-phase-2.md); do not place a populated environment file in the repository or WordPress root.
+
+## Current commands
+
+The following are the exact Playwright scripts exposed by `package.json`:
+
+| Command | Scope |
+| --- | --- |
+| `npm run test:e2e` | Current default suite: every implemented Playwright spec, plus authentication setup and cleanup projects. |
+| `npm run test:e2e:settings` | `nmkr-settings.regression.spec.ts` |
+| `npm run test:e2e:dashboard` | `nmkr-dashboard.regression.spec.ts` |
+| `npm run test:e2e:projects` | `nmkr-projects.regression.spec.ts` |
+| `npm run test:e2e:shortcodes` | `nmkr-shortcodes.regression.spec.ts` |
+| `npm run test:e2e:analytics` | `nmkr-analytics.regression.spec.ts` |
+| `npm run test:e2e:sync-state` | `nmkr-sync-state.regression.spec.ts` |
+| `npm run test:e2e:sync-resilience` | `nmkr-sync-resilience.regression.spec.ts` |
+| `npm run test:e2e:sync-final-state` | `nmkr-sync-final-state.regression.spec.ts` |
+| `npm run test:e2e:sync-run-authority` | `nmkr-sync-run-authority.regression.spec.ts` |
+| `npm run test:e2e:report` | Open an already-generated local HTML report; it does not run tests. |
+
+Append Playwright CLI options after `--`. For example, public-safe discovery of the default or a targeted spec is:
+
+```bash
+npm run test:e2e -- --list --reporter=list
+npm run test:e2e:settings -- --list --reporter=list
+```
+
+These commands only discover tests. Removing `--list` performs browser execution and therefore requires the private WordPress test environment.
+
+## Implemented coverage
+
+| Area | Specification | What it currently checks | Interaction model |
+| --- | --- | --- | --- |
+| Admin smoke | `nmkr-admin.smoke.spec.ts` | Login, active plugin row, dashboard/settings navigation, and basic safe controls. | Read-only navigation and assertions. |
+| Settings | `nmkr-settings.regression.spec.ts` | Settings form sections, control types, profile options, and save/reset control presence. | Structural/read-only; it does not submit settings. |
+| Dashboard structure | `nmkr-dashboard.regression.spec.ts` | Dashboard panels, controls, nonces by presence/type, progress UI structure, statistics structure, and optional log-panel structure. | Structural/read-only with locally fulfilled page-load API-status AJAX and guards for unexpected actions. |
+| Projects | `nmkr-projects.regression.spec.ts` | Default no-project-selected selector state and surrounding page structure. | Structural/read-only with locally fulfilled guards for unexpected actions. |
+| Shortcodes | `nmkr-shortcodes.regression.spec.ts` | Shortcode reference page structure and implemented shortcode headings. | Structural/read-only with locally fulfilled guards for unexpected actions. |
+| Analytics | `nmkr-analytics.regression.spec.ts` | Analytics shell and runtime control/container presence when that UI is enabled. | Structural/read-only; expected page-load analytics AJAX is locally fulfilled with empty data and guarded actions are intercepted. |
+| Synchronization state | `nmkr-sync-state.regression.spec.ts` | Dashboard transitions for controlled active and completed synchronization responses. | Locally stubbed AJAX lifecycle simulation. |
+| Synchronization resilience | `nmkr-sync-resilience.regression.spec.ts` | Dashboard polling UI reactions to controlled retriable and security-error responses. | Locally stubbed AJAX lifecycle simulation. |
+| Synchronization final states | `nmkr-sync-final-state.regression.spec.ts` | Dashboard UI reactions to controlled stopped, incomplete-marker, and payload-error final-state sequences. | Locally stubbed AJAX lifecycle simulation. |
+| Run authority | `nmkr-sync-run-authority.regression.spec.ts` | Run-scoped dashboard control authority across controlled response sequences. | Locally stubbed AJAX lifecycle simulation. |
+
+Locally fulfilled AJAX responses are browser-route fixtures. They exercise client-side behavior using controlled responses and prevent the intercepted request from reaching WordPress. They **do not execute a real NMKR synchronization**, prove the server-side synchronization path, or validate live NMKR API results. Some unrelated requests may be allowed to continue; the private test site remains a required boundary.
+
+## Authentication and private-environment boundary
+
+The default project order is `auth-setup`, `chromium`, then `auth-cleanup`. Setup signs in through the WordPress login form, validates the admin shell, and writes Playwright storage state to a wrapper-approved owner-only location. `scripts/nmkr-playwright.js` creates a fresh randomly named authentication directory for each invocation and normally removes it at process exit; the cleanup project also removes the state file. `NMKR_RETAIN_AUTH_STATE=true` is for exceptional private diagnostics only.
+
+Authentication state is sensitive session material. Browser execution must stay on a private WordPress test environment with test credentials and an approved target URL. Never use public CI for login or add credentials, private URLs, environment contents, cookies, nonces, or authentication state to command output, issues, pull requests, or committed files.
+
+## Output and data-safety rules
+
+- Screenshots, traces, and videos are off by default. `PW_SAVE_ARTIFACTS=true` retains failure artifacts; enable it only for necessary private diagnostics and review every file locally.
+- The HTML reporter is configured even when rich artifacts are off. Treat `playwright-report/` and any custom report directory as private run output, not as an ordinary shareable artifact.
+- Keep `test-results/`, HTML reports, screenshots, traces, videos, logs, and authentication state out of Git and public uploads. Phase 2 redirects these paths beneath its external private run directory.
+- Keep `.env.tests` and every populated environment file private and uncommitted. Do not print or copy their contents into diagnostics.
+- Use generic placeholders in documentation and shared commands. Do not publish credentials, test-site or service URLs, nonces, cookies, API keys, deployment commands, or filesystem details that identify a private environment.
+- Assertions and diagnostics must avoid exposing customer project/token data, analytics data, secrets, or raw log content. A passing structural assertion does not make its surrounding report safe to publish.
+
+## Troubleshooting: start with non-mutating checks
+
+1. Confirm the checkout and dependencies without contacting WordPress: `git status --short`, `npm ci`, then `npm run test:e2e -- --list --reporter=list`.
+2. Confirm Chromium is installed with a discovery command first; install it with `npx playwright install chromium` if the browser executable is absent.
+3. Check that required variable names are populated without printing their values. Confirm the target is the intended private WordPress test environment before browser execution.
+4. Verify the configured WordPress and NMKR admin paths by read-only navigation. Do not begin by saving settings, clearing logs, selecting customer data, or starting synchronization.
+5. Run one targeted Playwright spec to isolate a UI failure. Keep `PW_SAVE_ARTIFACTS=false` initially.
+6. For Phase 2 failures, use its summary to identify the failed stage and inspect the referenced private log locally. Do not paste the log or report into a public channel.
+7. Enable private failure artifacts only when the preceding non-mutating checks are insufficient; remove them after diagnosis.


### PR DESCRIPTION
### Motivation

- Centralize and modernize Playwright operational guidance into a single authoritative maintainer document while preserving the numbered phase records as historical implementation notes.
- Reduce confusion about public-safe discovery, private Playwright execution, and Phase 2 orchestration by making their differences explicit.
- Reconcile Phase documentation with the current runner, environment handling, and npm scripts without changing runtime code, tests, scripts, or behavior.

### Description

- Add `docs/testing-playwright.md` as the authoritative Playwright maintainer guide covering purpose, architecture, environment/setup, exact `npm` commands, implemented coverage matrix, locally stubbed AJAX boundaries, authentication/state handling, artifact and data-safety rules, and non-mutating troubleshooting.
- Update `docs/testing-phase-1.md` to mark Phase 1 as a historical implementation record, correct installation guidance to prefer `npm ci`, and clarify that `npm run test:e2e` now runs the current default suite rather than only the original smoke test.
- Update `docs/testing-phase-2.md` to reflect the current Phase 2 runner behavior and boundaries, including owner-private external state layout and private run-directory structure, `existing-readonly` profile exact-SHA and clean-worktree requirements, dependency/Chromium preconditions, WordPress readiness gate behavior, authentication-state cleanup, and the current concise summary fields.
- Update `docs/testing-phase-3.md` to preserve Phase 3 as an implementation record, add a prominent link to the new Playwright guide, clarify which coverage originated in Phase 3, and correct targeted environment-file examples.
- Apply the review follow-up correcting the deployment-skip condition and clarifying that Playwright `--list` discovery does not launch Chromium.

### Scope

- Base SHA: `6255a8de4d998bf25f49c64721c36dfe5f3f3646`
- Branch: `codex/update-playwright-documentation`
- Current reviewed head: `32c576e6b080531ecdb201e08fd8736864625828`
- Changed paths only:
  - `docs/testing-playwright.md`
  - `docs/testing-phase-1.md`
  - `docs/testing-phase-2.md`
  - `docs/testing-phase-3.md`
- No runtime code, tests, scripts, configuration, README content, or synchronization behavior changed.

### Validation

- `git diff --check`
- Markdown fence-pairing checks
- Repository-relative link and anchor validation
- `npm run test:public`
- Phase 4 CI public-safe checks passed on the current exact head
- No real NMKR synchronization or private Playwright artifacts were produced

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6af461f2a883338a7a4b7c5922075e)