### PR TITLE
Add validation policy and targeted-readonly Phase 2 profile with runner and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository validation
+
+- Use [`docs/validation-policy.md`](docs/validation-policy.md) as the canonical validation policy and classify risk before selecting checks.
+- Preserve exact-head trust and keep all committed and console output public-safe.
+- Never run a real NMKR synchronization by default, and never expose private inputs, environment details, authentication state, logs, or test artifacts.
+- Use the smallest profile required by the policy; do not repeat full private validation when a targeted profile is sufficient.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -202,18 +202,7 @@ Public CI does not authenticate to WordPress or execute Playwright browser behav
 
 ## Selecting checks by change type
 
-“Private required” means an exact-head, prepared private WordPress installation; higher-risk changes should use a deployment-equivalent VM or staging environment. Discovery is never counted as browser execution.
-
-| Change | Minimum public checks | Prepared private / exact-head validation |
-| --- | --- | --- |
-| Documentation only | `git diff --check`; link/table/path validation; `npm run test:public` when commands or architecture are affected | Usually no; exact-commit maintainer/reproducibility review when documentation is delivery evidence. |
-| PHP/helper | `npm run test:php74`; `npm run test:public`; focused synthetic regression | Required when runtime behavior changes. |
-| Settings or role/capability | Public umbrella plus relevant syntax/regression discovery | Required: targeted settings/access Playwright and authorization checks. |
-| Shortcode/front-end | Public umbrella plus targeted suite discovery | Required: relevant shortcode browser checks and representative escaped rendering. |
-| Analytics | Public umbrella plus analytics suite discovery and relevant synthetic checks | Required: configured-mode, consent, ingestion, authorization, and retention behavior as affected. |
-| Synchronization lifecycle | Public umbrella and all affected synchronization regressions/discovery | Required on the exact head; controlled real sync only when explicitly authorized and relevant. |
-| Database/schema/persistent state | Public umbrella plus schema/database regression scripts as applicable | Required: upgrade, rollback/cleanup, concurrency, and read-only state checks against exact head. |
-| Workflow/test infrastructure | Public umbrella and syntax/dry-run/discovery appropriate to the changed tooling | Prepared private run required if private orchestration or browser/runtime semantics change; otherwise validate the exact public workflow head. |
+Use the canonical [pull-request validation policy](validation-policy.md) to classify changes as docs/metadata, test/tooling-only, ordinary runtime, or high-risk and to select proportional pre-merge, review, and post-merge checks. The numbered testing guides remain authoritative for how their individual runners operate; they do not replace the policy.
 
 ## Contribution workflow
 

--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -79,13 +79,14 @@ Use this profile for an ordinary exact-head runtime change that needs one affect
 ```bash
 NMKR_PHASE2_ENV_FILE=/path/to/private/phase2.env \
 NMKR_PHASE2_EXPECTED_SOURCE_SHA=<40-character-reviewed-sha> \
+NMKR_DEPLOYED_PLUGIN_PATH=/path/to/deployed/plugin-worktree \
 NMKR_PHASE2_TARGET_SUITE=settings \
 npm run test:phase2:targeted-readonly
 ```
 
 The internal allowlist is `settings`, `dashboard`, `projects`, `shortcodes`, `analytics`, `ajax-security`, `sync-state`, `sync-run-authority`, `sync-resilience`, and `sync-final-state`. Unknown values fail closed; values are mapped to existing `test:e2e:*` package scripts and are never executed as caller-provided commands. Caller-selected profile and suite values cannot be replaced by the private environment file.
 
-This profile enforces the same exact source SHA, clean source, optional exact/clean deployed worktree, no-install, no-deploy, no-real-sync, and no-artifact rules as `existing-readonly`. It runs readiness, only the selected Playwright suite, and WP-CLI smoke; DB-state is intentionally skipped. Both readonly profiles perform one final source/deployed SHA and cleanliness recheck. Set `NMKR_PHASE2_RUNTIME_INTEGRITY=true` to run the existing Composer/vendor integrity gate once; this requires `NMKR_DEPLOYED_PLUGIN_PATH`.
+This profile requires `NMKR_DEPLOYED_PLUGIN_PATH` and enforces the same exact source SHA, clean source, exact/clean deployed worktree, no-install, no-deploy, no-real-sync, and no-artifact rules as `existing-readonly`. It runs readiness, only the selected Playwright suite, and WP-CLI smoke; DB-state is intentionally skipped. Both readonly profiles perform one final source/deployed SHA and cleanliness recheck. Set `NMKR_PHASE2_RUNTIME_INTEGRITY=true` to run the existing Composer/vendor integrity gate once.
 
 ## Authentication and output handling
 

--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -1,6 +1,6 @@
 # Phase 2 private VM test runner
 
-Phase 2 orchestrates validation of a deployed NMKR Connect installation from a private, user-owned checkout. For Playwright-only guidance and the current coverage map, see [`testing-playwright.md`](testing-playwright.md).
+The [validation policy](validation-policy.md) determines when to use full or targeted private validation. Phase 2 orchestrates validation of a deployed NMKR Connect installation from a private, user-owned checkout. For Playwright-only guidance and the current coverage map, see [`testing-playwright.md`](testing-playwright.md).
 
 The runner combines optional deployment, dependency/browser preparation, WordPress readiness, the complete Playwright suite, WP-CLI smoke checks, and WP-CLI database-state checks. It does not change the implementations of those checks, and real NMKR synchronization remains outside this workflow.
 
@@ -72,6 +72,21 @@ Source integrity is reported as `PASS` only after the exact-SHA and clean-worktr
 
 `existing-readonly` prevents runner-driven deployment and package/browser installation. The Playwright suite still authenticates and executes browser behavior, and the orchestration still runs readiness and WP-CLI/database-state checks, so use only a private test environment prepared for those checks.
 
+## `targeted-readonly` profile
+
+Use this profile for an ordinary exact-head runtime change that needs one affected browser suite, readiness, and WP-CLI smoke without full Playwright or DB-state validation:
+
+```bash
+NMKR_PHASE2_ENV_FILE=/path/to/private/phase2.env \
+NMKR_PHASE2_EXPECTED_SOURCE_SHA=<40-character-reviewed-sha> \
+NMKR_PHASE2_TARGET_SUITE=settings \
+npm run test:phase2:targeted-readonly
+```
+
+The internal allowlist is `settings`, `dashboard`, `projects`, `shortcodes`, `analytics`, `ajax-security`, `sync-state`, `sync-run-authority`, `sync-resilience`, and `sync-final-state`. Unknown values fail closed; values are mapped to existing `test:e2e:*` package scripts and are never executed as caller-provided commands. Caller-selected profile and suite values cannot be replaced by the private environment file.
+
+This profile enforces the same exact source SHA, clean source, optional exact/clean deployed worktree, no-install, no-deploy, no-real-sync, and no-artifact rules as `existing-readonly`. It runs readiness, only the selected Playwright suite, and WP-CLI smoke; DB-state is intentionally skipped. Both readonly profiles perform one final source/deployed SHA and cleanliness recheck. Set `NMKR_PHASE2_RUNTIME_INTEGRITY=true` to run the existing Composer/vendor integrity gate once; this requires `NMKR_DEPLOYED_PLUGIN_PATH`.
+
 ## Authentication and output handling
 
 Phase 2 redirects `PLAYWRIGHT_HTML_REPORT` and `PLAYWRIGHT_TEST_OUTPUT_DIR` into the private run directory and supplies that directory as `NMKR_AUTH_STATE_ROOT`. The Playwright wrapper creates a unique owner-only child directory and normally removes it after the run. The authentication cleanup project removes the state file as well. The runner records authentication-state cleanup as `MANAGED_BY_WRAPPER`; `NMKR_RETAIN_AUTH_STATE=true` changes the summary to `RETAINED` and is appropriate only for exceptional private diagnostics.
@@ -91,6 +106,9 @@ Phase 2 summary
   playwright: PASS
   wpcli: PASS
   db-state: PASS
+  targeted-suite: full
+  runtime-integrity: SKIPPED
+  final-integrity: SKIPPED
   profile: general
   source-integrity: SKIPPED
   deployed-integrity: SKIPPED

--- a/docs/testing-playwright.md
+++ b/docs/testing-playwright.md
@@ -1,6 +1,6 @@
 # Playwright testing guide
 
-This is the authoritative operational overview of the repository's Playwright suite. The numbered phase documents remain implementation records and contain the detailed safety rationale for the coverage introduced at each stage.
+The [validation policy](validation-policy.md) determines when to run targeted or full private coverage. This is the authoritative operational overview of the repository's Playwright suite. The numbered phase documents remain implementation records and contain the detailed safety rationale for the coverage introduced at each stage.
 
 ## Purpose and architecture
 

--- a/docs/validation-policy.md
+++ b/docs/validation-policy.md
@@ -21,10 +21,10 @@ The specialized `npm run test:ajax-security` runner remains the preferred one-co
 
 - `npm run test:phase2` preserves the general deploy-and-full-validation workflow.
 - `npm run test:phase2:existing-readonly` validates an existing exact deployment with full Playwright, WP-CLI smoke, and DB-state checks.
-- `NMKR_PHASE2_TARGET_SUITE=<allowlisted-suite> npm run test:phase2:targeted-readonly` validates an existing exact deployment with readiness, one targeted Playwright suite, and WP-CLI smoke; DB-state is intentionally skipped.
+- `NMKR_DEPLOYED_PLUGIN_PATH=/path/to/deployed/plugin-worktree NMKR_PHASE2_TARGET_SUITE=<allowlisted-suite> npm run test:phase2:targeted-readonly` validates an existing exact deployment with readiness, one targeted Playwright suite, and WP-CLI smoke; DB-state is intentionally skipped.
 - Set `NMKR_PHASE2_RUNTIME_INTEGRITY=true` only when the profile must verify Composer/runtime deployment integrity. A deployed plugin path is then mandatory, and the gate runs once.
 
-Readonly profiles require `NMKR_PHASE2_EXPECTED_SOURCE_SHA` as a full 40-character reviewed SHA, require a clean source worktree, and verify a supplied deployed plugin worktree at that same SHA. They repeat source/deployed SHA and cleanliness checks after successful validation.
+Readonly profiles require `NMKR_PHASE2_EXPECTED_SOURCE_SHA` as a full 40-character reviewed SHA and a clean source worktree. `targeted-readonly` also requires a deployed plugin worktree at that same SHA with a clean tracked state; `existing-readonly` continues to verify it when supplied. They repeat source/deployed SHA and cleanliness checks after successful validation.
 
 ## Blockers and investigation
 

--- a/docs/validation-policy.md
+++ b/docs/validation-policy.md
@@ -1,0 +1,63 @@
+# Pull-request validation policy
+
+## Purpose and safety boundary
+
+This is the canonical policy for selecting pre-merge review and validation and proportional post-merge checks. Classify the change before choosing commands; do not infer risk mechanically from diff size. When a change spans classes, use the highest applicable class.
+
+Public CI runs the public-safe `npm run test:public` umbrella. It must not receive WordPress credentials, private endpoints, deployment configuration, authentication state, or private artifacts. Private browser, WP-CLI, and deployment validation runs only in an approved prepared environment with owner-private inputs and output. Keep `RUN_REAL_SYNC=false` and `PW_SAVE_ARTIFACTS=false` for routine validation. A real NMKR synchronization is never part of these profiles and requires separate explicit authorization and the guarded real-sync procedure.
+
+## Risk classes
+
+| Class | Pre-merge minimum | Review | Post-merge |
+| --- | --- | --- | --- |
+| **Docs / metadata** | Public CI and validation of changed links, tables, paths, and commands. Run `git diff --check`. Normally no private deployment. | Inspect affected documentation and confirm that no private information or unsafe operational guidance was introduced. | Confirm the merged ref and CI where relevant. Normally do not deploy to a private VM. |
+| **Test / tooling only** | Public CI plus the affected synthetic regression. Private validation is required only when private orchestration, browser, WP-CLI, deployment, authentication-state, artifact, or trust semantics changed. Public-only tooling does not require full WordPress or Playwright execution. | Review the affected test boundary for false passes, unsafe defaults, and private-output leakage. | Confirm merged CI. Run only the affected private profile when private machinery changed. |
+| **Ordinary runtime** | Validate the exact reviewed PR head. Use the Phase 2 `targeted-readonly` profile for an allowlisted affected browser suite, WordPress readiness, and WP-CLI smoke. Add DB/state checks only when the change can affect persistence or runtime state; use the full readonly profile when necessary. Full Playwright is not automatic. | Review the complete affected runtime path, input validation, escaping, and relevant WordPress boundary. | When the merged tree is equivalent to the reviewed head, confirm the exact merged deployment, readiness/smoke, and affected regression instead of automatically repeating all Playwright suites. Escalate if the merge changed the tested tree. |
+| **High-risk** | Required for changes to synchronization lifecycle/concurrency/finalization; database/schema/options/transients/persistence; capabilities/nonces/authentication/authorization/security; Composer dependency trust; or deployment/runtime integrity. Validate exact reviewed and deployed heads, perform deeper affected review, run runtime integrity where applicable, and run specialized security/state plus DB/idle/final-state checks as applicable. Run full Playwright when the boundary is broad enough to justify it. | Review state ownership, failure/cleanup paths, authorization, persistence, concurrency, and trust assumptions as applicable. | Revalidate merged main at depth proportional to release/environment risk. Synchronization, schema/persistence, security/auth, dependency-trust, and deployment-integrity changes normally retain deep affected or full merged-main validation. |
+
+The specialized `npm run test:ajax-security` runner remains the preferred one-command validation for narrowly scoped privileged AJAX authorization changes because it supplies negative/authorized state comparisons and final idle checks. Phase 2 does not duplicate that runner.
+
+## Phase 2 selection
+
+- `npm run test:phase2` preserves the general deploy-and-full-validation workflow.
+- `npm run test:phase2:existing-readonly` validates an existing exact deployment with full Playwright, WP-CLI smoke, and DB-state checks.
+- `NMKR_PHASE2_TARGET_SUITE=<allowlisted-suite> npm run test:phase2:targeted-readonly` validates an existing exact deployment with readiness, one targeted Playwright suite, and WP-CLI smoke; DB-state is intentionally skipped.
+- Set `NMKR_PHASE2_RUNTIME_INTEGRITY=true` only when the profile must verify Composer/runtime deployment integrity. A deployed plugin path is then mandatory, and the gate runs once.
+
+Readonly profiles require `NMKR_PHASE2_EXPECTED_SOURCE_SHA` as a full 40-character reviewed SHA, require a clean source worktree, and verify a supplied deployed plugin worktree at that same SHA. They repeat source/deployed SHA and cleanliness checks after successful validation.
+
+## Blockers and investigation
+
+Block on:
+
+- source or deployed SHA mismatch, dirty tracked state, or failed final integrity;
+- failed runtime integrity when required;
+- PHP fatal, parse, or uncaught failures regardless of origin;
+- fresh first-party NMKR Connect warnings or errors;
+- failed authorization, nonce, capability, security, functional, persistence, DB, idle, final-state, or cleanup assertions required by the selected class;
+- ambiguous results that prevent establishing the required invariant.
+
+Investigate the smallest failing stage and inspect private diagnostics only in the approved private location. Do not publish raw logs, DB output, credentials, nonces, URLs, paths, screenshots, traces, videos, reports, or authentication state.
+
+### Third-party vendor warnings
+
+A fresh warning attributable only to third-party vendor code may be reported as non-blocking when dependency/runtime-integrity files did not change, runtime integrity passes where applicable, and relevant functional/state validation passes. It must be reported and must not be silently ignored. It is blocking when dependency, build, or deployment state changed, another relevant validation failed, its origin is ambiguous, or it is fatal, parse, or uncaught severity. The current log classifier remains fail-closed; this policy permits a documented maintainer disposition after private inspection rather than automatic suppression.
+
+## Follow-up commits and review invalidation
+
+Repeat full affected review and exact-head validation after a follow-up changes synchronization lifecycle, DB/persistence, authorization/security, runtime-state classification, deployment integrity, dependency trust, secret/private-artifact boundaries, or broad runtime behavior.
+
+For documentation, metadata, test labels, comments, evidence pointers, or narrow non-semantic corrections, inspect the new hunk, rerun affected checks, and rely on CI. Do not automatically restart an unrelated full review or private VM cycle. Record why previous substantive review remains applicable.
+
+## Exact-ref deployment contract
+
+Use this host-neutral contract for deployment-integrity validation:
+
+1. Fetch the exact ref.
+2. Materialize and build that exact ref in a private temporary location outside the repository and WordPress root.
+3. Run `composer install --no-dev --prefer-dist --no-interaction` from that ref's exact lockfile.
+4. Deploy tracked source and generated `vendor/` together while preserving WordPress database, options, uploads, and private configuration.
+5. Verify the exact deployed ref and clean tracked state.
+6. Run the runtime-integrity gate once before affected functional validation.
+
+Host-specific paths, domains, credentials, and deployment commands belong only in approved private configuration and must not be committed or printed.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test:e2e:report": "playwright show-report",
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
     "test:phase2:existing-readonly": "NMKR_PHASE2_PROFILE=existing-readonly bash scripts/nmkr-phase2-test-runner.sh",
+    "test:phase2:targeted-readonly": "NMKR_PHASE2_PROFILE=targeted-readonly bash scripts/nmkr-phase2-test-runner.sh",
     "test:php74": "bash scripts/nmkr-php74-compat-scan.sh",
     "test:public": "bash scripts/nmkr-public-checks.sh",
     "test:e2e:settings": "node scripts/nmkr-playwright.js tests/e2e/nmkr-settings.regression.spec.ts",

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -244,7 +244,23 @@ git -C "$target_fixture" config user.name PublicTest
 git -C "$target_fixture" add AGENTS.md docs package.json scripts
 git -C "$target_fixture" commit --allow-empty -q -m 'synthetic targeted profile fixture'
 target_sha="$(git -C "$target_fixture" rev-parse HEAD)"
+deployed_fixture="$tmp_dir/deployed-fixture"
+cp -a "$target_fixture/." "$deployed_fixture/"
 target_bin="$tmp_dir/target-bin"; mkdir -p "$target_bin"
+real_git="$(command -v git)"
+cat >"$target_bin/git" <<'EOF_GIT'
+#!/usr/bin/env bash
+worktree=
+args=("$@")
+if [[ "${1:-}" == -C ]]; then worktree="$2"; shift 2; fi
+if [[ "${1:-}" == status && -n "${FAIL_GIT_STATUS_PATH:-}" && "$worktree" == "$FAIL_GIT_STATUS_PATH" ]]; then
+  counter="${GIT_STATUS_COUNTER_DIR}/$(printf '%s' "$worktree" | sed 's/[^A-Za-z0-9]/_/g')"
+  count=0; [[ ! -f "$counter" ]] || read -r count <"$counter"
+  count=$((count + 1)); printf '%s\n' "$count" >"$counter"
+  [[ "$count" != "${FAIL_GIT_STATUS_CALL:-1}" ]] || exit 73
+fi
+exec "$REAL_GIT" "${args[@]}"
+EOF_GIT
 cat >"$target_bin/node" <<'EOF_NODE'
 #!/usr/bin/env bash
 exit 0
@@ -260,6 +276,13 @@ EOF_NPM
 cat >"$target_bin/wp" <<'EOF_WP'
 #!/usr/bin/env bash
 case "$*" in
+  *' eval '*)
+    case "${TARGET_ACTIVE_PLUGIN_MODE:-valid}" in
+      valid) printf '%s' "$TARGET_ACTIVE_PLUGIN_FILE" ;;
+      malformed) printf 'not-an-absolute-plugin-path' ;;
+      failure) exit 1 ;;
+    esac
+    ;;
   *'db prefix'*) printf 'wp_\n' ;;
   *'SHOW TABLES LIKE'*) printf '%s\n' "$*" | sed -n "s/.*SHOW TABLES LIKE '\([^']*\)'.*/\1/p" ;;
   *'option get nmkr_api_key'*) printf '"synthetic"\n' ;;
@@ -275,11 +298,12 @@ while (($#)); do
 done
 printf '200'
 EOF_CURL
-chmod 700 "$target_bin/node" "$target_bin/npm" "$target_bin/wp" "$target_bin/curl"
+chmod 700 "$target_bin/git" "$target_bin/node" "$target_bin/npm" "$target_bin/wp" "$target_bin/curl"
 target_private="$tmp_dir/target-private"; mkdir -m700 "$target_private"
 target_env="$tmp_dir/target.env"; : >"$target_env"; chmod 600 "$target_env"
 target_log="$tmp_dir/target-calls"
-target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_DEPLOYED_PLUGIN_PATH="$target_fixture" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
+git_counter_dir="$tmp_dir/git-status-counters"; mkdir "$git_counter_dir"
+target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" REAL_GIT="$real_git" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" TARGET_ACTIVE_PLUGIN_FILE="$deployed_fixture/nmkr-connect.php" GIT_STATUS_COUNTER_DIR="$git_counter_dir" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PLUGIN_SLUG=nmkr-connect.php NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_DEPLOYED_PLUGIN_PATH="$deployed_fixture" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
 "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-success.output"
 grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
 ! grep -Fx 'run test:e2e' "$target_log" >/dev/null
@@ -292,7 +316,7 @@ grep -F 'final-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 # Targeted readonly requires deployment identity, while existing readonly keeps
 # accepting an omitted deployed path. General runtime integrity runs only after
 # deployment and fails closed rather than reaching functional validation.
-if "${target_base[@]/NMKR_DEPLOYED_PLUGIN_PATH=$target_fixture/NMKR_DEPLOYED_PLUGIN_PATH=}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-missing-deployed.output" 2>&1; then exit 1; fi
+if "${target_base[@]/NMKR_DEPLOYED_PLUGIN_PATH=$deployed_fixture/NMKR_DEPLOYED_PLUGIN_PATH=}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-missing-deployed.output" 2>&1; then exit 1; fi
 grep -F 'failed step: preflight' "$tmp_dir/target-missing-deployed.output" >/dev/null
 
 : >"$target_log"
@@ -300,6 +324,34 @@ if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=e
 grep -Fx 'run test:e2e' "$target_log" >/dev/null
 grep -F 'failed step: wpcli-db-state' "$tmp_dir/existing-compatible.output" >/dev/null
 grep -F 'deployed-integrity: SKIPPED' "$tmp_dir/existing-compatible.output" >/dev/null
+
+# A clean clone is insufficient unless the selected WordPress installation's
+# active plugin resolves canonically to that deployed worktree.
+if "${target_base[@]}" TARGET_ACTIVE_PLUGIN_FILE="$target_fixture/nmkr-connect.php" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-binding-mismatch.output" 2>&1; then exit 1; fi
+grep -F 'failed step: preflight' "$tmp_dir/target-binding-mismatch.output" >/dev/null
+! grep -F "$target_fixture" "$tmp_dir/target-binding-mismatch.output" >/dev/null
+for mode in failure malformed; do
+  if "${target_base[@]}" TARGET_ACTIVE_PLUGIN_MODE="$mode" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-binding-$mode.output" 2>&1; then exit 1; fi
+  grep -F 'failed step: preflight' "$tmp_dir/target-binding-$mode.output" >/dev/null
+  ! grep -F "$deployed_fixture" "$tmp_dir/target-binding-$mode.output" >/dev/null
+done
+
+# Every initial and final source/deployed status boundary fails closed when
+# Git itself cannot establish cleanliness.
+assert_git_status_failure() {
+  local worktree="$1" call="$2" label="$3"
+  rm -f "$git_counter_dir"/*
+  if "${target_base[@]}" FAIL_GIT_STATUS_PATH="$worktree" FAIL_GIT_STATUS_CALL="$call" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/git-status-$label.output" 2>&1; then exit 1; fi
+  if [[ "$call" == 1 ]]; then
+    grep -F 'failed step: preflight' "$tmp_dir/git-status-$label.output" >/dev/null
+  else
+    grep -F 'failed step: final-integrity' "$tmp_dir/git-status-$label.output" >/dev/null
+  fi
+}
+assert_git_status_failure "$target_fixture" 1 initial-source
+assert_git_status_failure "$deployed_fixture" 1 initial-deployed
+assert_git_status_failure "$target_fixture" 2 final-source
+assert_git_status_failure "$deployed_fixture" 2 final-deployed
 
 general_deploy_marker="$tmp_dir/general-deployed"
 if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=}" NMKR_DEPLOYED_PLUGIN_PATH= NMKR_PHASE2_TARGET_SUITE= NMKR_PHASE2_RUNTIME_INTEGRITY=true NMKR_PHASE2_SKIP_DEPLOY=false NMKR_DEPLOY_COMMAND="touch '$general_deploy_marker'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/general-runtime.output" 2>&1; then exit 1; fi

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -241,6 +241,11 @@ target_fixture="$tmp_dir/target-fixture"
 cp -a "$ROOT/." "$target_fixture/"
 git -C "$target_fixture" config user.email public@example.invalid
 git -C "$target_fixture" config user.name PublicTest
+cat >"$target_fixture/scripts/nmkr-ajax-runtime-integrity.sh" <<'EOF_RUNTIME_INTEGRITY'
+#!/usr/bin/env bash
+printf 'runtime-integrity\n' >>"$RUNTIME_INTEGRITY_CALL_LOG"
+EOF_RUNTIME_INTEGRITY
+chmod 700 "$target_fixture/scripts/nmkr-ajax-runtime-integrity.sh"
 git -C "$target_fixture" add AGENTS.md docs package.json scripts
 git -C "$target_fixture" commit --allow-empty -q -m 'synthetic targeted profile fixture'
 target_sha="$(git -C "$target_fixture" rev-parse HEAD)"
@@ -270,6 +275,12 @@ cat >"$target_bin/npm" <<'EOF_NPM'
 printf '%s\n' "$*" >>"$TARGET_CALL_LOG"
 if [[ "${TARGET_DIRTY_AFTER_PLAYWRIGHT:-false}" == true && "$*" == 'run test:e2e:settings' ]]; then
   printf '\nsynthetic-dirty\n' >>"$TARGET_REPO/README.md"
+fi
+if [[ -n "${TARGET_HIDDEN_AFTER_PLAYWRIGHT:-}" && "$*" == 'run test:e2e:settings' ]]; then
+  hidden_repo="$TARGET_REPO"
+  [[ "${TARGET_HIDDEN_WORKTREE:-source}" != deployed ]] || hidden_repo="$TARGET_DEPLOYED_REPO"
+  "$REAL_GIT" -C "$hidden_repo" update-index "--$TARGET_HIDDEN_AFTER_PLAYWRIGHT" README.md
+  printf '\nsynthetic-hidden\n' >>"$hidden_repo/README.md"
 fi
 exit 0
 EOF_NPM
@@ -303,7 +314,8 @@ target_private="$tmp_dir/target-private"; mkdir -m700 "$target_private"
 target_env="$tmp_dir/target.env"; : >"$target_env"; chmod 600 "$target_env"
 target_log="$tmp_dir/target-calls"
 git_counter_dir="$tmp_dir/git-status-counters"; mkdir "$git_counter_dir"
-target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" REAL_GIT="$real_git" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" TARGET_ACTIVE_PLUGIN_FILE="$deployed_fixture/nmkr-connect.php" GIT_STATUS_COUNTER_DIR="$git_counter_dir" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PLUGIN_SLUG=nmkr-connect.php NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_DEPLOYED_PLUGIN_PATH="$deployed_fixture" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
+runtime_integrity_log="$tmp_dir/runtime-integrity-calls"
+target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" REAL_GIT="$real_git" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" TARGET_DEPLOYED_REPO="$deployed_fixture" TARGET_ACTIVE_PLUGIN_FILE="$deployed_fixture/nmkr-connect.php" RUNTIME_INTEGRITY_CALL_LOG="$runtime_integrity_log" GIT_STATUS_COUNTER_DIR="$git_counter_dir" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PLUGIN_SLUG=nmkr-connect.php NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_DEPLOYED_PLUGIN_PATH="$deployed_fixture" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
 "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-success.output"
 grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
 ! grep -Fx 'run test:e2e' "$target_log" >/dev/null
@@ -353,11 +365,49 @@ assert_git_status_failure "$deployed_fixture" 1 initial-deployed
 assert_git_status_failure "$target_fixture" 2 final-source
 assert_git_status_failure "$deployed_fixture" 2 final-deployed
 
+# Index hints must not hide changed tracked bytes at either integrity boundary.
+assert_hidden_initial_failure() {
+  local worktree="$1" flag="$2" label="$3"
+  git -C "$worktree" update-index "--$flag" README.md
+  printf '\nsynthetic-hidden\n' >>"$worktree/README.md"
+  if "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/hidden-initial-$label.output" 2>&1; then exit 1; fi
+  grep -F 'failed step: preflight' "$tmp_dir/hidden-initial-$label.output" >/dev/null
+  git -C "$worktree" update-index "--no-$flag" README.md
+  git -C "$worktree" checkout -q -- README.md
+}
+for flag in assume-unchanged skip-worktree; do
+  assert_hidden_initial_failure "$target_fixture" "$flag" "source-$flag"
+  assert_hidden_initial_failure "$deployed_fixture" "$flag" "deployed-$flag"
+  for worktree in source deployed; do
+    if "${target_base[@]}" TARGET_HIDDEN_AFTER_PLAYWRIGHT="$flag" TARGET_HIDDEN_WORKTREE="$worktree" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/hidden-final-$worktree-$flag.output" 2>&1; then exit 1; fi
+    grep -F 'failed step: final-integrity' "$tmp_dir/hidden-final-$worktree-$flag.output" >/dev/null
+    hidden_repo="$target_fixture"; [[ "$worktree" != deployed ]] || hidden_repo="$deployed_fixture"
+    git -C "$hidden_repo" update-index "--no-$flag" README.md
+    git -C "$hidden_repo" checkout -q -- README.md
+  done
+done
+
 general_deploy_marker="$tmp_dir/general-deployed"
 if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=}" NMKR_DEPLOYED_PLUGIN_PATH= NMKR_PHASE2_TARGET_SUITE= NMKR_PHASE2_RUNTIME_INTEGRITY=true NMKR_PHASE2_SKIP_DEPLOY=false NMKR_DEPLOY_COMMAND="touch '$general_deploy_marker'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/general-runtime.output" 2>&1; then exit 1; fi
 test -e "$general_deploy_marker"
 grep -F 'failed step: runtime-integrity' "$tmp_dir/general-runtime.output" >/dev/null
 grep -F 'runtime-integrity: SKIPPED' "$tmp_dir/general-runtime.output" >/dev/null && exit 1
+
+# General and existing-readonly runtime integrity bind to the WordPress-active
+# deployment before invoking the helper, and invoke that helper exactly once.
+for profile in general existing-readonly; do
+  : >"$runtime_integrity_log"; : >"$target_log"
+  profile_value=""; suite_value=""
+  [[ "$profile" != existing-readonly ]] || profile_value=existing-readonly
+  if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=$profile_value}" NMKR_PHASE2_TARGET_SUITE="$suite_value" NMKR_PHASE2_RUNTIME_INTEGRITY=true TARGET_ACTIVE_PLUGIN_FILE="$target_fixture/nmkr-connect.php" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/runtime-binding-mismatch-$profile.output" 2>&1; then exit 1; fi
+  grep -F 'failed step: runtime-integrity' "$tmp_dir/runtime-binding-mismatch-$profile.output" >/dev/null
+  test ! -s "$runtime_integrity_log"
+
+  : >"$runtime_integrity_log"
+  "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=$profile_value}" NMKR_PHASE2_TARGET_SUITE="$suite_value" NMKR_PHASE2_RUNTIME_INTEGRITY=true bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/runtime-binding-match-$profile.output" 2>&1 || true
+  test "$(wc -l <"$runtime_integrity_log")" = 1
+  grep -F 'runtime-integrity: PASS' "$tmp_dir/runtime-binding-match-$profile.output" >/dev/null
+done
 
 printf 'NMKR_PHASE2_TARGET_SUITE=dashboard\n' >"$target_env"
 if "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-conflict.output" 2>&1; then exit 1; fi

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -258,6 +258,7 @@ cat >"$target_bin/git" <<'EOF_GIT'
 worktree=
 args=("$@")
 if [[ "${1:-}" == -C ]]; then worktree="$2"; shift 2; fi
+if [[ "${1:-}" == -c && "${2:-}" == core.fileMode=true ]]; then shift 2; fi
 if [[ "${1:-}" == status && -n "${FAIL_GIT_STATUS_PATH:-}" && "$worktree" == "$FAIL_GIT_STATUS_PATH" ]]; then
   counter="${GIT_STATUS_COUNTER_DIR}/$(printf '%s' "$worktree" | sed 's/[^A-Za-z0-9]/_/g')"
   count=0; [[ ! -f "$counter" ]] || read -r count <"$counter"
@@ -281,6 +282,11 @@ if [[ -n "${TARGET_HIDDEN_AFTER_PLAYWRIGHT:-}" && "$*" == 'run test:e2e:settings
   [[ "${TARGET_HIDDEN_WORKTREE:-source}" != deployed ]] || hidden_repo="$TARGET_DEPLOYED_REPO"
   "$REAL_GIT" -C "$hidden_repo" update-index "--$TARGET_HIDDEN_AFTER_PLAYWRIGHT" README.md
   printf '\nsynthetic-hidden\n' >>"$hidden_repo/README.md"
+fi
+if [[ "${TARGET_MODE_AFTER_PLAYWRIGHT:-false}" == true && "$*" == 'run test:e2e:settings' ]]; then
+  mode_repo="$TARGET_REPO"
+  [[ "${TARGET_MODE_WORKTREE:-source}" != deployed ]] || mode_repo="$TARGET_DEPLOYED_REPO"
+  chmod +x "$mode_repo/README.md"
 fi
 exit 0
 EOF_NPM
@@ -387,11 +393,39 @@ for flag in assume-unchanged skip-worktree; do
   done
 done
 
+# File-mode differences remain visible even when a worktree disables its
+# ordinary file-mode detection, at both initial and final integrity boundaries.
+for worktree in source deployed; do
+  mode_repo="$target_fixture"; [[ "$worktree" != deployed ]] || mode_repo="$deployed_fixture"
+  git -C "$mode_repo" config core.fileMode false
+  chmod +x "$mode_repo/README.md"
+  if "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/mode-initial-$worktree.output" 2>&1; then exit 1; fi
+  grep -F 'failed step: preflight' "$tmp_dir/mode-initial-$worktree.output" >/dev/null
+  chmod -x "$mode_repo/README.md"
+
+  if "${target_base[@]}" TARGET_MODE_AFTER_PLAYWRIGHT=true TARGET_MODE_WORKTREE="$worktree" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/mode-final-$worktree.output" 2>&1; then exit 1; fi
+  grep -F 'failed step: final-integrity' "$tmp_dir/mode-final-$worktree.output" >/dev/null
+  chmod -x "$mode_repo/README.md"
+done
+
 general_deploy_marker="$tmp_dir/general-deployed"
 if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=}" NMKR_DEPLOYED_PLUGIN_PATH= NMKR_PHASE2_TARGET_SUITE= NMKR_PHASE2_RUNTIME_INTEGRITY=true NMKR_PHASE2_SKIP_DEPLOY=false NMKR_DEPLOY_COMMAND="touch '$general_deploy_marker'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/general-runtime.output" 2>&1; then exit 1; fi
 test -e "$general_deploy_marker"
 grep -F 'failed step: runtime-integrity' "$tmp_dir/general-runtime.output" >/dev/null
 grep -F 'runtime-integrity: SKIPPED' "$tmp_dir/general-runtime.output" >/dev/null && exit 1
+
+# A nominally successful general deployment cannot validate a clean stale
+# deployed commit, and the runtime-integrity helper must not be invoked.
+git -C "$deployed_fixture" config user.email public@example.invalid
+git -C "$deployed_fixture" config user.name PublicTest
+git -C "$deployed_fixture" commit --allow-empty -q -m 'synthetic stale deployment'
+: >"$runtime_integrity_log"
+stale_deploy_marker="$tmp_dir/general-stale-deployed"
+if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=}" NMKR_PHASE2_TARGET_SUITE= NMKR_PHASE2_RUNTIME_INTEGRITY=true NMKR_PHASE2_SKIP_DEPLOY=false NMKR_DEPLOY_COMMAND="touch '$stale_deploy_marker'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/general-stale-runtime.output" 2>&1; then exit 1; fi
+test -e "$stale_deploy_marker"
+grep -F 'failed step: runtime-integrity' "$tmp_dir/general-stale-runtime.output" >/dev/null
+test ! -s "$runtime_integrity_log"
+git -C "$deployed_fixture" reset --hard -q "$target_sha"
 
 # General and existing-readonly runtime integrity bind to the WordPress-active
 # deployment before invoking the helper, and invoke that helper exactly once.

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -232,6 +232,71 @@ fi
 grep -F -- 'ERROR: Phase 2 private run directory is unsafe.' "$tmp_dir/runs-file.output" >/dev/null
 rm -f "$tmp_dir/private/runs"; mkdir -p "$tmp_dir/private/runs"; chmod 700 "$tmp_dir/private/runs"
 
+rm -f "$checkout_collision"
+# Targeted readonly selection is allowlisted, cannot be replaced by the env file,
+# invokes only the selected package script, skips DB state, and rechecks integrity.
+target_fixture="$tmp_dir/target-fixture"
+cp -a "$ROOT/." "$target_fixture/"
+git -C "$target_fixture" config user.email public@example.invalid
+git -C "$target_fixture" config user.name PublicTest
+git -C "$target_fixture" add AGENTS.md docs package.json scripts
+git -C "$target_fixture" commit -q -m 'synthetic targeted profile fixture'
+target_sha="$(git -C "$target_fixture" rev-parse HEAD)"
+target_bin="$tmp_dir/target-bin"; mkdir -p "$target_bin"
+cat >"$target_bin/node" <<'EOF_NODE'
+#!/usr/bin/env bash
+exit 0
+EOF_NODE
+cat >"$target_bin/npm" <<'EOF_NPM'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$TARGET_CALL_LOG"
+if [[ "${TARGET_DIRTY_AFTER_PLAYWRIGHT:-false}" == true && "$*" == 'run test:e2e:settings' ]]; then
+  printf '\nsynthetic-dirty\n' >>"$TARGET_REPO/README.md"
+fi
+exit 0
+EOF_NPM
+cat >"$target_bin/wp" <<'EOF_WP'
+#!/usr/bin/env bash
+case "$*" in
+  *'db prefix'*) printf 'wp_\n' ;;
+  *'SHOW TABLES LIKE'*) printf '%s\n' "$*" | sed -n "s/.*SHOW TABLES LIKE '\([^']*\)'.*/\1/p" ;;
+  *'option get nmkr_api_key'*) printf '"synthetic"\n' ;;
+  *'SELECT COUNT(*)'*) printf '0\n' ;;
+  *) : ;;
+esac
+EOF_WP
+cat >"$target_bin/curl" <<'EOF_CURL'
+#!/usr/bin/env bash
+while (($#)); do
+  if [[ "$1" == -o ]]; then shift; printf '<input id="user_login">' >"$1"; fi
+  shift
+done
+printf '200'
+EOF_CURL
+chmod 700 "$target_bin/node" "$target_bin/npm" "$target_bin/wp" "$target_bin/curl"
+target_private="$tmp_dir/target-private"; mkdir -m700 "$target_private"
+target_env="$tmp_dir/target.env"; : >"$target_env"; chmod 600 "$target_env"
+target_log="$tmp_dir/target-calls"
+target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
+"${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-success.output"
+grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
+! grep -Fx 'run test:e2e' "$target_log" >/dev/null
+grep -F 'targeted-suite: settings' "$tmp_dir/target-success.output" >/dev/null
+grep -F 'db-state: SKIPPED' "$tmp_dir/target-success.output" >/dev/null
+grep -F 'final-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
+
+printf 'NMKR_PHASE2_TARGET_SUITE=dashboard\n' >"$target_env"
+if "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-conflict.output" 2>&1; then exit 1; fi
+grep -F 'failed step: preflight' "$tmp_dir/target-conflict.output" >/dev/null
+: >"$target_env"
+if "${target_base[@]/NMKR_PHASE2_TARGET_SUITE=settings/NMKR_PHASE2_TARGET_SUITE=unknown}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-unknown.output" 2>&1; then exit 1; fi
+grep -F 'failed step: preflight' "$tmp_dir/target-unknown.output" >/dev/null
+
+: >"$target_log"
+if "${target_base[@]}" TARGET_DIRTY_AFTER_PLAYWRIGHT=true bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-dirty.output" 2>&1; then exit 1; fi
+grep -F 'failed step: final-integrity' "$tmp_dir/target-dirty.output" >/dev/null
+git -C "$target_fixture" checkout -q -- README.md
+
 # Signals must stop a dedicated process group before deployment can complete or readiness begins.
 mkdir -p "$tmp_dir/bin"
 cat >"$tmp_dir/long-child.sh" <<'EOF_CHILD'

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -166,6 +166,8 @@ printf 'NMKR_PHASE2_PROFILE=\nNMKR_DEPLOY_COMMAND="touch %s/marker"\nNMKR_PHASE2
 expect_fail 'Phase 2 profile conflict.' NMKR_PHASE2_PROFILE=existing-readonly NMKR_PHASE2_ENV_FILE="$tmp_dir/env"
 test ! -e "$tmp_dir/marker"
 printf 'NMKR_PHASE2_PROFILE=general\n' >"$tmp_dir/env"; expect_fail 'Phase 2 profile conflict.' NMKR_PHASE2_PROFILE=existing-readonly NMKR_PHASE2_ENV_FILE="$tmp_dir/env"
+# Caller-selected runtime integrity cannot be downgraded by a sourced file.
+printf 'NMKR_PHASE2_RUNTIME_INTEGRITY=false\n' >"$tmp_dir/env"; expect_fail 'Phase 2 runtime integrity conflict.' NMKR_PHASE2_RUNTIME_INTEGRITY=true NMKR_PHASE2_ENV_FILE="$tmp_dir/env"
 printf 'NMKR_PHASE2_SKIP_DEPLOY=true\n' >"$tmp_dir/env"; expect_fail 'Expected source SHA is invalid.' NMKR_PHASE2_PROFILE=existing-readonly NMKR_PHASE2_ENV_FILE="$tmp_dir/env" NMKR_PHASE2_EXPECTED_SOURCE_SHA=invalid
 printf 'NMKR_PHASE2_PROFILE=existing-readonly\n' >"$tmp_dir/env"; expect_fail 'Expected source SHA is invalid.' NMKR_PHASE2_ENV_FILE="$tmp_dir/env" NMKR_PHASE2_EXPECTED_SOURCE_SHA=invalid
 # A sourced env file cannot clear the runner's selected-file identity before
@@ -277,13 +279,33 @@ chmod 700 "$target_bin/node" "$target_bin/npm" "$target_bin/wp" "$target_bin/cur
 target_private="$tmp_dir/target-private"; mkdir -m700 "$target_private"
 target_env="$tmp_dir/target.env"; : >"$target_env"; chmod 600 "$target_env"
 target_log="$tmp_dir/target-calls"
-target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
+target_base=(env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN="$target_bin/wp" WP_PATH="$tmp_dir/wp" NMKR_PHASE2_LOG_DIR="$target_private" NMKR_PHASE2_ENV_FILE="$target_env" NMKR_PHASE2_PROFILE=targeted-readonly NMKR_PHASE2_TARGET_SUITE=settings NMKR_PHASE2_EXPECTED_SOURCE_SHA="$target_sha" NMKR_DEPLOYED_PLUGIN_PATH="$target_fixture" NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false)
 "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-success.output"
 grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
 ! grep -Fx 'run test:e2e' "$target_log" >/dev/null
 grep -F 'targeted-suite: settings' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'db-state: SKIPPED' "$tmp_dir/target-success.output" >/dev/null
+grep -F 'source-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
+grep -F 'deployed-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'final-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
+
+# Targeted readonly requires deployment identity, while existing readonly keeps
+# accepting an omitted deployed path. General runtime integrity runs only after
+# deployment and fails closed rather than reaching functional validation.
+if "${target_base[@]/NMKR_DEPLOYED_PLUGIN_PATH=$target_fixture/NMKR_DEPLOYED_PLUGIN_PATH=}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-missing-deployed.output" 2>&1; then exit 1; fi
+grep -F 'failed step: preflight' "$tmp_dir/target-missing-deployed.output" >/dev/null
+
+: >"$target_log"
+if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=existing-readonly}" NMKR_DEPLOYED_PLUGIN_PATH= NMKR_PHASE2_TARGET_SUITE= bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/existing-compatible.output" 2>&1; then exit 1; fi
+grep -Fx 'run test:e2e' "$target_log" >/dev/null
+grep -F 'failed step: wpcli-db-state' "$tmp_dir/existing-compatible.output" >/dev/null
+grep -F 'deployed-integrity: SKIPPED' "$tmp_dir/existing-compatible.output" >/dev/null
+
+general_deploy_marker="$tmp_dir/general-deployed"
+if "${target_base[@]/NMKR_PHASE2_PROFILE=targeted-readonly/NMKR_PHASE2_PROFILE=}" NMKR_DEPLOYED_PLUGIN_PATH= NMKR_PHASE2_TARGET_SUITE= NMKR_PHASE2_RUNTIME_INTEGRITY=true NMKR_PHASE2_SKIP_DEPLOY=false NMKR_DEPLOY_COMMAND="touch '$general_deploy_marker'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/general-runtime.output" 2>&1; then exit 1; fi
+test -e "$general_deploy_marker"
+grep -F 'failed step: runtime-integrity' "$tmp_dir/general-runtime.output" >/dev/null
+grep -F 'runtime-integrity: SKIPPED' "$tmp_dir/general-runtime.output" >/dev/null && exit 1
 
 printf 'NMKR_PHASE2_TARGET_SUITE=dashboard\n' >"$target_env"
 if "${target_base[@]}" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" >"$tmp_dir/target-conflict.output" 2>&1; then exit 1; fi

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -240,7 +240,7 @@ cp -a "$ROOT/." "$target_fixture/"
 git -C "$target_fixture" config user.email public@example.invalid
 git -C "$target_fixture" config user.name PublicTest
 git -C "$target_fixture" add AGENTS.md docs package.json scripts
-git -C "$target_fixture" commit -q -m 'synthetic targeted profile fixture'
+git -C "$target_fixture" commit --allow-empty -q -m 'synthetic targeted profile fixture'
 target_sha="$(git -C "$target_fixture" rev-parse HEAD)"
 target_bin="$tmp_dir/target-bin"; mkdir -p "$target_bin"
 cat >"$target_bin/node" <<'EOF_NODE'

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -339,6 +339,14 @@ git_head_and_clean() {
   if ! status="$(git -C "$worktree" status --porcelain 2>/dev/null)" || [[ -n "$status" ]]; then
     return 1
   fi
+  # status intentionally honors index hints that can hide modified tracked
+  # bytes. Exact-head validation must reject either hint rather than trust it.
+  if ! git -C "$worktree" ls-files -v -z 2>/dev/null |
+    while IFS= read -r -d '' index_entry; do
+      [[ "${index_entry:0:1}" != S && "${index_entry:0:1}" != [a-z] ]] || exit 1
+    done; then
+    return 1
+  fi
 }
 bind_active_plugin_to_deployed_worktree() {
   local deployed_root git_root expected_file active_file active_file_output wp_cli_args
@@ -498,6 +506,9 @@ fi
 if [[ "$NMKR_PHASE2_RUNTIME_INTEGRITY" == "true" ]]; then
   RUNTIME_INTEGRITY_STATUS="FAIL"
   [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
+  if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]]; then
+    bind_active_plugin_to_deployed_worktree || { printf 'Active plugin deployment binding failed.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
+  fi
   run_external "$REPO_ROOT/scripts/nmkr-ajax-runtime-integrity.sh" "$NMKR_DEPLOYED_PLUGIN_PATH" >"$RUN_DIR/runtime-integrity.log" 2>&1 || fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1
   RUNTIME_INTEGRITY_STATUS="PASS"
 fi

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -14,6 +14,7 @@ fi
 RUN_REAL_SYNC="${RUN_REAL_SYNC:-false}"
 PW_SAVE_ARTIFACTS="${PW_SAVE_ARTIFACTS:-false}"
 CALLER_PROFILE="${NMKR_PHASE2_PROFILE:-}"
+CALLER_TARGET_SUITE="${NMKR_PHASE2_TARGET_SUITE:-}"
 WP_CLI_BIN="${WP_CLI_BIN:-wp}"
 NMKR_PLUGIN_SLUG="${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}"
 NMKR_DEBUG_LOG_RELATIVE_PATH="${NMKR_DEBUG_LOG_RELATIVE_PATH:-wp-content/debug.log}"
@@ -21,6 +22,7 @@ NMKR_DEBUG_LOG_LOOKBACK_MINUTES="${NMKR_DEBUG_LOG_LOOKBACK_MINUTES:-30}"
 NMKR_PHASE2_INSTALL_DEPS="${NMKR_PHASE2_INSTALL_DEPS:-auto}"
 NMKR_PHASE2_INSTALL_BROWSER="${NMKR_PHASE2_INSTALL_BROWSER:-false}"
 NMKR_PHASE2_SKIP_DEPLOY="${NMKR_PHASE2_SKIP_DEPLOY:-false}"
+NMKR_PHASE2_RUNTIME_INTEGRITY="${NMKR_PHASE2_RUNTIME_INTEGRITY:-false}"
 NMKR_PHASE2_WP_READY_TIMEOUT_SECONDS="${NMKR_PHASE2_WP_READY_TIMEOUT_SECONDS:-120}"
 NMKR_PHASE2_WP_READY_INTERVAL_SECONDS="${NMKR_PHASE2_WP_READY_INTERVAL_SECONDS:-5}"
 NMKR_PHASE2_WP_READY_HTTP_TIMEOUT_SECONDS="${NMKR_PHASE2_WP_READY_HTTP_TIMEOUT_SECONDS:-10}"
@@ -63,6 +65,8 @@ NMKR_PHASE2_WP_READY_TIMEOUT_SECONDS="${NMKR_PHASE2_WP_READY_TIMEOUT_SECONDS:-12
 NMKR_PHASE2_WP_READY_INTERVAL_SECONDS="${NMKR_PHASE2_WP_READY_INTERVAL_SECONDS:-5}"
 NMKR_PHASE2_WP_READY_HTTP_TIMEOUT_SECONDS="${NMKR_PHASE2_WP_READY_HTTP_TIMEOUT_SECONDS:-10}"
 NMKR_PHASE2_PROFILE="${NMKR_PHASE2_PROFILE:-}"
+NMKR_PHASE2_TARGET_SUITE="${NMKR_PHASE2_TARGET_SUITE:-}"
+NMKR_PHASE2_RUNTIME_INTEGRITY="${NMKR_PHASE2_RUNTIME_INTEGRITY:-false}"
 NMKR_RETAIN_AUTH_STATE="${NMKR_RETAIN_AUTH_STATE:-false}"
 
 validate_boolean() {
@@ -77,6 +81,9 @@ WORDPRESS_READY_STATUS="SKIPPED"
 PLAYWRIGHT_STATUS="SKIPPED"
 WPCLI_STATUS="SKIPPED"
 DBSTATE_STATUS="SKIPPED"
+RUNTIME_INTEGRITY_STATUS="SKIPPED"
+FINAL_INTEGRITY="SKIPPED"
+SELECTED_SUITE="full"
 FAILED_STEP=""
 FAILED_LOG=""
 EXIT_CODE=0
@@ -97,6 +104,9 @@ print_summary() {
   printf '  playwright: %s\n' "$PLAYWRIGHT_STATUS"
   printf '  wpcli: %s\n' "$WPCLI_STATUS"
   printf '  db-state: %s\n' "$DBSTATE_STATUS"
+  printf '  targeted-suite: %s\n' "$SELECTED_SUITE"
+  printf '  runtime-integrity: %s\n' "$RUNTIME_INTEGRITY_STATUS"
+  printf '  final-integrity: %s\n' "$FINAL_INTEGRITY"
   printf '  profile: %s\n' "${NMKR_PHASE2_PROFILE:-general}"
   printf '  source-integrity: %s\n' "${SOURCE_INTEGRITY:-SKIPPED}"
   printf '  deployed-integrity: %s\n' "${DEPLOYED_INTEGRITY:-SKIPPED}"
@@ -349,10 +359,23 @@ validate_positive_integer "NMKR_PHASE2_WP_READY_HTTP_TIMEOUT_SECONDS" "$NMKR_PHA
 if [[ -n "$CALLER_PROFILE" && "$CALLER_PROFILE" != "$NMKR_PHASE2_PROFILE" ]]; then
   printf 'Phase 2 profile conflict.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
 fi
-case "$NMKR_PHASE2_PROFILE" in ''|existing-readonly) ;; *) printf 'Unknown Phase 2 profile.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1 ;; esac
-for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_INSTALL_BROWSER NMKR_PHASE2_SKIP_DEPLOY NMKR_RETAIN_AUTH_STATE; do validate_boolean "$boolean" "${!boolean}"; done
+if [[ -n "$CALLER_TARGET_SUITE" && "$CALLER_TARGET_SUITE" != "$NMKR_PHASE2_TARGET_SUITE" ]]; then
+  printf 'Phase 2 target suite conflict.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+fi
+case "$NMKR_PHASE2_PROFILE" in ''|existing-readonly|targeted-readonly) ;; *) printf 'Unknown Phase 2 profile.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1 ;; esac
+for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_INSTALL_BROWSER NMKR_PHASE2_SKIP_DEPLOY NMKR_PHASE2_RUNTIME_INTEGRITY NMKR_RETAIN_AUTH_STATE; do validate_boolean "$boolean" "${!boolean}"; done
 
-if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" ]]; then
+case "$NMKR_PHASE2_TARGET_SUITE" in
+  settings|dashboard|projects|shortcodes|analytics|ajax-security|sync-state|sync-run-authority|sync-resilience|sync-final-state) ;;
+  '') [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]] || { printf 'Target suite is required.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; } ;;
+  *) printf 'Unknown target suite.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1 ;;
+esac
+if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" && -n "$NMKR_PHASE2_TARGET_SUITE" ]]; then
+  printf 'Target suite requires targeted-readonly profile.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+fi
+[[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]] || SELECTED_SUITE="$NMKR_PHASE2_TARGET_SUITE"
+
+if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
   READONLY_POLICY="ENFORCED"; SOURCE_INTEGRITY="FAIL"; DEPLOYED_INTEGRITY="SKIPPED"
   readonly_overrides=false
   for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_SKIP_DEPLOY NMKR_PHASE2_INSTALL_BROWSER; do [[ "${!boolean}" != "false" || "$boolean" == NMKR_PHASE2_SKIP_DEPLOY ]] && readonly_overrides=true; done
@@ -370,6 +393,12 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" ]]; then
   fi
   run_external node -e "require('@playwright/test')" >/dev/null 2>&1 || { printf 'Required Node dependencies are unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   run_external node -e "const { chromium }=require('@playwright/test'); (async()=>{const b=await chromium.launch({headless:true}); await b.close();})().catch(()=>process.exit(1))" >/dev/null 2>&1 || { printf 'Configured Chromium is unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+  if [[ "$NMKR_PHASE2_RUNTIME_INTEGRITY" == "true" ]]; then
+    [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+    RUNTIME_INTEGRITY_STATUS="FAIL"
+    run_external "$REPO_ROOT/scripts/nmkr-ajax-runtime-integrity.sh" "$NMKR_DEPLOYED_PLUGIN_PATH" >"$RUN_DIR/runtime-integrity.log" 2>&1 || fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1
+    RUNTIME_INTEGRITY_STATUS="PASS"
+  fi
 fi
 
 case "$NMKR_PHASE2_INSTALL_DEPS" in
@@ -439,7 +468,12 @@ export NMKR_AUTH_STATE_ROOT="$RUN_DIR"
 unset NMKR_AUTH_STATE_DIR NMKR_AUTH_STATE_PATH NMKR_AUTH_STATE_OWNER_TOKEN
 
 PLAYWRIGHT_STATUS="FAIL"
-if run_external npm run test:e2e >"$RUN_DIR/playwright.log" 2>&1; then
+if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
+  playwright_command=(npm run "test:e2e:$NMKR_PHASE2_TARGET_SUITE")
+else
+  playwright_command=(npm run test:e2e)
+fi
+if run_external "${playwright_command[@]}" >"$RUN_DIR/playwright.log" 2>&1; then
   PLAYWRIGHT_STATUS="PASS"
 else
   fail_step "playwright" "$RUN_DIR/playwright.log" 4
@@ -452,11 +486,24 @@ else
   fail_step "wpcli" "$RUN_DIR/wpcli.log" 5
 fi
 
-DBSTATE_STATUS="FAIL"
-if run_external bash scripts/nmkr-wpcli-db-state.sh >"$RUN_DIR/wpcli-db-state.log" 2>&1; then
-  DBSTATE_STATUS="PASS"
+if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
+  DBSTATE_STATUS="SKIPPED"
 else
-  fail_step "wpcli-db-state" "$RUN_DIR/wpcli-db-state.log" 6
+  DBSTATE_STATUS="FAIL"
+  if run_external bash scripts/nmkr-wpcli-db-state.sh >"$RUN_DIR/wpcli-db-state.log" 2>&1; then
+    DBSTATE_STATUS="PASS"
+  else
+    fail_step "wpcli-db-state" "$RUN_DIR/wpcli-db-state.log" 6
+  fi
+fi
+
+if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
+  FINAL_INTEGRITY="FAIL"
+  [[ "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" && -z "$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null)" ]] || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
+  if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
+    [[ "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD 2>/dev/null)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" && -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" status --porcelain 2>/dev/null)" ]] || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
+  fi
+  FINAL_INTEGRITY="PASS"
 fi
 
 EXIT_CODE=0

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -461,8 +461,8 @@ else
 fi
 
 if [[ "$NMKR_PHASE2_RUNTIME_INTEGRITY" == "true" ]]; then
-  [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
   RUNTIME_INTEGRITY_STATUS="FAIL"
+  [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
   run_external "$REPO_ROOT/scripts/nmkr-ajax-runtime-integrity.sh" "$NMKR_DEPLOYED_PLUGIN_PATH" >"$RUN_DIR/runtime-integrity.log" 2>&1 || fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1
   RUNTIME_INTEGRITY_STATUS="PASS"
 fi

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -336,7 +336,7 @@ git_head_and_clean() {
   if ! head="$(git -C "$worktree" rev-parse HEAD 2>/dev/null)" || [[ "$head" != "$expected_sha" ]]; then
     return 1
   fi
-  if ! status="$(git -C "$worktree" status --porcelain 2>/dev/null)" || [[ -n "$status" ]]; then
+  if ! status="$(git -C "$worktree" -c core.fileMode=true status --porcelain 2>/dev/null)" || [[ -n "$status" ]]; then
     return 1
   fi
   # status intentionally honors index hints that can hide modified tracked
@@ -506,6 +506,11 @@ fi
 if [[ "$NMKR_PHASE2_RUNTIME_INTEGRITY" == "true" ]]; then
   RUNTIME_INTEGRITY_STATUS="FAIL"
   [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
+  if [[ -z "$NMKR_PHASE2_PROFILE" ]]; then
+    runtime_source_sha="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)" || { printf 'Runtime deployment integrity could not be established.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
+    git_head_and_clean "$REPO_ROOT" "$runtime_source_sha" &&
+      git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$runtime_source_sha" || { printf 'Runtime deployment integrity could not be established.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
+  fi
   if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]]; then
     bind_active_plugin_to_deployed_worktree || { printf 'Active plugin deployment binding failed.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
   fi

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -331,6 +331,39 @@ run_external() {
   ACTIVE_CHILD_PID=""
   return "$status"
 }
+git_head_and_clean() {
+  local worktree="$1" expected_sha="$2" head status
+  if ! head="$(git -C "$worktree" rev-parse HEAD 2>/dev/null)" || [[ "$head" != "$expected_sha" ]]; then
+    return 1
+  fi
+  if ! status="$(git -C "$worktree" status --porcelain 2>/dev/null)" || [[ -n "$status" ]]; then
+    return 1
+  fi
+}
+bind_active_plugin_to_deployed_worktree() {
+  local deployed_root git_root expected_file active_file active_file_output wp_cli_args
+  [[ "$NMKR_PLUGIN_SLUG" != /* && "$NMKR_PLUGIN_SLUG" != *//* && "$NMKR_PLUGIN_SLUG" != ../* && "$NMKR_PLUGIN_SLUG" != */../* && "$NMKR_PLUGIN_SLUG" != */.. && "$NMKR_PLUGIN_SLUG" != ./* && "$NMKR_PLUGIN_SLUG" != */./* ]] || return 1
+  [[ ! -L "$NMKR_DEPLOYED_PLUGIN_PATH" ]] || return 1
+  deployed_root="$(realpath -e -- "$NMKR_DEPLOYED_PLUGIN_PATH" 2>/dev/null)" || return 1
+  [[ -d "$deployed_root" ]] || return 1
+  git_root="$(git -C "$deployed_root" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  git_root="$(realpath -e -- "$git_root" 2>/dev/null)" || return 1
+  [[ "$git_root" == "$deployed_root" ]] || return 1
+  expected_file="$deployed_root/${NMKR_PLUGIN_SLUG##*/}"
+  [[ -f "$expected_file" && ! -L "$expected_file" ]] || return 1
+  [[ "$(realpath -e -- "$expected_file" 2>/dev/null)" == "$expected_file" ]] || return 1
+  wp_cli_args=("$WP_CLI_BIN")
+  [[ -z "$WP_PATH" ]] || wp_cli_args+=("--path=$WP_PATH")
+  wp_cli_args+=(eval 'require_once ABSPATH . "wp-admin/includes/plugin.php"; $slug = getenv("NMKR_PLUGIN_SLUG"); if (!is_string($slug) || $slug === "" || validate_file($slug) !== 0 || !is_plugin_active($slug)) { exit(1); } $file = realpath(WP_PLUGIN_DIR . "/" . $slug); if ($file === false || !is_file($file)) { exit(1); } echo $file;')
+  active_file_output="$RUN_DIR/active-plugin-path.tmp"
+  if ! run_external "${wp_cli_args[@]}" >"$active_file_output" 2>/dev/null; then
+    rm -f "$active_file_output"
+    return 1
+  fi
+  active_file="$(cat "$active_file_output")" || { rm -f "$active_file_output"; return 1; }
+  rm -f "$active_file_output"
+  [[ "$active_file" == "$expected_file" ]]
+}
 terminate_active_child() {
   local pid="$ACTIVE_CHILD_PID" attempts=0
   [[ -n "$pid" ]] || return 0
@@ -387,16 +420,18 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" ==
   RUN_REAL_SYNC=false; PW_SAVE_ARTIFACTS=false; NMKR_PHASE2_SKIP_DEPLOY=true; NMKR_PHASE2_INSTALL_DEPS=false; NMKR_PHASE2_INSTALL_BROWSER=false; unset NMKR_DEPLOY_COMMAND
   [[ "$readonly_overrides" == true ]] && printf 'INFO: readonly overrides present.\n'
   [[ "${NMKR_PHASE2_EXPECTED_SOURCE_SHA:-}" =~ ^[0-9a-fA-F]{40}$ ]] || { printf 'Expected source SHA is invalid.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-  [[ "$(git -C "$REPO_ROOT" rev-parse HEAD)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" ]] || { printf 'Source SHA mismatch.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-  [[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]] || { printf 'Source worktree is dirty.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+  git_head_and_clean "$REPO_ROOT" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || { printf 'Source worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   SOURCE_INTEGRITY="PASS"
   if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" && -z "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
     printf 'Targeted readonly requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
   fi
   if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
     DEPLOYED_INTEGRITY="FAIL"
-    git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 && [[ "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" ]] && [[ -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" status --porcelain)" ]] || { printf 'Deployed worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || { printf 'Deployed worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
     DEPLOYED_INTEGRITY="PASS"
+  fi
+  if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
+    bind_active_plugin_to_deployed_worktree || { printf 'Active plugin deployment binding failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   fi
   run_external node -e "require('@playwright/test')" >/dev/null 2>&1 || { printf 'Required Node dependencies are unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   run_external node -e "const { chromium }=require('@playwright/test'); (async()=>{const b=await chromium.launch({headless:true}); await b.close();})().catch(()=>process.exit(1))" >/dev/null 2>&1 || { printf 'Configured Chromium is unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
@@ -507,9 +542,9 @@ fi
 
 if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
   FINAL_INTEGRITY="FAIL"
-  [[ "$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" && -z "$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null)" ]] || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
+  git_head_and_clean "$REPO_ROOT" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
   if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
-    [[ "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD 2>/dev/null)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" && -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" status --porcelain 2>/dev/null)" ]] || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
+    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
   fi
   FINAL_INTEGRITY="PASS"
 fi

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -15,6 +15,7 @@ RUN_REAL_SYNC="${RUN_REAL_SYNC:-false}"
 PW_SAVE_ARTIFACTS="${PW_SAVE_ARTIFACTS:-false}"
 CALLER_PROFILE="${NMKR_PHASE2_PROFILE:-}"
 CALLER_TARGET_SUITE="${NMKR_PHASE2_TARGET_SUITE:-}"
+CALLER_RUNTIME_INTEGRITY="${NMKR_PHASE2_RUNTIME_INTEGRITY:-}"
 WP_CLI_BIN="${WP_CLI_BIN:-wp}"
 NMKR_PLUGIN_SLUG="${NMKR_PLUGIN_SLUG:-nmkr-connect/nmkr-connect.php}"
 NMKR_DEBUG_LOG_RELATIVE_PATH="${NMKR_DEBUG_LOG_RELATIVE_PATH:-wp-content/debug.log}"
@@ -362,6 +363,9 @@ fi
 if [[ -n "$CALLER_TARGET_SUITE" && "$CALLER_TARGET_SUITE" != "$NMKR_PHASE2_TARGET_SUITE" ]]; then
   printf 'Phase 2 target suite conflict.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
 fi
+if [[ -n "$CALLER_RUNTIME_INTEGRITY" && "$CALLER_RUNTIME_INTEGRITY" != "$NMKR_PHASE2_RUNTIME_INTEGRITY" ]]; then
+  printf 'Phase 2 runtime integrity conflict.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+fi
 case "$NMKR_PHASE2_PROFILE" in ''|existing-readonly|targeted-readonly) ;; *) printf 'Unknown Phase 2 profile.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1 ;; esac
 for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_INSTALL_BROWSER NMKR_PHASE2_SKIP_DEPLOY NMKR_PHASE2_RUNTIME_INTEGRITY NMKR_RETAIN_AUTH_STATE; do validate_boolean "$boolean" "${!boolean}"; done
 
@@ -386,6 +390,9 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" ==
   [[ "$(git -C "$REPO_ROOT" rev-parse HEAD)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" ]] || { printf 'Source SHA mismatch.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   [[ -z "$(git -C "$REPO_ROOT" status --porcelain)" ]] || { printf 'Source worktree is dirty.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   SOURCE_INTEGRITY="PASS"
+  if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" && -z "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
+    printf 'Targeted readonly requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+  fi
   if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
     DEPLOYED_INTEGRITY="FAIL"
     git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse --is-inside-work-tree >/dev/null 2>&1 && [[ "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD)" == "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" ]] && [[ -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" status --porcelain)" ]] || { printf 'Deployed worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
@@ -393,12 +400,6 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" ==
   fi
   run_external node -e "require('@playwright/test')" >/dev/null 2>&1 || { printf 'Required Node dependencies are unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   run_external node -e "const { chromium }=require('@playwright/test'); (async()=>{const b=await chromium.launch({headless:true}); await b.close();})().catch(()=>process.exit(1))" >/dev/null 2>&1 || { printf 'Configured Chromium is unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-  if [[ "$NMKR_PHASE2_RUNTIME_INTEGRITY" == "true" ]]; then
-    [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-    RUNTIME_INTEGRITY_STATUS="FAIL"
-    run_external "$REPO_ROOT/scripts/nmkr-ajax-runtime-integrity.sh" "$NMKR_DEPLOYED_PLUGIN_PATH" >"$RUN_DIR/runtime-integrity.log" 2>&1 || fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1
-    RUNTIME_INTEGRITY_STATUS="PASS"
-  fi
 fi
 
 case "$NMKR_PHASE2_INSTALL_DEPS" in
@@ -457,6 +458,13 @@ if [[ "$NMKR_PHASE2_INSTALL_BROWSER" == "true" ]]; then
   fi
 else
   BROWSER_STATUS="SKIPPED"
+fi
+
+if [[ "$NMKR_PHASE2_RUNTIME_INTEGRITY" == "true" ]]; then
+  [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || { printf 'Runtime integrity requires deployed plugin path.\n' >"$RUN_DIR/runtime-integrity.log"; fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1; }
+  RUNTIME_INTEGRITY_STATUS="FAIL"
+  run_external "$REPO_ROOT/scripts/nmkr-ajax-runtime-integrity.sh" "$NMKR_DEPLOYED_PLUGIN_PATH" >"$RUN_DIR/runtime-integrity.log" 2>&1 || fail_step "runtime-integrity" "$RUN_DIR/runtime-integrity.log" 1
+  RUNTIME_INTEGRITY_STATUS="PASS"
 fi
 
 WORDPRESS_READY_STATUS="FAIL"


### PR DESCRIPTION
### Motivation

- Provide a canonical pull-request validation policy and explicit guidance for selecting proportional public vs private checks. 
- Allow maintainers to validate exact-head ordinary runtime changes with a smaller targeted browser suite without running full DB/state validation. 
- Preserve strict private-run safety by enforcing readonly rules, disallowing env-file overrides, and preventing accidental real syncs or artifact leakage.

### Description

- Add `docs/validation-policy.md` and `AGENTS.md` to establish the canonical validation policy and repository safety rules. 
- Document a new `targeted-readonly` Phase 2 profile in `docs/testing-phase-2.md` and update `docs/developer-guide.md` and `docs/testing-playwright.md` to reference the validation policy. 
- Add `test:phase2:targeted-readonly` to `package.json` and extend `scripts/nmkr-phase2-test-runner.sh` to support `NMKR_PHASE2_TARGET_SUITE`, enforce an allowlist of suites, run only the selected Playwright suite, skip DB-state in this profile, support `NMKR_PHASE2_RUNTIME_INTEGRITY`, and perform final integrity rechecks and summary reporting. 
- Update the Phase 2 regression harness `scripts/nmkr-phase2-profile-regression.sh` to exercise and validate the new profile, permission/conflict checks, and summary outputs.

### Testing

- Executed the Phase 2 profile regression script `scripts/nmkr-phase2-profile-regression.sh`, which exercises the new `targeted-readonly` profile and synthetic Playwright invocation, and observed the expected assertions pass. 
- Verified preflight checks (dependency and Chromium availability), allowlist validation, and readonly-enforced overrides in the synthetic test harness. 
- Confirmed the runner prints the new summary fields (`targeted-suite`, `runtime-integrity`, `final-integrity`) and that `test:phase2:targeted-readonly` maps to the intended targeted `test:e2e:*` script during synthetic runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7c286a4d2083339f75054cc01660b7)