### PR TITLE
Introduce unified Phase 2 operator mode (pre/post-merge)

### DIFF
--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -2,7 +2,7 @@
 
 The [validation policy](validation-policy.md) determines when to use full or targeted private validation. Phase 2 orchestrates validation of a deployed NMKR Connect installation from a private, user-owned checkout. For Playwright-only guidance and the current coverage map, see [`testing-playwright.md`](testing-playwright.md).
 
-The runner combines optional deployment, dependency/browser preparation, WordPress readiness, the complete Playwright suite, WP-CLI smoke checks, and WP-CLI database-state checks. It does not change the implementations of those checks, and real NMKR synchronization remains outside this workflow.
+The runner combines optional deployment, dependency/browser preparation, WordPress readiness, the complete Playwright suite, WP-CLI smoke checks, and WP-CLI database-state checks. WP-CLI smoke reports recent third-party `vendor/` PHP warnings/notices generically without blocking; fatal/parse errors, NMKR errors, first-party warnings/notices, and unclassifiable warnings/notices remain blocking. It does not change the implementations of those checks, and real NMKR synchronization remains outside this workflow.
 
 ## Private inputs and external state
 

--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -124,3 +124,43 @@ The console does **not** print the private run-directory path. On failure it add
 ## Safety boundary
 
 Keep `RUN_REAL_SYNC=false`. Neither the Playwright route simulations nor Phase 2 orchestration executes a real NMKR synchronization. Do not commit `.env.tests`, populated environment files, private state directories, reports, test output, authentication state, screenshots, traces, videos, or logs.
+
+## Unified pre/post-merge operator workflow
+
+Private operators can select the complete exact-head workflow without rebuilding an environment-variable prefix:
+
+```bash
+npm run test:phase2 -- \
+  --stage pre-merge \
+  --class ordinary-runtime \
+  --profile targeted-readonly \
+  --reviewed-sha <reviewed-40-character-sha> \
+  --deployed-sha <deployed-40-character-sha> \
+  --target-suite <allowlisted-suite> \
+  --deploy-mode skip \
+  --runtime-integrity false
+```
+
+All eight options are required in operator mode. Unknown, duplicate, missing, malformed, or conflicting selections fail closed. The arguments are captured before the owner-private environment file is sourced; that file cannot replace or clear them. Operator mode always forces `RUN_REAL_SYNC=false`, `PW_SAVE_ARTIFACTS=false`, `NMKR_PHASE2_INSTALL_DEPS=false`, and `NMKR_PHASE2_INSTALL_BROWSER=false`.
+
+Use `targeted-readonly` with exactly one existing allowlisted package suite, or `existing-readonly` for full Playwright plus WP-CLI smoke and DB-state. `docs-metadata` is rejected before private inputs are used and belongs in public CI. `test-tooling` is appropriate only for an explicit private run when tooling changes private orchestration or runtime semantics. `ordinary-runtime` normally uses targeted readonly; selecting the full profile is an explicit escalation. `high-risk` requires the full profile. Privileged AJAX authorization validation remains separate under `npm run test:ajax-security`.
+
+For pre-merge validation, the reviewed and deployed SHAs must be equal, and both source and deployed worktrees must be clean at that exact commit. For post-merge validation, source and deployed HEAD must equal the merged/deployed SHA, while Git tree objects for the reviewed and merged commits must be identical. The runner resolves already-local commits only; it does not fetch, switch, or alter branches. Failure to resolve either commit or prove tree equality requires deeper review and validation.
+
+`--deploy-mode run` checks the clean source first, executes the private `NMKR_DEPLOY_COMMAND` exactly once with output captured privately, and then requires exact deployed identity, cleanliness, and active-plugin binding before runtime checks. `--deploy-mode skip` never executes that command and applies the same checks to the existing deployment. The runner does not clone, fetch, check out, copy files, install Composer dependencies, or roll back. If deployment succeeds and a later check fails, the summary reports deployment status and `rollback: NOT_ATTEMPTED`; the validated private rollback procedure remains the operator's responsibility.
+
+A post-merge invocation changes the stage and identities, for example:
+
+```bash
+npm run test:phase2 -- \
+  --stage post-merge \
+  --class high-risk \
+  --profile existing-readonly \
+  --reviewed-sha <reviewed-40-character-sha> \
+  --deployed-sha <merged-main-40-character-sha> \
+  --target-suite <allowlisted-suite> \
+  --deploy-mode run \
+  --runtime-integrity true
+```
+
+The existing environment-only `test:phase2`, `test:phase2:targeted-readonly`, and `test:phase2:existing-readonly` entry points remain supported with their existing semantics.

--- a/docs/validation-policy.md
+++ b/docs/validation-policy.md
@@ -41,7 +41,7 @@ Investigate the smallest failing stage and inspect private diagnostics only in t
 
 ### Third-party vendor warnings
 
-A fresh warning attributable only to third-party vendor code may be reported as non-blocking when dependency/runtime-integrity files did not change, runtime integrity passes where applicable, and relevant functional/state validation passes. It must be reported and must not be silently ignored. It is blocking when dependency, build, or deployment state changed, another relevant validation failed, its origin is ambiguous, or it is fatal, parse, or uncaught severity. The current log classifier remains fail-closed; this policy permits a documented maintainer disposition after private inspection rather than automatic suppression.
+A fresh PHP warning or notice with a conventional source location classified inside a `vendor/` path segment is surfaced generically by WP-CLI smoke but does not block validation. Fatal and parse errors remain blocking regardless of origin, as do NMKR fatal/error/exception diagnostics, first-party warnings/notices, and warnings/notices whose source cannot be safely classified. The classifier remains fail-closed for ambiguous diagnostics and never prints log content or source paths.
 
 ## Follow-up commits and review invalidation
 

--- a/docs/validation-policy.md
+++ b/docs/validation-policy.md
@@ -61,3 +61,20 @@ Use this host-neutral contract for deployment-integrity validation:
 6. Run the runtime-integrity gate once before affected functional validation.
 
 Host-specific paths, domains, credentials, and deployment commands belong only in approved private configuration and must not be committed or printed.
+
+## Unified Phase 2 operator contract
+
+The opt-in operator form is `npm run test:phase2 -- --stage <pre-merge|post-merge> --class <class> --profile <profile> --reviewed-sha <sha> --deployed-sha <sha> --target-suite <suite> --deploy-mode <run|skip> --runtime-integrity <true|false>`. Every selection is explicit; no profile is inferred. The compatibility matrix is:
+
+| Validation class | Operator profile |
+| --- | --- |
+| `docs-metadata` | Not applicable: reject before private inputs and use public CI. |
+| `test-tooling` | Targeted or full readonly only for explicitly required private orchestration/runtime-semantic validation. Public-only tooling remains CI-only. |
+| `ordinary-runtime` | `targeted-readonly` normally; `existing-readonly` only as an explicit escalation. |
+| `high-risk` | `existing-readonly`, including full Playwright, WP-CLI smoke, and DB-state. |
+
+Pre-merge requires reviewed SHA = deployed SHA, source HEAD = reviewed SHA, and deployed HEAD = deployed SHA. Post-merge requires both source and deployed HEAD at the deployed merged-main SHA and identical source-repository Git tree objects for reviewed and deployed commits. Unresolvable or unequal trees invalidate reviewed-tree equivalence and require deeper review/validation.
+
+Deployment `run` verifies source integrity before executing the opaque private command once, then verifies deployed identity, cleanliness, and WordPress active-plugin binding. Deployment `skip` does not execute it and verifies the existing deployment to the same standard. Both choices enter readonly functional validation with real synchronization, artifact saving, dependency installation, and browser installation disabled. Runtime integrity, when selected, runs once before readiness; targeted runs one allowlisted suite and smoke without DB-state, while full runs all Playwright, smoke, and DB-state. Separate source and deployed expectations are checked again at final integrity.
+
+No automatic rollback is attempted. A successful deployment followed by failure is reported publicly as `deploy: PASS`, `result: FAIL`, and `rollback: NOT_ATTEMPTED`; diagnosis and the validated private rollback procedure remain owner responsibilities. Existing environment-only Phase 2 commands remain backward compatible. The specialized restricted-account AJAX security runner stays separate and its credentials are not Phase 2 inputs.

--- a/scripts/nmkr-debug-log-classifier.py
+++ b/scripts/nmkr-debug-log-classifier.py
@@ -8,10 +8,16 @@ import datetime as dt
 import os
 import re
 import sys
-ERROR_PATTERN = re.compile(
-    r"PHP (?:Fatal error|Parse error|Warning|Notice)|NMKR.*(?:Fatal|Error|Exception)",
+
+BLOCKING_PATTERN = re.compile(
+    r"PHP (?:Fatal error|Parse error)|NMKR.*(?:Fatal|Error|Exception)",
     re.IGNORECASE,
 )
+WARNING_NOTICE_PATTERN = re.compile(r"PHP (?:Warning|Notice)", re.IGNORECASE)
+SOURCE_LOCATION_PATTERN = re.compile(
+    r"\bin\s+(.+?)\s+on line\s+\d+\s*$", re.IGNORECASE
+)
+VENDOR_SEGMENT_PATTERN = re.compile(r"(?:^|/)vendor(?:/|$)", re.IGNORECASE)
 TIMESTAMP_PATTERN = re.compile(r"^\[([^]]+)]")
 TIMESTAMP_FORMATS = (
     "%d-%b-%Y %H:%M:%S %Z",
@@ -38,7 +44,22 @@ def parse_timestamp(line: str) -> dt.datetime | None:
     return None
 
 
-def has_failing_match(path: str, lookback_minutes: int, now: dt.datetime) -> bool:
+def is_qualifying(line: str, cutoff: dt.datetime, file_is_recent: bool) -> bool:
+    timestamp = parse_timestamp(line)
+    if timestamp is None:
+        return file_is_recent
+    return timestamp >= cutoff
+
+
+def is_vendor_warning_or_notice(line: str) -> bool:
+    location = SOURCE_LOCATION_PATTERN.search(line)
+    if location is None:
+        return False
+    normalized_path = location.group(1).strip().replace("\\", "/")
+    return VENDOR_SEGMENT_PATTERN.search(normalized_path) is not None
+
+
+def classify_matches(path: str, lookback_minutes: int, now: dt.datetime) -> int:
     cutoff = now - dt.timedelta(minutes=lookback_minutes)
     file_is_recent = dt.datetime.fromtimestamp(
         os.stat(path, follow_symlinks=False).st_mtime, dt.timezone.utc
@@ -46,16 +67,18 @@ def has_failing_match(path: str, lookback_minutes: int, now: dt.datetime) -> boo
 
     lines = tail_lines(path, 300)
 
+    vendor_diagnostic = False
     for line in lines:
-        if ERROR_PATTERN.search(line) is None:
+        blocking = BLOCKING_PATTERN.search(line) is not None
+        warning_or_notice = WARNING_NOTICE_PATTERN.search(line) is not None
+        if not blocking and not warning_or_notice:
             continue
-        timestamp = parse_timestamp(line)
-        if timestamp is None:
-            if file_is_recent:
-                return True
-        elif timestamp >= cutoff:
-            return True
-    return False
+        if not is_qualifying(line, cutoff, file_is_recent):
+            continue
+        if blocking or not is_vendor_warning_or_notice(line):
+            return 1
+        vendor_diagnostic = True
+    return 3 if vendor_diagnostic else 0
 
 
 def tail_lines(path: str, limit: int) -> list[str]:
@@ -92,10 +115,8 @@ def main() -> int:
         return 2
 
     try:
-        return int(
-            has_failing_match(
-                args.path, args.lookback_minutes, dt.datetime.now(dt.timezone.utc)
-            )
+        return classify_matches(
+            args.path, args.lookback_minutes, dt.datetime.now(dt.timezone.utc)
         )
     except (OSError, OverflowError, ValueError):
         return 2

--- a/scripts/nmkr-debug-log-classifier.py
+++ b/scripts/nmkr-debug-log-classifier.py
@@ -15,7 +15,7 @@ BLOCKING_PATTERN = re.compile(
 )
 WARNING_NOTICE_PATTERN = re.compile(r"PHP (?:Warning|Notice)", re.IGNORECASE)
 SOURCE_LOCATION_PATTERN = re.compile(
-    r"\bin\s+(.+?)\s+on line\s+\d+\s*$", re.IGNORECASE
+    r"\bin\s+(.+?)\s+on line\s+\d+", re.IGNORECASE
 )
 VENDOR_SEGMENT_PATTERN = re.compile(r"(?:^|/)vendor(?:/|$)", re.IGNORECASE)
 TIMESTAMP_PATTERN = re.compile(r"^\[([^]]+)]")
@@ -52,10 +52,10 @@ def is_qualifying(line: str, cutoff: dt.datetime, file_is_recent: bool) -> bool:
 
 
 def is_vendor_warning_or_notice(line: str) -> bool:
-    location = SOURCE_LOCATION_PATTERN.search(line)
-    if location is None:
+    locations = SOURCE_LOCATION_PATTERN.findall(line)
+    if len(locations) != 1:
         return False
-    normalized_path = location.group(1).strip().replace("\\", "/")
+    normalized_path = locations[0].strip().replace("\\", "/")
     return VENDOR_SEGMENT_PATTERN.search(normalized_path) is not None
 
 

--- a/scripts/nmkr-debug-log-regression.sh
+++ b/scripts/nmkr-debug-log-regression.sh
@@ -35,10 +35,19 @@ fresh="$(timestamp -1)"
 printf '[%s] PHP Warning: SYNTHETIC_PRIVATE_MARKER_OLD\n[%s] benign entry\n' "$old" "$fresh" >"$FIXTURE_ROOT/old.log"
 run_case 0 "$FIXTURE_ROOT/old.log"
 
-printf '[%s] PHP Warning: SYNTHETIC_PRIVATE_MARKER_WARNING\n' "$fresh" >"$FIXTURE_ROOT/warning.log"
+printf '[%s] PHP Warning: SYNTHETIC_FIRST_PARTY_WARNING in /synthetic/plugin/includes/check.php on line 12\n' "$fresh" >"$FIXTURE_ROOT/warning.log"
 run_case 1 "$FIXTURE_ROOT/warning.log"
 
-printf '[%s] PHP Fatal error: SYNTHETIC_PRIVATE_MARKER_FATAL\n' "$fresh" >"$FIXTURE_ROOT/fatal.log"
+printf '[%s] PHP Notice: SYNTHETIC_UNCLASSIFIED_NOTICE\n' "$fresh" >"$FIXTURE_ROOT/unclassified-notice.log"
+run_case 1 "$FIXTURE_ROOT/unclassified-notice.log"
+
+printf '[%s] PHP Warning: SYNTHETIC_VENDOR_WARNING in /synthetic/plugin/vendor/package/check.php on line 34\n' "$fresh" >"$FIXTURE_ROOT/vendor-warning.log"
+run_case 3 "$FIXTURE_ROOT/vendor-warning.log"
+
+printf '[%s] PHP Notice: SYNTHETIC_VENDOR_NOTICE in C:\\synthetic\\plugin\\vendor\\package\\check.php on line 56\n' "$fresh" >"$FIXTURE_ROOT/vendor-notice.log"
+run_case 3 "$FIXTURE_ROOT/vendor-notice.log"
+
+printf '[%s] PHP Fatal error: SYNTHETIC_VENDOR_FATAL in /synthetic/plugin/vendor/package/check.php on line 78\n' "$fresh" >"$FIXTURE_ROOT/fatal.log"
 run_case 1 "$FIXTURE_ROOT/fatal.log"
 
 printf '[%s] NMKR Error: SYNTHETIC_PRIVATE_MARKER_NMKR\n' "$fresh" >"$FIXTURE_ROOT/nmkr.log"
@@ -46,6 +55,9 @@ run_case 1 "$FIXTURE_ROOT/nmkr.log"
 
 printf 'PHP Notice: SYNTHETIC_PRIVATE_MARKER_UNCLASSIFIED\n' >"$FIXTURE_ROOT/unclassified.log"
 run_case 1 "$FIXTURE_ROOT/unclassified.log"
+
+printf '[%s] PHP Warning: SYNTHETIC_VENDOR_MIXED in /synthetic/plugin/vendor/package/check.php on line 90\n[%s] PHP Warning: SYNTHETIC_FIRST_PARTY_MIXED in /synthetic/plugin/includes/check.php on line 91\n' "$fresh" "$fresh" >"$FIXTURE_ROOT/mixed.log"
+run_case 1 "$FIXTURE_ROOT/mixed.log"
 
 printf '[%s] PHP Warning: SYNTHETIC_PRIVATE_MARKER_OUTSIDE_TAIL\n' "$fresh" >"$FIXTURE_ROOT/tail.log"
 for i in $(seq 1 300); do printf '[%s] benign tail entry %s\n' "$fresh" "$i"; done >>"$FIXTURE_ROOT/tail.log"

--- a/scripts/nmkr-debug-log-regression.sh
+++ b/scripts/nmkr-debug-log-regression.sh
@@ -47,6 +47,12 @@ run_case 3 "$FIXTURE_ROOT/vendor-warning.log"
 printf '[%s] PHP Notice: SYNTHETIC_VENDOR_NOTICE in C:\\synthetic\\plugin\\vendor\\package\\check.php on line 56\n' "$fresh" >"$FIXTURE_ROOT/vendor-notice.log"
 run_case 3 "$FIXTURE_ROOT/vendor-notice.log"
 
+printf '[%s] PHP Warning: SYNTHETIC_AMBIGUOUS_FIRST_PARTY prior location in /synthetic/plugin/vendor/package/check.php on line 57 final location in /synthetic/plugin/includes/check.php on line 58\n' "$fresh" >"$FIXTURE_ROOT/ambiguous-first-party.log"
+run_case 1 "$FIXTURE_ROOT/ambiguous-first-party.log"
+
+printf '[%s] PHP Notice: SYNTHETIC_AMBIGUOUS_VENDOR prior location in /synthetic/plugin/includes/check.php on line 59 final location in /synthetic/plugin/vendor/package/check.php on line 60\n' "$fresh" >"$FIXTURE_ROOT/ambiguous-vendor.log"
+run_case 1 "$FIXTURE_ROOT/ambiguous-vendor.log"
+
 printf '[%s] PHP Fatal error: SYNTHETIC_VENDOR_FATAL in /synthetic/plugin/vendor/package/check.php on line 78\n' "$fresh" >"$FIXTURE_ROOT/fatal.log"
 run_case 1 "$FIXTURE_ROOT/fatal.log"
 

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -411,6 +411,7 @@ source_failure_env="$tmp_dir/source-failure.env"
 cat >"$source_failure_env" <<EOF_SOURCE_FAILURE
 printf '%s\\n' '$source_secret'
 false
+SOURCE_ASSIGNMENT_AFTER_FAILURE=present
 EOF_SOURCE_FAILURE
 chmod 600 "$source_failure_env"
 source_failure_count="$tmp_dir/source-failure-deploy-count"
@@ -419,8 +420,11 @@ source_failure_output="$tmp_dir/source-failure.output"
 if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE TMPDIR="$source_tmp" NMKR_PHASE2_ENV_FILE="$source_failure_env" NMKR_DEPLOY_COMMAND="printf 'call\\n' >>'$source_failure_count'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$source_failure_output" 2>&1; then exit 1; fi
 test ! -e "$source_failure_count"
 grep -Fx 'ERROR: Phase 2 private configuration could not be loaded.' "$source_failure_output" >/dev/null
+test "$(wc -l <"$source_failure_output")" = 1
 ! grep -F "$source_secret" "$source_failure_output" >/dev/null
+! grep -E 'line [0-9]+|false|SOURCE_ASSIGNMENT_AFTER_FAILURE|present' "$source_failure_output" >/dev/null
 ! find "$target_fixture" "$deployed_fixture" "$tmp_dir/wp" "$artifact_fixture" "$source_tmp" -type f -exec grep -Fl -- "$source_secret" {} + | grep . >/dev/null
+! find "$target_fixture" "$deployed_fixture" "$tmp_dir/wp" "$artifact_fixture" "$source_tmp" -type f -exec grep -El -- 'SOURCE_ASSIGNMENT_AFTER_FAILURE|present' {} + | grep . >/dev/null
 test -z "$(find "$source_tmp" -mindepth 1 -print -quit)"
 ! grep -E '^run test:e2e|wp .*nmkr-wpcli-(smoke|db-state)' "$target_log" >/dev/null
 
@@ -438,6 +442,18 @@ grep -Fx 'ERROR: Phase 2 private configuration could not be loaded.' "$protected
 ! grep -F "$(basename "$target_env")" "$protected_output" >/dev/null
 ! grep -E 'line [0-9]+|CLI_STAGE=|readonly variable' "$protected_output" >/dev/null
 ! grep -E '^run test:e2e|wp .*nmkr-wpcli-(smoke|db-state)' "$target_log" >/dev/null
+: >"$target_env"
+
+# Failures explicitly handled by the private configuration retain Bash's
+# normal semantics and do not incorrectly abort an otherwise valid load.
+cat >"$target_env" <<'EOF_HANDLED_SOURCE_FAILURE'
+false || true
+HANDLED_SOURCE_VALUE=present
+EOF_HANDLED_SOURCE_FAILURE
+: >"$target_log"
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$tmp_dir/handled-source-failure.output"
+grep -F 'result: PASS' "$tmp_dir/handled-source-failure.output" >/dev/null
+grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
 : >"$target_env"
 
 deploy_count="$tmp_dir/operator-deploy-count"

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -399,6 +399,31 @@ grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
 grep -F 'safety RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false' "$target_log" >/dev/null
 : >"$target_env"
 
+# Caller-controlled TMPDIR may point inside the checkout or an artifact-like
+# directory, but private source output is never persisted there. A unique
+# marker emitted before failure stays off-console and out of every public or
+# collected fixture, and no deployment or functional command is reached.
+source_tmp="$target_fixture/source-tmp"
+artifact_fixture="$tmp_dir/artifact-fixture"
+mkdir -p "$source_tmp" "$artifact_fixture"
+source_secret='SYNTHETIC_SOURCE_SECRET_4f9c3d8a'
+source_failure_env="$tmp_dir/source-failure.env"
+cat >"$source_failure_env" <<EOF_SOURCE_FAILURE
+printf '%s\\n' '$source_secret'
+false
+EOF_SOURCE_FAILURE
+chmod 600 "$source_failure_env"
+source_failure_count="$tmp_dir/source-failure-deploy-count"
+source_failure_output="$tmp_dir/source-failure.output"
+: >"$target_log"
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE TMPDIR="$source_tmp" NMKR_PHASE2_ENV_FILE="$source_failure_env" NMKR_DEPLOY_COMMAND="printf 'call\\n' >>'$source_failure_count'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$source_failure_output" 2>&1; then exit 1; fi
+test ! -e "$source_failure_count"
+grep -Fx 'ERROR: Phase 2 private configuration could not be loaded.' "$source_failure_output" >/dev/null
+! grep -F "$source_secret" "$source_failure_output" >/dev/null
+! find "$target_fixture" "$deployed_fixture" "$tmp_dir/wp" "$artifact_fixture" "$source_tmp" -type f -exec grep -Fl -- "$source_secret" {} + | grep . >/dev/null
+test -z "$(find "$source_tmp" -mindepth 1 -print -quit)"
+! grep -E '^run test:e2e|wp .*nmkr-wpcli-(smoke|db-state)' "$target_log" >/dev/null
+
 # Attempts to assign the protected internal namespace fail closed while the
 # private file is sourced, before deployment or functional validation, without
 # exposing any part of the private source diagnostic.

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -81,6 +81,21 @@ mkdir -p "$synthetic_home" "$synthetic_tmp"
 chmod 700 "$synthetic_home" "$synthetic_tmp"
 base=(env -i PATH="$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" WP_BASE_URL=http://invalid.test WP_ADMIN_USER=placeholder WP_ADMIN_PASSWORD=placeholder WP_CLI_BIN=true WP_PATH="$tmp_dir/wp" NMKR_PHASE2_LOG_DIR="$tmp_dir/private" NMKR_PHASE2_ENV_FILE="$synthetic_env" NMKR_PHASE2_PROFILE= RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false NMKR_RETAIN_AUTH_STATE=false NMKR_PHASE2_INSTALL_DEPS=false NMKR_PHASE2_INSTALL_BROWSER=false NMKR_PHASE2_SKIP_DEPLOY=true)
 
+# Operator syntax is fail-closed before private preflight. Docs/metadata is a
+# public-CI-only class and must reject before even sourcing a configured file.
+operator_sha=0123456789abcdef0123456789abcdef01234567
+operator_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$operator_sha" --deployed-sha "$operator_sha" --target-suite settings --deploy-mode skip --runtime-integrity false)
+for bad_args in '--unknown value' '--stage' '--stage pre-merge --stage pre-merge' '--stage invalid'; do
+  read -r -a bad <<<"$bad_args"
+  if env -i PATH="$safe_path" HOME="$synthetic_home" bash "$runner" "${bad[@]}" >/dev/null 2>&1; then exit 1; fi
+done
+if env -i PATH="$safe_path" HOME="$synthetic_home" bash "$runner" "${operator_args[@]/test-tooling/high-risk}" >/dev/null 2>&1; then exit 1; fi
+docs_env="$tmp_dir/docs-private.env"
+printf 'touch "%s"\n' "$tmp_dir/docs-env-loaded" >"$docs_env"
+if env -i PATH="$safe_path" HOME="$synthetic_home" NMKR_PHASE2_ENV_FILE="$docs_env" bash "$runner" "${operator_args[@]/test-tooling/docs-metadata}" >"$tmp_dir/docs-rejection.output" 2>&1; then exit 1; fi
+grep -F 'use public CI' "$tmp_dir/docs-rejection.output" >/dev/null
+test ! -e "$tmp_dir/docs-env-loaded"
+
 # Exercise asdf-style shims without requiring asdf in CI. The child starts
 # with only shim entries for Node tools and a minimal fake `asdf which`; the
 # resolver must replace them with the caller's actual executable directories
@@ -330,6 +345,61 @@ grep -F 'db-state: SKIPPED' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'source-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'deployed-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'final-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
+
+# Unified operator mode preserves every explicit selection across env sourcing,
+# validates exact pre-merge identity, and keeps deployment invocation opaque.
+operator_target_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha "$target_sha" --target-suite settings --deploy-mode skip --runtime-integrity false)
+: >"$target_log"
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$tmp_dir/operator-target.output"
+grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
+grep -F 'stage: pre-merge' "$tmp_dir/operator-target.output" >/dev/null
+grep -F 'rollback: NOT_ATTEMPTED' "$tmp_dir/operator-target.output" >/dev/null
+
+mismatch_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha 0123456789abcdef0123456789abcdef01234567 --target-suite settings --deploy-mode skip --runtime-integrity false)
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${mismatch_args[@]}" >/dev/null 2>&1; then exit 1; fi
+
+# Every explicit operator selection conflicts rather than being replaced or
+# downgraded by the sourced environment file.
+operator_env_names=(NMKR_PHASE2_STAGE NMKR_PHASE2_VALIDATION_CLASS NMKR_PHASE2_PROFILE NMKR_PHASE2_REVIEWED_SHA NMKR_PHASE2_DEPLOYED_SHA NMKR_PHASE2_TARGET_SUITE NMKR_PHASE2_DEPLOY_MODE NMKR_PHASE2_RUNTIME_INTEGRITY)
+for env_name in "${operator_env_names[@]}"; do
+  printf '%s=conflict\n' "$env_name" >"$target_env"
+  if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$tmp_dir/operator-conflict.output" 2>&1; then exit 1; fi
+  grep -F 'operator selection conflicts' "$tmp_dir/operator-conflict.output" >/dev/null
+done
+: >"$target_env"
+
+deploy_count="$tmp_dir/operator-deploy-count"
+deploy_command="printf 'call\\n' >>'$deploy_count'"
+run_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha "$target_sha" --target-suite settings --deploy-mode run --runtime-integrity false)
+: >"$target_log"
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="$deploy_command" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${run_args[@]}" >"$tmp_dir/operator-deploy.output"
+test "$(wc -l <"$deploy_count")" = 1
+grep -F 'deploy: PASS' "$tmp_dir/operator-deploy.output" >/dev/null
+! grep -F "$deploy_command" "$tmp_dir/operator-deploy.output" >/dev/null
+rm -f "$deploy_count"
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="$deploy_command" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >/dev/null
+test ! -e "$deploy_count"
+
+# Post-merge accepts distinct commits only when their source-tree objects are
+# identical; missing reviewed commits and different trees fail closed.
+git -C "$target_fixture" commit --allow-empty -q -m 'synthetic merged equivalent tree'
+merged_sha="$(git -C "$target_fixture" rev-parse HEAD)"
+git -C "$deployed_fixture" fetch -q "$target_fixture" "$merged_sha"
+git -C "$deployed_fixture" reset --hard -q "$merged_sha"
+post_args=(--stage post-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha "$merged_sha" --target-suite settings --deploy-mode skip --runtime-integrity false)
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${post_args[@]}" >"$tmp_dir/operator-post.output"
+grep -F 'reviewed-tree-equivalence: PASS' "$tmp_dir/operator-post.output" >/dev/null
+missing_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${post_args[@]/$target_sha/$missing_sha}" >/dev/null 2>&1; then exit 1; fi
+printf '\nchanged-tree\n' >>"$target_fixture/README.md"
+git -C "$target_fixture" add README.md
+git -C "$target_fixture" commit -q -m 'synthetic merged different tree'
+different_sha="$(git -C "$target_fixture" rev-parse HEAD)"
+git -C "$deployed_fixture" fetch -q "$target_fixture" "$different_sha"
+git -C "$deployed_fixture" reset --hard -q "$different_sha"
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${post_args[@]/$merged_sha/$different_sha}" >/dev/null 2>&1; then exit 1; fi
+git -C "$target_fixture" reset --hard -q "$target_sha"
+git -C "$deployed_fixture" reset --hard -q "$target_sha"
 
 # Targeted readonly requires deployment identity, while existing readonly keeps
 # accepting an omitted deployed path. General runtime integrity runs only after

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -261,6 +261,23 @@ cat >"$target_fixture/scripts/nmkr-ajax-runtime-integrity.sh" <<'EOF_RUNTIME_INT
 printf 'runtime-integrity\n' >>"$RUNTIME_INTEGRITY_CALL_LOG"
 EOF_RUNTIME_INTEGRITY
 chmod 700 "$target_fixture/scripts/nmkr-ajax-runtime-integrity.sh"
+for phase2_child in nmkr-wpcli-smoke nmkr-wpcli-db-state; do
+  mv "$target_fixture/scripts/$phase2_child.sh" "$target_fixture/scripts/$phase2_child.real.sh"
+  cat >"$target_fixture/scripts/$phase2_child.sh" <<'EOF_PHASE2_CHILD'
+#!/usr/bin/env bash
+set -Eeuo pipefail
+if [[ "${ASSERT_REQUIRED_CHILD_ENV:-false}" != true ]]; then
+  exec "${BASH_SOURCE[0]%.sh}.real.sh" "$@"
+fi
+[[ "${WP_BASE_URL:-}" == 'https://phase2.invalid' ]]
+[[ "${WP_ADMIN_USER:-}" == 'phase2-user-marker' ]]
+[[ "${WP_ADMIN_PASSWORD:-}" == 'phase2-password-marker' ]]
+[[ "${WP_PATH:-}" == '/phase2-wp-path-marker' ]]
+"$WP_CLI_BIN" "--path=$WP_PATH" core is-installed >/dev/null
+printf '%s required-child-env PASS\n' "${BASH_SOURCE[0]##*/}" >>"$TARGET_CALL_LOG"
+EOF_PHASE2_CHILD
+  chmod 700 "$target_fixture/scripts/$phase2_child.sh"
+done
 git -C "$target_fixture" add AGENTS.md docs package.json scripts
 git -C "$target_fixture" commit --allow-empty -q -m 'synthetic targeted profile fixture'
 target_sha="$(git -C "$target_fixture" rev-parse HEAD)"
@@ -288,6 +305,13 @@ exit 0
 EOF_NODE
 cat >"$target_bin/npm" <<'EOF_NPM'
 #!/usr/bin/env bash
+if [[ "${ASSERT_REQUIRED_CHILD_ENV:-false}" == true ]]; then
+  [[ "${WP_BASE_URL:-}" == 'https://phase2.invalid' ]]
+  [[ "${WP_ADMIN_USER:-}" == 'phase2-user-marker' ]]
+  [[ "${WP_ADMIN_PASSWORD:-}" == 'phase2-password-marker' ]]
+  [[ "${WP_PATH:-}" == '/phase2-wp-path-marker' ]]
+  printf 'required-child-env PASS\n' >>"$TARGET_CALL_LOG"
+fi
 printf '%s\n' "$*" >>"$TARGET_CALL_LOG"
 printf 'safety RUN_REAL_SYNC=%s PW_SAVE_ARTIFACTS=%s\n' "${RUN_REAL_SYNC:-unset}" "${PW_SAVE_ARTIFACTS:-unset}" >>"$TARGET_CALL_LOG"
 if [[ "${TARGET_DIRTY_AFTER_PLAYWRIGHT:-false}" == true && "$*" == 'run test:e2e:settings' ]]; then
@@ -308,6 +332,14 @@ exit 0
 EOF_NPM
 cat >"$target_bin/wp" <<'EOF_WP'
 #!/usr/bin/env bash
+if [[ "${ASSERT_REQUIRED_CHILD_ENV:-false}" == true ]]; then
+  [[ "${WP_BASE_URL:-}" == 'https://phase2.invalid' ]]
+  [[ "${WP_ADMIN_USER:-}" == 'phase2-user-marker' ]]
+  [[ "${WP_ADMIN_PASSWORD:-}" == 'phase2-password-marker' ]]
+  [[ "${WP_PATH:-}" == '/phase2-wp-path-marker' ]]
+  [[ "$*" == *'--path=/phase2-wp-path-marker'* ]]
+  printf 'required-child-env PASS\n' >>"$TARGET_CALL_LOG"
+fi
 printf 'wp %s\n' "$*" >>"$TARGET_CALL_LOG"
 case "$*" in
   *' eval '*)
@@ -347,6 +379,37 @@ grep -F 'db-state: SKIPPED' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'source-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'deployed-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 grep -F 'final-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
+
+# Required Phase 2 values may be ordinary, non-exported private-file
+# assignments. Playwright, WP-CLI smoke, and DB-state children must receive the
+# fixed synthetic markers, and WP-CLI must use the configured path rather than
+# falling back to the repository checkout.
+plain_assignment_env="$tmp_dir/plain-assignment.env"
+cat >"$plain_assignment_env" <<EOF_PLAIN_ASSIGNMENTS
+WP_BASE_URL=https://phase2.invalid
+WP_ADMIN_USER=phase2-user-marker
+WP_ADMIN_PASSWORD=phase2-password-marker
+WP_PATH=/phase2-wp-path-marker
+WP_CLI_BIN=$(printf '%q' "$target_bin/wp")
+NMKR_PLUGIN_SLUG=nmkr-connect.php
+NMKR_PHASE2_LOG_DIR=$(printf '%q' "$target_private")
+NMKR_DEPLOYED_PLUGIN_PATH=$(printf '%q' "$deployed_fixture")
+NMKR_PHASE2_INSTALL_DEPS=false
+NMKR_PHASE2_INSTALL_BROWSER=false
+RUN_REAL_SYNC=false
+PW_SAVE_ARTIFACTS=false
+NMKR_RETAIN_AUTH_STATE=false
+EOF_PLAIN_ASSIGNMENTS
+chmod 600 "$plain_assignment_env"
+plain_assignment_args=(--stage pre-merge --class high-risk --profile existing-readonly --reviewed-sha "$target_sha" --deployed-sha "$target_sha" --target-suite settings --deploy-mode skip --runtime-integrity false)
+: >"$target_log"
+env -i PATH="$target_bin:$safe_path" HOME="$synthetic_home" TMPDIR="$synthetic_tmp" REAL_GIT="$real_git" TARGET_CALL_LOG="$target_log" TARGET_REPO="$target_fixture" TARGET_DEPLOYED_REPO="$deployed_fixture" TARGET_ACTIVE_PLUGIN_FILE="$deployed_fixture/nmkr-connect.php" RUNTIME_INTEGRITY_CALL_LOG="$runtime_integrity_log" GIT_STATUS_COUNTER_DIR="$git_counter_dir" ASSERT_REQUIRED_CHILD_ENV=true NMKR_PHASE2_ENV_FILE="$plain_assignment_env" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${plain_assignment_args[@]}" >"$tmp_dir/plain-assignment.output"
+grep -F 'result: PASS' "$tmp_dir/plain-assignment.output" >/dev/null
+grep -Fx 'run test:e2e' "$target_log" >/dev/null
+grep -Fx 'nmkr-wpcli-smoke.sh required-child-env PASS' "$target_log" >/dev/null
+grep -Fx 'nmkr-wpcli-db-state.sh required-child-env PASS' "$target_log" >/dev/null
+grep -Fx 'required-child-env PASS' "$target_log" >/dev/null
+! grep -F -- "--path=$target_fixture" "$target_log" >/dev/null
 
 # Unified operator mode preserves every explicit selection across env sourcing,
 # validates exact pre-merge identity, and keeps deployment invocation opaque.

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -400,11 +400,19 @@ grep -F 'safety RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false' "$target_log" >/dev
 : >"$target_env"
 
 # Attempts to assign the protected internal namespace fail closed while the
-# private file is sourced, before deployment or functional validation.
+# private file is sourced, before deployment or functional validation, without
+# exposing any part of the private source diagnostic.
 printf 'CLI_STAGE=post-merge\n' >"$target_env"
 protected_state_count="$tmp_dir/protected-state-deploy-count"
-if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="printf 'call\\n' >>'$protected_state_count'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >/dev/null 2>&1; then exit 1; fi
+protected_output="$tmp_dir/protected-state.output"
+: >"$target_log"
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="printf 'call\\n' >>'$protected_state_count'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$protected_output" 2>&1; then exit 1; fi
 test ! -e "$protected_state_count"
+grep -Fx 'ERROR: Phase 2 private configuration could not be loaded.' "$protected_output" >/dev/null
+! grep -F "$target_env" "$protected_output" >/dev/null
+! grep -F "$(basename "$target_env")" "$protected_output" >/dev/null
+! grep -E 'line [0-9]+|CLI_STAGE=|readonly variable' "$protected_output" >/dev/null
+! grep -E '^run test:e2e|wp .*nmkr-wpcli-(smoke|db-state)' "$target_log" >/dev/null
 : >"$target_env"
 
 deploy_count="$tmp_dir/operator-deploy-count"
@@ -447,6 +455,25 @@ git -C "$deployed_fixture" reset --hard -q "$merged_sha"
 post_args=(--stage post-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha "$merged_sha" --target-suite settings --deploy-mode skip --runtime-integrity false)
 "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${post_args[@]}" >"$tmp_dir/operator-post.output"
 grep -F 'reviewed-tree-equivalence: PASS' "$tmp_dir/operator-post.output" >/dev/null
+# Tree equivalence is established only between the two exact commit identities.
+# A matching raw tree or another non-commit object fails before functional work
+# and must never be summarized as reviewed-tree equivalence PASS.
+matching_tree="$(git -C "$target_fixture" rev-parse "$target_sha^{tree}")"
+noncommit_blob="$(git -C "$target_fixture" rev-parse "$target_sha:README.md")"
+for identity_case in reviewed-tree deployed-blob; do
+  invalid_args=("${post_args[@]}")
+  if [[ "$identity_case" == reviewed-tree ]]; then
+    invalid_args=("${invalid_args[@]/$target_sha/$matching_tree}")
+  else
+    invalid_args=("${invalid_args[@]/$merged_sha/$noncommit_blob}")
+  fi
+  : >"$target_log"
+  invalid_output="$tmp_dir/operator-post-$identity_case.output"
+  if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${invalid_args[@]}" >"$invalid_output" 2>&1; then exit 1; fi
+  grep -F 'reviewed-tree-equivalence: NOT_ESTABLISHED' "$invalid_output" >/dev/null
+  ! grep -F 'reviewed-tree-equivalence: PASS' "$invalid_output" >/dev/null
+  ! grep -E '^run test:e2e|wp .*nmkr-wpcli-(smoke|db-state)' "$target_log" >/dev/null
+done
 missing_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${post_args[@]/$target_sha/$missing_sha}" >/dev/null 2>&1; then exit 1; fi
 printf '\nchanged-tree\n' >>"$target_fixture/README.md"

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -386,6 +386,7 @@ grep -F 'final-integrity: PASS' "$tmp_dir/target-success.output" >/dev/null
 # falling back to the repository checkout.
 plain_assignment_env="$tmp_dir/plain-assignment.env"
 cat >"$plain_assignment_env" <<EOF_PLAIN_ASSIGNMENTS
+set +a
 WP_BASE_URL=https://phase2.invalid
 WP_ADMIN_USER=phase2-user-marker
 WP_ADMIN_PASSWORD=phase2-password-marker

--- a/scripts/nmkr-phase2-profile-regression.sh
+++ b/scripts/nmkr-phase2-profile-regression.sh
@@ -289,6 +289,7 @@ EOF_NODE
 cat >"$target_bin/npm" <<'EOF_NPM'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"$TARGET_CALL_LOG"
+printf 'safety RUN_REAL_SYNC=%s PW_SAVE_ARTIFACTS=%s\n' "${RUN_REAL_SYNC:-unset}" "${PW_SAVE_ARTIFACTS:-unset}" >>"$TARGET_CALL_LOG"
 if [[ "${TARGET_DIRTY_AFTER_PLAYWRIGHT:-false}" == true && "$*" == 'run test:e2e:settings' ]]; then
   printf '\nsynthetic-dirty\n' >>"$TARGET_REPO/README.md"
 fi
@@ -307,6 +308,7 @@ exit 0
 EOF_NPM
 cat >"$target_bin/wp" <<'EOF_WP'
 #!/usr/bin/env bash
+printf 'wp %s\n' "$*" >>"$TARGET_CALL_LOG"
 case "$*" in
   *' eval '*)
     case "${TARGET_ACTIVE_PLUGIN_MODE:-valid}" in
@@ -355,6 +357,13 @@ grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
 grep -F 'stage: pre-merge' "$tmp_dir/operator-target.output" >/dev/null
 grep -F 'rollback: NOT_ATTEMPTED' "$tmp_dir/operator-target.output" >/dev/null
 
+# Accepted uppercase SHAs normalize to Git's lowercase identity before every
+# comparison and are reported in normalized form.
+uppercase_sha="${target_sha^^}"
+uppercase_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$uppercase_sha" --deployed-sha "$uppercase_sha" --target-suite settings --deploy-mode skip --runtime-integrity false)
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${uppercase_args[@]}" >"$tmp_dir/operator-uppercase.output"
+grep -F "reviewed-commit: ${target_sha:0:12}" "$tmp_dir/operator-uppercase.output" >/dev/null
+
 mismatch_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha 0123456789abcdef0123456789abcdef01234567 --target-suite settings --deploy-mode skip --runtime-integrity false)
 if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${mismatch_args[@]}" >/dev/null 2>&1; then exit 1; fi
 
@@ -368,14 +377,63 @@ for env_name in "${operator_env_names[@]}"; do
 done
 : >"$target_env"
 
+# Legacy OP_* assignments cannot change the immutable CLI request, while
+# unsafe behavior toggles are forcibly disabled after private configuration.
+cat >"$target_env" <<'EOF_OPERATOR_OVERRIDE'
+OPERATOR_MODE=false
+OP_STAGE=post-merge
+OP_CLASS=high-risk
+OP_PROFILE=existing-readonly
+OP_REVIEWED_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+OP_DEPLOYED_SHA=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+OP_TARGET_SUITE=dashboard
+OP_DEPLOY_MODE=run
+OP_RUNTIME_INTEGRITY=true
+RUN_REAL_SYNC=true
+PW_SAVE_ARTIFACTS=true
+EOF_OPERATOR_OVERRIDE
+: >"$target_log"
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >"$tmp_dir/operator-immutable.output"
+grep -F 'stage: pre-merge' "$tmp_dir/operator-immutable.output" >/dev/null
+grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
+grep -F 'safety RUN_REAL_SYNC=false PW_SAVE_ARTIFACTS=false' "$target_log" >/dev/null
+: >"$target_env"
+
+# Attempts to assign the protected internal namespace fail closed while the
+# private file is sourced, before deployment or functional validation.
+printf 'CLI_STAGE=post-merge\n' >"$target_env"
+protected_state_count="$tmp_dir/protected-state-deploy-count"
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="printf 'call\\n' >>'$protected_state_count'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >/dev/null 2>&1; then exit 1; fi
+test ! -e "$protected_state_count"
+: >"$target_env"
+
 deploy_count="$tmp_dir/operator-deploy-count"
-deploy_command="printf 'call\\n' >>'$deploy_count'"
+run_deployed_fixture="$tmp_dir/run-deployed-fixture"
+deploy_command="printf 'call\\n' >>'$deploy_count'; '$real_git' clone -q '$target_fixture' '$run_deployed_fixture'"
 run_args=(--stage pre-merge --class test-tooling --profile targeted-readonly --reviewed-sha "$target_sha" --deployed-sha "$target_sha" --target-suite settings --deploy-mode run --runtime-integrity false)
 : >"$target_log"
-"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="$deploy_command" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${run_args[@]}" >"$tmp_dir/operator-deploy.output"
+"${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOYED_PLUGIN_PATH="$run_deployed_fixture" TARGET_ACTIVE_PLUGIN_FILE="$run_deployed_fixture/nmkr-connect.php" NMKR_DEPLOY_COMMAND="$deploy_command" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${run_args[@]}" >"$tmp_dir/operator-deploy.output"
 test "$(wc -l <"$deploy_count")" = 1
 grep -F 'deploy: PASS' "$tmp_dir/operator-deploy.output" >/dev/null
 ! grep -F "$deploy_command" "$tmp_dir/operator-deploy.output" >/dev/null
+grep -Fx 'run test:e2e:settings' "$target_log" >/dev/null
+
+# A missing configured verification target fails before the opaque mutation.
+rm -f "$deploy_count"
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOYED_PLUGIN_PATH= NMKR_DEPLOY_COMMAND="printf 'call\\n' >>'$deploy_count'" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${run_args[@]}" >"$tmp_dir/operator-missing-path.output" 2>&1; then exit 1; fi
+test ! -e "$deploy_count"
+grep -F 'failed step: preflight' "$tmp_dir/operator-missing-path.output" >/dev/null
+
+# Deployment is invoked once, then an incorrect active binding fails at the
+# deploy-integrity boundary before any functional command can start.
+rm -rf "$run_deployed_fixture"; : >"$target_log"; rm -f "$deploy_count"
+if "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOYED_PLUGIN_PATH="$run_deployed_fixture" TARGET_ACTIVE_PLUGIN_FILE="$target_fixture/nmkr-connect.php" NMKR_DEPLOY_COMMAND="$deploy_command" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${run_args[@]}" >"$tmp_dir/operator-binding-failure.output" 2>&1; then exit 1; fi
+test "$(wc -l <"$deploy_count")" = 1
+grep -F 'failed step: deploy-integrity' "$tmp_dir/operator-binding-failure.output" >/dev/null
+grep -F 'rollback: NOT_ATTEMPTED' "$tmp_dir/operator-binding-failure.output" >/dev/null
+! grep -E '^run test:e2e|wp .*nmkr-wpcli-(smoke|db-state)' "$target_log" >/dev/null
+test "$(grep -c '^wp ' "$target_log")" = 1
+
 rm -f "$deploy_count"
 "${target_base[@]}" env -u NMKR_PHASE2_PROFILE -u NMKR_PHASE2_TARGET_SUITE NMKR_DEPLOY_COMMAND="$deploy_command" bash "$target_fixture/scripts/nmkr-phase2-test-runner.sh" "${operator_target_args[@]}" >/dev/null
 test ! -e "$deploy_count"

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -101,32 +101,49 @@ if [[ -n "$ENV_FILE" ]]; then
     printf 'ERROR: Phase 2 env file could not be resolved.\n' >&2
     exit 1
   fi
-  SOURCE_DIAGNOSTICS=""
+  SOURCE_DRAIN_PID=""
+  SOURCE_DRAIN_FD=""
   cleanup_source_diagnostics() {
-    [[ -z "$SOURCE_DIAGNOSTICS" ]] || rm -f -- "$SOURCE_DIAGNOSTICS"
+    if [[ -n "$SOURCE_DRAIN_FD" ]]; then
+      eval "exec ${SOURCE_DRAIN_FD}>&-"
+      SOURCE_DRAIN_FD=""
+    fi
+    if [[ -n "$SOURCE_DRAIN_PID" ]]; then
+      kill "$SOURCE_DRAIN_PID" 2>/dev/null || true
+      wait "$SOURCE_DRAIN_PID" 2>/dev/null || true
+      SOURCE_DRAIN_PID=""
+    fi
   }
   source_boundary_signal() {
     cleanup_source_diagnostics
     trap - EXIT INT TERM
     exit "$1"
   }
-  source_umask="$(umask)"
-  umask 077
-  if ! SOURCE_DIAGNOSTICS="$(mktemp "${TMPDIR:-/tmp}/nmkr-phase2-source.XXXXXX" 2>/dev/null)"; then
-    umask "$source_umask"
-    printf 'ERROR: Phase 2 private configuration could not be loaded.\n' >&2
-    exit 1
-  fi
-  umask "$source_umask"
   trap cleanup_source_diagnostics EXIT
   trap 'source_boundary_signal 130' INT
   trap 'source_boundary_signal 143' TERM
+  # Drain private source output through an anonymous pipe. Nothing is written
+  # beneath caller-selected TMPDIR (or any other persistent location), while
+  # the drain's status still records whether the source emitted even one byte.
+  coproc SOURCE_OUTPUT_DRAIN {
+    if IFS= read -r -n 1; then
+      cat >/dev/null
+      exit 1
+    fi
+  }
+  SOURCE_DRAIN_PID="$SOURCE_OUTPUT_DRAIN_PID"
+  SOURCE_DRAIN_FD="${SOURCE_OUTPUT_DRAIN[1]}"
   set -a
   # shellcheck source=/dev/null
   source_status=0
-  source "$SELECTED_ENV_FILE" >"$SOURCE_DIAGNOSTICS" 2>&1 || source_status=$?
+  source "$SELECTED_ENV_FILE" >&"$SOURCE_DRAIN_FD" || source_status=$?
   set +a
-  if [[ "$source_status" -ne 0 || -s "$SOURCE_DIAGNOSTICS" ]]; then
+  eval "exec ${SOURCE_DRAIN_FD}>&-"
+  SOURCE_DRAIN_FD=""
+  source_output_status=0
+  wait "$SOURCE_DRAIN_PID" || source_output_status=$?
+  SOURCE_DRAIN_PID=""
+  if [[ "$source_status" -ne 0 || "$source_output_status" -ne 0 ]]; then
     cleanup_source_diagnostics
     trap - EXIT INT TERM
     printf 'ERROR: Phase 2 private configuration could not be loaded.\n' >&2

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -101,10 +101,39 @@ if [[ -n "$ENV_FILE" ]]; then
     printf 'ERROR: Phase 2 env file could not be resolved.\n' >&2
     exit 1
   fi
+  SOURCE_DIAGNOSTICS=""
+  cleanup_source_diagnostics() {
+    [[ -z "$SOURCE_DIAGNOSTICS" ]] || rm -f -- "$SOURCE_DIAGNOSTICS"
+  }
+  source_boundary_signal() {
+    cleanup_source_diagnostics
+    trap - EXIT INT TERM
+    exit "$1"
+  }
+  source_umask="$(umask)"
+  umask 077
+  if ! SOURCE_DIAGNOSTICS="$(mktemp "${TMPDIR:-/tmp}/nmkr-phase2-source.XXXXXX" 2>/dev/null)"; then
+    umask "$source_umask"
+    printf 'ERROR: Phase 2 private configuration could not be loaded.\n' >&2
+    exit 1
+  fi
+  umask "$source_umask"
+  trap cleanup_source_diagnostics EXIT
+  trap 'source_boundary_signal 130' INT
+  trap 'source_boundary_signal 143' TERM
   set -a
   # shellcheck source=/dev/null
-  source "$SELECTED_ENV_FILE"
+  source_status=0
+  source "$SELECTED_ENV_FILE" >"$SOURCE_DIAGNOSTICS" 2>&1 || source_status=$?
   set +a
+  if [[ "$source_status" -ne 0 || -s "$SOURCE_DIAGNOSTICS" ]]; then
+    cleanup_source_diagnostics
+    trap - EXIT INT TERM
+    printf 'ERROR: Phase 2 private configuration could not be loaded.\n' >&2
+    exit 1
+  fi
+  cleanup_source_diagnostics
+  trap - EXIT INT TERM
   export NMKR_PHASE2_ENV_FILE="$SELECTED_ENV_FILE"
 fi
 
@@ -523,8 +552,13 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" ==
       [[ "$CLI_REVIEWED_SHA" == "$CLI_DEPLOYED_SHA" ]] || { printf 'Pre-merge reviewed/deployed identity mismatch.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
       EXPECTED_SOURCE_SHA="$CLI_REVIEWED_SHA"; TREE_EQUIVALENCE="NOT_APPLICABLE"
     else
-      reviewed_tree="$(git -C "$REPO_ROOT" rev-parse "$CLI_REVIEWED_SHA^{tree}" 2>/dev/null || true)"
-      deployed_tree="$(git -C "$REPO_ROOT" rev-parse "$CLI_DEPLOYED_SHA^{tree}" 2>/dev/null || true)"
+      reviewed_commit="$(git -C "$REPO_ROOT" rev-parse --verify "$CLI_REVIEWED_SHA^{commit}" 2>/dev/null || true)"
+      deployed_commit="$(git -C "$REPO_ROOT" rev-parse --verify "$CLI_DEPLOYED_SHA^{commit}" 2>/dev/null || true)"
+      reviewed_tree=""; deployed_tree=""
+      if [[ "$reviewed_commit" == "$CLI_REVIEWED_SHA" && "$deployed_commit" == "$CLI_DEPLOYED_SHA" ]]; then
+        reviewed_tree="$(git -C "$REPO_ROOT" rev-parse --verify "$reviewed_commit^{tree}" 2>/dev/null || true)"
+        deployed_tree="$(git -C "$REPO_ROOT" rev-parse --verify "$deployed_commit^{tree}" 2>/dev/null || true)"
+      fi
       if [[ -z "$reviewed_tree" || -z "$deployed_tree" || "$reviewed_tree" != "$deployed_tree" ]]; then
         TREE_EQUIVALENCE="NOT_ESTABLISHED"
         printf 'Reviewed/merged equivalence was not established; deeper review and validation are required.\n' >>"$RUN_DIR/preflight.log"

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -11,6 +11,49 @@ else
   REPO_ROOT="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 fi
 
+# Arguments opt in to the unified operator workflow. Legacy environment-only
+# invocations continue through the existing path unchanged.
+OPERATOR_MODE=false
+OP_STAGE= OP_CLASS= OP_PROFILE= OP_REVIEWED_SHA= OP_DEPLOYED_SHA=
+OP_TARGET_SUITE= OP_DEPLOY_MODE= OP_RUNTIME_INTEGRITY=
+declare -A OP_SEEN=()
+operator_error() { printf 'ERROR: Invalid Phase 2 operator arguments.\n' >&2; exit 1; }
+while (($#)); do
+  OPERATOR_MODE=true
+  option="$1"; shift
+  case "$option" in
+    --stage|--class|--profile|--reviewed-sha|--deployed-sha|--target-suite|--deploy-mode|--runtime-integrity) ;;
+    *) operator_error ;;
+  esac
+  [[ -z "${OP_SEEN[$option]:-}" ]] || operator_error
+  OP_SEEN[$option]=true
+  (($#)) || operator_error
+  value="$1"; shift
+  [[ -n "$value" && "$value" != --* ]] || operator_error
+  case "$option" in
+    --stage) OP_STAGE="$value" ;; --class) OP_CLASS="$value" ;;
+    --profile) OP_PROFILE="$value" ;; --reviewed-sha) OP_REVIEWED_SHA="$value" ;;
+    --deployed-sha) OP_DEPLOYED_SHA="$value" ;; --target-suite) OP_TARGET_SUITE="$value" ;;
+    --deploy-mode) OP_DEPLOY_MODE="$value" ;; --runtime-integrity) OP_RUNTIME_INTEGRITY="$value" ;;
+  esac
+done
+if [[ "$OPERATOR_MODE" == true ]]; then
+  for required in OP_STAGE OP_CLASS OP_PROFILE OP_REVIEWED_SHA OP_DEPLOYED_SHA OP_TARGET_SUITE OP_DEPLOY_MODE OP_RUNTIME_INTEGRITY; do
+    [[ -n "${!required}" ]] || operator_error
+  done
+  case "$OP_STAGE" in pre-merge|post-merge) ;; *) operator_error ;; esac
+  case "$OP_CLASS" in docs-metadata|test-tooling|ordinary-runtime|high-risk) ;; *) operator_error ;; esac
+  case "$OP_PROFILE" in targeted-readonly|existing-readonly) ;; *) operator_error ;; esac
+  [[ "$OP_REVIEWED_SHA" =~ ^[0-9a-fA-F]{40}$ && "$OP_DEPLOYED_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || operator_error
+  case "$OP_DEPLOY_MODE" in run|skip) ;; *) operator_error ;; esac
+  case "$OP_RUNTIME_INTEGRITY" in true|false) ;; *) operator_error ;; esac
+  if [[ "$OP_CLASS" == docs-metadata ]]; then
+    printf 'ERROR: Phase 2 private validation is not applicable for docs/metadata; use public CI.\n' >&2
+    exit 1
+  fi
+  [[ "$OP_CLASS" != high-risk || "$OP_PROFILE" == existing-readonly ]] || operator_error
+fi
+
 RUN_REAL_SYNC="${RUN_REAL_SYNC:-false}"
 PW_SAVE_ARTIFACTS="${PW_SAVE_ARTIFACTS:-false}"
 CALLER_PROFILE="${NMKR_PHASE2_PROFILE:-}"
@@ -51,6 +94,26 @@ if [[ -n "$ENV_FILE" ]]; then
   source "$SELECTED_ENV_FILE"
   set +a
   export NMKR_PHASE2_ENV_FILE="$SELECTED_ENV_FILE"
+fi
+
+if [[ "$OPERATOR_MODE" == true ]]; then
+  operator_conflict=false
+  check_operator_env() { local name="$1" expected="$2"; [[ -z "${!name+x}" || "${!name}" == "$expected" ]] || operator_conflict=true; }
+  check_operator_env NMKR_PHASE2_STAGE "$OP_STAGE"
+  check_operator_env NMKR_PHASE2_VALIDATION_CLASS "$OP_CLASS"
+  check_operator_env NMKR_PHASE2_PROFILE "$OP_PROFILE"
+  check_operator_env NMKR_PHASE2_REVIEWED_SHA "$OP_REVIEWED_SHA"
+  check_operator_env NMKR_PHASE2_DEPLOYED_SHA "$OP_DEPLOYED_SHA"
+  check_operator_env NMKR_PHASE2_TARGET_SUITE "$OP_TARGET_SUITE"
+  check_operator_env NMKR_PHASE2_DEPLOY_MODE "$OP_DEPLOY_MODE"
+  check_operator_env NMKR_PHASE2_RUNTIME_INTEGRITY "$OP_RUNTIME_INTEGRITY"
+  [[ "$operator_conflict" == false ]] || { printf 'ERROR: Phase 2 operator selection conflicts with environment configuration.\n' >&2; exit 1; }
+  NMKR_PHASE2_STAGE="$OP_STAGE"; NMKR_PHASE2_VALIDATION_CLASS="$OP_CLASS"
+  NMKR_PHASE2_PROFILE="$OP_PROFILE"; NMKR_PHASE2_REVIEWED_SHA="$OP_REVIEWED_SHA"
+  NMKR_PHASE2_DEPLOYED_SHA="$OP_DEPLOYED_SHA"; NMKR_PHASE2_TARGET_SUITE="$OP_TARGET_SUITE"
+  NMKR_PHASE2_DEPLOY_MODE="$OP_DEPLOY_MODE"; NMKR_PHASE2_RUNTIME_INTEGRITY="$OP_RUNTIME_INTEGRITY"
+  RUN_REAL_SYNC=false; PW_SAVE_ARTIFACTS=false
+  NMKR_PHASE2_INSTALL_DEPS=false; NMKR_PHASE2_INSTALL_BROWSER=false
 fi
 
 export RUN_REAL_SYNC="${RUN_REAL_SYNC:-false}"
@@ -98,6 +161,14 @@ print_summary() {
   local commit="unknown"
   commit="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || printf 'unknown')"
   printf '\nPhase 2 summary\n'
+  if [[ "$OPERATOR_MODE" == true ]]; then
+    printf '  stage: %s\n' "$OP_STAGE"
+    printf '  validation-class: %s\n' "$OP_CLASS"
+    printf '  reviewed-commit: %.12s\n' "$OP_REVIEWED_SHA"
+    printf '  expected-deployed-commit: %.12s\n' "$OP_DEPLOYED_SHA"
+    printf '  deploy-mode: %s\n' "$OP_DEPLOY_MODE"
+    printf '  reviewed-tree-equivalence: %s\n' "${TREE_EQUIVALENCE:-NOT_APPLICABLE}"
+  fi
   printf '  deploy: %s\n' "$DEPLOY_STATUS"
   printf '  dependencies: %s\n' "$DEPS_STATUS"
   printf '  browser: %s\n' "$BROWSER_STATUS"
@@ -114,6 +185,7 @@ print_summary() {
   printf '  readonly-policy: %s\n' "${READONLY_POLICY:-SKIPPED}"
   printf '  authentication-state-cleanup: %s\n' "$AUTH_STATE_CLEANUP"
   printf '  result: %s\n' "$result"
+  [[ "$OPERATOR_MODE" != true ]] || printf '  rollback: NOT_ATTEMPTED\n'
   printf '  commit: %s\n' "$commit"
   if [[ "$EXIT_CODE" != "0" ]]; then
     printf '  failed step: %s\n' "$FAILED_STEP"
@@ -415,7 +487,10 @@ case "$NMKR_PHASE2_TARGET_SUITE" in
   '') [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]] || { printf 'Target suite is required.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; } ;;
   *) printf 'Unknown target suite.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1 ;;
 esac
-if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" && -n "$NMKR_PHASE2_TARGET_SUITE" ]]; then
+if [[ "$OPERATOR_MODE" == true && "$NMKR_PHASE2_TARGET_SUITE" == ajax-security ]]; then
+  printf 'Specialized AJAX security validation must use its separate runner.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+fi
+if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" && -n "$NMKR_PHASE2_TARGET_SUITE" && "$OPERATOR_MODE" != true ]]; then
   printf 'Target suite requires targeted-readonly profile.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
 fi
 [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]] || SELECTED_SUITE="$NMKR_PHASE2_TARGET_SUITE"
@@ -423,22 +498,41 @@ fi
 if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
   READONLY_POLICY="ENFORCED"; SOURCE_INTEGRITY="FAIL"; DEPLOYED_INTEGRITY="SKIPPED"
   readonly_overrides=false
-  for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_SKIP_DEPLOY NMKR_PHASE2_INSTALL_BROWSER; do [[ "${!boolean}" != "false" || "$boolean" == NMKR_PHASE2_SKIP_DEPLOY ]] && readonly_overrides=true; done
+  for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_INSTALL_BROWSER; do [[ "${!boolean}" != "false" ]] && readonly_overrides=true; done
   [[ "$NMKR_PHASE2_INSTALL_DEPS" != "false" ]] && readonly_overrides=true
-  RUN_REAL_SYNC=false; PW_SAVE_ARTIFACTS=false; NMKR_PHASE2_SKIP_DEPLOY=true; NMKR_PHASE2_INSTALL_DEPS=false; NMKR_PHASE2_INSTALL_BROWSER=false; unset NMKR_DEPLOY_COMMAND
+  RUN_REAL_SYNC=false; PW_SAVE_ARTIFACTS=false; NMKR_PHASE2_INSTALL_DEPS=false; NMKR_PHASE2_INSTALL_BROWSER=false
+  if [[ "$OPERATOR_MODE" != true ]]; then NMKR_PHASE2_SKIP_DEPLOY=true; unset NMKR_DEPLOY_COMMAND; fi
   [[ "$readonly_overrides" == true ]] && printf 'INFO: readonly overrides present.\n'
-  [[ "${NMKR_PHASE2_EXPECTED_SOURCE_SHA:-}" =~ ^[0-9a-fA-F]{40}$ ]] || { printf 'Expected source SHA is invalid.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-  git_head_and_clean "$REPO_ROOT" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || { printf 'Source worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-  SOURCE_INTEGRITY="PASS"
-  if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" && -z "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
-    printf 'Targeted readonly requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+  EXPECTED_SOURCE_SHA="${NMKR_PHASE2_EXPECTED_SOURCE_SHA:-}"
+  EXPECTED_DEPLOYED_SHA="$EXPECTED_SOURCE_SHA"
+  if [[ "$OPERATOR_MODE" == true ]]; then
+    EXPECTED_SOURCE_SHA="$OP_DEPLOYED_SHA"; EXPECTED_DEPLOYED_SHA="$OP_DEPLOYED_SHA"
+    if [[ "$OP_STAGE" == pre-merge ]]; then
+      [[ "$OP_REVIEWED_SHA" == "$OP_DEPLOYED_SHA" ]] || { printf 'Pre-merge reviewed/deployed identity mismatch.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+      EXPECTED_SOURCE_SHA="$OP_REVIEWED_SHA"; TREE_EQUIVALENCE="NOT_APPLICABLE"
+    else
+      reviewed_tree="$(git -C "$REPO_ROOT" rev-parse "$OP_REVIEWED_SHA^{tree}" 2>/dev/null || true)"
+      deployed_tree="$(git -C "$REPO_ROOT" rev-parse "$OP_DEPLOYED_SHA^{tree}" 2>/dev/null || true)"
+      if [[ -z "$reviewed_tree" || -z "$deployed_tree" || "$reviewed_tree" != "$deployed_tree" ]]; then
+        TREE_EQUIVALENCE="NOT_ESTABLISHED"
+        printf 'Reviewed/merged equivalence was not established; deeper review and validation are required.\n' >>"$RUN_DIR/preflight.log"
+        fail_step "preflight" "$RUN_DIR/preflight.log" 1
+      fi
+      TREE_EQUIVALENCE="PASS"
+    fi
   fi
-  if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
+  [[ "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { printf 'Expected source SHA is invalid.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+  git_head_and_clean "$REPO_ROOT" "$EXPECTED_SOURCE_SHA" || { printf 'Source worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+  SOURCE_INTEGRITY="PASS"
+  if [[ ( "$NMKR_PHASE2_PROFILE" == "targeted-readonly" || "$OPERATOR_MODE" == true ) && -z "${NMKR_DEPLOYED_PLUGIN_PATH:-}" && !( "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == run ) ]]; then
+    printf 'Readonly workflow requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
+  fi
+  if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" && !( "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == run ) ]]; then
     DEPLOYED_INTEGRITY="FAIL"
-    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || { printf 'Deployed worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$EXPECTED_DEPLOYED_SHA" || { printf 'Deployed worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
     DEPLOYED_INTEGRITY="PASS"
   fi
-  if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
+  if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" || ( "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == skip ) ]]; then
     bind_active_plugin_to_deployed_worktree || { printf 'Active plugin deployment binding failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   fi
   run_external node -e "require('@playwright/test')" >/dev/null 2>&1 || { printf 'Required Node dependencies are unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
@@ -455,18 +549,27 @@ esac
 
 cd "$REPO_ROOT"
 
-if [[ "$NMKR_PHASE2_SKIP_DEPLOY" == "true" ]]; then
+if [[ "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == skip ]]; then
+  DEPLOY_STATUS="SKIPPED"
+elif [[ "$NMKR_PHASE2_SKIP_DEPLOY" == "true" && "$OPERATOR_MODE" != true ]]; then
   DEPLOY_STATUS="SKIPPED"
 else
   DEPLOY_STATUS="FAIL"
   if [[ -z "${NMKR_DEPLOY_COMMAND:-}" ]]; then
-    printf 'NMKR_DEPLOY_COMMAND is required unless NMKR_PHASE2_SKIP_DEPLOY=true.\n' >"$RUN_DIR/deploy.log"
+    printf 'NMKR_DEPLOY_COMMAND is required unless deployment is skipped.\n' >"$RUN_DIR/deploy.log"
     fail_step "deploy" "$RUN_DIR/deploy.log" 2
   fi
   if run_external bash -lc "$NMKR_DEPLOY_COMMAND" >"$RUN_DIR/deploy.log" 2>&1; then
     DEPLOY_STATUS="PASS"
   else
     fail_step "deploy" "$RUN_DIR/deploy.log" 2
+  fi
+  if [[ "$OPERATOR_MODE" == true ]]; then
+    [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || fail_step "deploy-integrity" "$RUN_DIR/deploy.log" 1
+    DEPLOYED_INTEGRITY="FAIL"
+    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$EXPECTED_DEPLOYED_SHA" || fail_step "deploy-integrity" "$RUN_DIR/deploy.log" 1
+    bind_active_plugin_to_deployed_worktree || fail_step "deploy-integrity" "$RUN_DIR/deploy.log" 1
+    DEPLOYED_INTEGRITY="PASS"
   fi
 fi
 
@@ -558,9 +661,9 @@ fi
 
 if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" == "targeted-readonly" ]]; then
   FINAL_INTEGRITY="FAIL"
-  git_head_and_clean "$REPO_ROOT" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
+  git_head_and_clean "$REPO_ROOT" "$EXPECTED_SOURCE_SHA" || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
   if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
-    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_PHASE2_EXPECTED_SOURCE_SHA" || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
+    git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$EXPECTED_DEPLOYED_SHA" || fail_step "final-integrity" "$RUN_DIR/preflight.log" 1
   fi
   FINAL_INTEGRITY="PASS"
 fi

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -45,6 +45,8 @@ if [[ "$OPERATOR_MODE" == true ]]; then
   case "$OP_CLASS" in docs-metadata|test-tooling|ordinary-runtime|high-risk) ;; *) operator_error ;; esac
   case "$OP_PROFILE" in targeted-readonly|existing-readonly) ;; *) operator_error ;; esac
   [[ "$OP_REVIEWED_SHA" =~ ^[0-9a-fA-F]{40}$ && "$OP_DEPLOYED_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || operator_error
+  OP_REVIEWED_SHA="${OP_REVIEWED_SHA,,}"
+  OP_DEPLOYED_SHA="${OP_DEPLOYED_SHA,,}"
   case "$OP_DEPLOY_MODE" in run|skip) ;; *) operator_error ;; esac
   case "$OP_RUNTIME_INTEGRITY" in true|false) ;; *) operator_error ;; esac
   if [[ "$OP_CLASS" == docs-metadata ]]; then
@@ -53,6 +55,16 @@ if [[ "$OPERATOR_MODE" == true ]]; then
   fi
   [[ "$OP_CLASS" != high-risk || "$OP_PROFILE" == existing-readonly ]] || operator_error
 fi
+
+# Lock the parsed request before crossing the private configuration boundary.
+# These internal names are deliberately readonly: the sourced file may set
+# legacy OP_* names, but it cannot replace or downgrade the authoritative CLI
+# request used by any later safety or validation decision.
+readonly CLI_OPERATOR_MODE="$OPERATOR_MODE"
+readonly CLI_STAGE="$OP_STAGE" CLI_CLASS="$OP_CLASS" CLI_PROFILE="$OP_PROFILE"
+readonly CLI_REVIEWED_SHA="$OP_REVIEWED_SHA" CLI_DEPLOYED_SHA="$OP_DEPLOYED_SHA"
+readonly CLI_TARGET_SUITE="$OP_TARGET_SUITE" CLI_DEPLOY_MODE="$OP_DEPLOY_MODE"
+readonly CLI_RUNTIME_INTEGRITY="$OP_RUNTIME_INTEGRITY"
 
 RUN_REAL_SYNC="${RUN_REAL_SYNC:-false}"
 PW_SAVE_ARTIFACTS="${PW_SAVE_ARTIFACTS:-false}"
@@ -96,22 +108,22 @@ if [[ -n "$ENV_FILE" ]]; then
   export NMKR_PHASE2_ENV_FILE="$SELECTED_ENV_FILE"
 fi
 
-if [[ "$OPERATOR_MODE" == true ]]; then
+if [[ "$CLI_OPERATOR_MODE" == true ]]; then
   operator_conflict=false
   check_operator_env() { local name="$1" expected="$2"; [[ -z "${!name+x}" || "${!name}" == "$expected" ]] || operator_conflict=true; }
-  check_operator_env NMKR_PHASE2_STAGE "$OP_STAGE"
-  check_operator_env NMKR_PHASE2_VALIDATION_CLASS "$OP_CLASS"
-  check_operator_env NMKR_PHASE2_PROFILE "$OP_PROFILE"
-  check_operator_env NMKR_PHASE2_REVIEWED_SHA "$OP_REVIEWED_SHA"
-  check_operator_env NMKR_PHASE2_DEPLOYED_SHA "$OP_DEPLOYED_SHA"
-  check_operator_env NMKR_PHASE2_TARGET_SUITE "$OP_TARGET_SUITE"
-  check_operator_env NMKR_PHASE2_DEPLOY_MODE "$OP_DEPLOY_MODE"
-  check_operator_env NMKR_PHASE2_RUNTIME_INTEGRITY "$OP_RUNTIME_INTEGRITY"
+  check_operator_env NMKR_PHASE2_STAGE "$CLI_STAGE"
+  check_operator_env NMKR_PHASE2_VALIDATION_CLASS "$CLI_CLASS"
+  check_operator_env NMKR_PHASE2_PROFILE "$CLI_PROFILE"
+  check_operator_env NMKR_PHASE2_REVIEWED_SHA "$CLI_REVIEWED_SHA"
+  check_operator_env NMKR_PHASE2_DEPLOYED_SHA "$CLI_DEPLOYED_SHA"
+  check_operator_env NMKR_PHASE2_TARGET_SUITE "$CLI_TARGET_SUITE"
+  check_operator_env NMKR_PHASE2_DEPLOY_MODE "$CLI_DEPLOY_MODE"
+  check_operator_env NMKR_PHASE2_RUNTIME_INTEGRITY "$CLI_RUNTIME_INTEGRITY"
   [[ "$operator_conflict" == false ]] || { printf 'ERROR: Phase 2 operator selection conflicts with environment configuration.\n' >&2; exit 1; }
-  NMKR_PHASE2_STAGE="$OP_STAGE"; NMKR_PHASE2_VALIDATION_CLASS="$OP_CLASS"
-  NMKR_PHASE2_PROFILE="$OP_PROFILE"; NMKR_PHASE2_REVIEWED_SHA="$OP_REVIEWED_SHA"
-  NMKR_PHASE2_DEPLOYED_SHA="$OP_DEPLOYED_SHA"; NMKR_PHASE2_TARGET_SUITE="$OP_TARGET_SUITE"
-  NMKR_PHASE2_DEPLOY_MODE="$OP_DEPLOY_MODE"; NMKR_PHASE2_RUNTIME_INTEGRITY="$OP_RUNTIME_INTEGRITY"
+  NMKR_PHASE2_STAGE="$CLI_STAGE"; NMKR_PHASE2_VALIDATION_CLASS="$CLI_CLASS"
+  NMKR_PHASE2_PROFILE="$CLI_PROFILE"; NMKR_PHASE2_REVIEWED_SHA="$CLI_REVIEWED_SHA"
+  NMKR_PHASE2_DEPLOYED_SHA="$CLI_DEPLOYED_SHA"; NMKR_PHASE2_TARGET_SUITE="$CLI_TARGET_SUITE"
+  NMKR_PHASE2_DEPLOY_MODE="$CLI_DEPLOY_MODE"; NMKR_PHASE2_RUNTIME_INTEGRITY="$CLI_RUNTIME_INTEGRITY"
   RUN_REAL_SYNC=false; PW_SAVE_ARTIFACTS=false
   NMKR_PHASE2_INSTALL_DEPS=false; NMKR_PHASE2_INSTALL_BROWSER=false
 fi
@@ -161,12 +173,12 @@ print_summary() {
   local commit="unknown"
   commit="$(git -C "$REPO_ROOT" rev-parse --short HEAD 2>/dev/null || printf 'unknown')"
   printf '\nPhase 2 summary\n'
-  if [[ "$OPERATOR_MODE" == true ]]; then
-    printf '  stage: %s\n' "$OP_STAGE"
-    printf '  validation-class: %s\n' "$OP_CLASS"
-    printf '  reviewed-commit: %.12s\n' "$OP_REVIEWED_SHA"
-    printf '  expected-deployed-commit: %.12s\n' "$OP_DEPLOYED_SHA"
-    printf '  deploy-mode: %s\n' "$OP_DEPLOY_MODE"
+  if [[ "$CLI_OPERATOR_MODE" == true ]]; then
+    printf '  stage: %s\n' "$CLI_STAGE"
+    printf '  validation-class: %s\n' "$CLI_CLASS"
+    printf '  reviewed-commit: %.12s\n' "$CLI_REVIEWED_SHA"
+    printf '  expected-deployed-commit: %.12s\n' "$CLI_DEPLOYED_SHA"
+    printf '  deploy-mode: %s\n' "$CLI_DEPLOY_MODE"
     printf '  reviewed-tree-equivalence: %s\n' "${TREE_EQUIVALENCE:-NOT_APPLICABLE}"
   fi
   printf '  deploy: %s\n' "$DEPLOY_STATUS"
@@ -185,7 +197,7 @@ print_summary() {
   printf '  readonly-policy: %s\n' "${READONLY_POLICY:-SKIPPED}"
   printf '  authentication-state-cleanup: %s\n' "$AUTH_STATE_CLEANUP"
   printf '  result: %s\n' "$result"
-  [[ "$OPERATOR_MODE" != true ]] || printf '  rollback: NOT_ATTEMPTED\n'
+  [[ "$CLI_OPERATOR_MODE" != true ]] || printf '  rollback: NOT_ATTEMPTED\n'
   printf '  commit: %s\n' "$commit"
   if [[ "$EXIT_CODE" != "0" ]]; then
     printf '  failed step: %s\n' "$FAILED_STEP"
@@ -487,10 +499,10 @@ case "$NMKR_PHASE2_TARGET_SUITE" in
   '') [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]] || { printf 'Target suite is required.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; } ;;
   *) printf 'Unknown target suite.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1 ;;
 esac
-if [[ "$OPERATOR_MODE" == true && "$NMKR_PHASE2_TARGET_SUITE" == ajax-security ]]; then
+if [[ "$CLI_OPERATOR_MODE" == true && "$NMKR_PHASE2_TARGET_SUITE" == ajax-security ]]; then
   printf 'Specialized AJAX security validation must use its separate runner.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
 fi
-if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" && -n "$NMKR_PHASE2_TARGET_SUITE" && "$OPERATOR_MODE" != true ]]; then
+if [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" && -n "$NMKR_PHASE2_TARGET_SUITE" && "$CLI_OPERATOR_MODE" != true ]]; then
   printf 'Target suite requires targeted-readonly profile.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
 fi
 [[ "$NMKR_PHASE2_PROFILE" != "targeted-readonly" ]] || SELECTED_SUITE="$NMKR_PHASE2_TARGET_SUITE"
@@ -501,18 +513,18 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" ==
   for boolean in RUN_REAL_SYNC PW_SAVE_ARTIFACTS NMKR_PHASE2_INSTALL_BROWSER; do [[ "${!boolean}" != "false" ]] && readonly_overrides=true; done
   [[ "$NMKR_PHASE2_INSTALL_DEPS" != "false" ]] && readonly_overrides=true
   RUN_REAL_SYNC=false; PW_SAVE_ARTIFACTS=false; NMKR_PHASE2_INSTALL_DEPS=false; NMKR_PHASE2_INSTALL_BROWSER=false
-  if [[ "$OPERATOR_MODE" != true ]]; then NMKR_PHASE2_SKIP_DEPLOY=true; unset NMKR_DEPLOY_COMMAND; fi
+  if [[ "$CLI_OPERATOR_MODE" != true ]]; then NMKR_PHASE2_SKIP_DEPLOY=true; unset NMKR_DEPLOY_COMMAND; fi
   [[ "$readonly_overrides" == true ]] && printf 'INFO: readonly overrides present.\n'
   EXPECTED_SOURCE_SHA="${NMKR_PHASE2_EXPECTED_SOURCE_SHA:-}"
   EXPECTED_DEPLOYED_SHA="$EXPECTED_SOURCE_SHA"
-  if [[ "$OPERATOR_MODE" == true ]]; then
-    EXPECTED_SOURCE_SHA="$OP_DEPLOYED_SHA"; EXPECTED_DEPLOYED_SHA="$OP_DEPLOYED_SHA"
-    if [[ "$OP_STAGE" == pre-merge ]]; then
-      [[ "$OP_REVIEWED_SHA" == "$OP_DEPLOYED_SHA" ]] || { printf 'Pre-merge reviewed/deployed identity mismatch.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
-      EXPECTED_SOURCE_SHA="$OP_REVIEWED_SHA"; TREE_EQUIVALENCE="NOT_APPLICABLE"
+  if [[ "$CLI_OPERATOR_MODE" == true ]]; then
+    EXPECTED_SOURCE_SHA="$CLI_DEPLOYED_SHA"; EXPECTED_DEPLOYED_SHA="$CLI_DEPLOYED_SHA"
+    if [[ "$CLI_STAGE" == pre-merge ]]; then
+      [[ "$CLI_REVIEWED_SHA" == "$CLI_DEPLOYED_SHA" ]] || { printf 'Pre-merge reviewed/deployed identity mismatch.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
+      EXPECTED_SOURCE_SHA="$CLI_REVIEWED_SHA"; TREE_EQUIVALENCE="NOT_APPLICABLE"
     else
-      reviewed_tree="$(git -C "$REPO_ROOT" rev-parse "$OP_REVIEWED_SHA^{tree}" 2>/dev/null || true)"
-      deployed_tree="$(git -C "$REPO_ROOT" rev-parse "$OP_DEPLOYED_SHA^{tree}" 2>/dev/null || true)"
+      reviewed_tree="$(git -C "$REPO_ROOT" rev-parse "$CLI_REVIEWED_SHA^{tree}" 2>/dev/null || true)"
+      deployed_tree="$(git -C "$REPO_ROOT" rev-parse "$CLI_DEPLOYED_SHA^{tree}" 2>/dev/null || true)"
       if [[ -z "$reviewed_tree" || -z "$deployed_tree" || "$reviewed_tree" != "$deployed_tree" ]]; then
         TREE_EQUIVALENCE="NOT_ESTABLISHED"
         printf 'Reviewed/merged equivalence was not established; deeper review and validation are required.\n' >>"$RUN_DIR/preflight.log"
@@ -524,15 +536,15 @@ if [[ "$NMKR_PHASE2_PROFILE" == "existing-readonly" || "$NMKR_PHASE2_PROFILE" ==
   [[ "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-fA-F]{40}$ ]] || { printf 'Expected source SHA is invalid.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   git_head_and_clean "$REPO_ROOT" "$EXPECTED_SOURCE_SHA" || { printf 'Source worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   SOURCE_INTEGRITY="PASS"
-  if [[ ( "$NMKR_PHASE2_PROFILE" == "targeted-readonly" || "$OPERATOR_MODE" == true ) && -z "${NMKR_DEPLOYED_PLUGIN_PATH:-}" && !( "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == run ) ]]; then
+  if [[ ( "$NMKR_PHASE2_PROFILE" == "targeted-readonly" || "$CLI_OPERATOR_MODE" == true ) && -z "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]]; then
     printf 'Readonly workflow requires deployed plugin path.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1
   fi
-  if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" && !( "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == run ) ]]; then
+  if [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" && !( "$CLI_OPERATOR_MODE" == true && "$CLI_DEPLOY_MODE" == run ) ]]; then
     DEPLOYED_INTEGRITY="FAIL"
     git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$EXPECTED_DEPLOYED_SHA" || { printf 'Deployed worktree integrity check failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
     DEPLOYED_INTEGRITY="PASS"
   fi
-  if [[ "$NMKR_PHASE2_PROFILE" == "targeted-readonly" || ( "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == skip ) ]]; then
+  if [[ ( "$NMKR_PHASE2_PROFILE" == "targeted-readonly" && "$CLI_OPERATOR_MODE" != true ) || ( "$CLI_OPERATOR_MODE" == true && "$CLI_DEPLOY_MODE" == skip ) ]]; then
     bind_active_plugin_to_deployed_worktree || { printf 'Active plugin deployment binding failed.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
   fi
   run_external node -e "require('@playwright/test')" >/dev/null 2>&1 || { printf 'Required Node dependencies are unavailable.\n' >>"$RUN_DIR/preflight.log"; fail_step "preflight" "$RUN_DIR/preflight.log" 1; }
@@ -549,9 +561,9 @@ esac
 
 cd "$REPO_ROOT"
 
-if [[ "$OPERATOR_MODE" == true && "$OP_DEPLOY_MODE" == skip ]]; then
+if [[ "$CLI_OPERATOR_MODE" == true && "$CLI_DEPLOY_MODE" == skip ]]; then
   DEPLOY_STATUS="SKIPPED"
-elif [[ "$NMKR_PHASE2_SKIP_DEPLOY" == "true" && "$OPERATOR_MODE" != true ]]; then
+elif [[ "$NMKR_PHASE2_SKIP_DEPLOY" == "true" && "$CLI_OPERATOR_MODE" != true ]]; then
   DEPLOY_STATUS="SKIPPED"
 else
   DEPLOY_STATUS="FAIL"
@@ -564,7 +576,7 @@ else
   else
     fail_step "deploy" "$RUN_DIR/deploy.log" 2
   fi
-  if [[ "$OPERATOR_MODE" == true ]]; then
+  if [[ "$CLI_OPERATOR_MODE" == true ]]; then
     [[ -n "${NMKR_DEPLOYED_PLUGIN_PATH:-}" ]] || fail_step "deploy-integrity" "$RUN_DIR/deploy.log" 1
     DEPLOYED_INTEGRITY="FAIL"
     git_head_and_clean "$NMKR_DEPLOYED_PLUGIN_PATH" "$EXPECTED_DEPLOYED_SHA" || fail_step "deploy-integrity" "$RUN_DIR/deploy.log" 1

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -103,6 +103,7 @@ if [[ -n "$ENV_FILE" ]]; then
   fi
   SOURCE_DRAIN_PID=""
   SOURCE_DRAIN_FD=""
+  SOURCE_PUBLIC_ERR_FD=""
   cleanup_source_diagnostics() {
     if [[ -n "$SOURCE_DRAIN_FD" ]]; then
       eval "exec ${SOURCE_DRAIN_FD}>&-"
@@ -113,6 +114,18 @@ if [[ -n "$ENV_FILE" ]]; then
       wait "$SOURCE_DRAIN_PID" 2>/dev/null || true
       SOURCE_DRAIN_PID=""
     fi
+    if [[ -n "$SOURCE_PUBLIC_ERR_FD" ]]; then
+      eval "exec ${SOURCE_PUBLIC_ERR_FD}>&-"
+      SOURCE_PUBLIC_ERR_FD=""
+    fi
+  }
+  source_load_error() {
+    local status=$?
+    [[ "$status" -ne 0 ]] || status=1
+    trap - ERR EXIT INT TERM
+    printf 'ERROR: Phase 2 private configuration could not be loaded.\n' >&"$SOURCE_ERROR_FD"
+    cleanup_source_diagnostics
+    exit "$status"
   }
   source_boundary_signal() {
     cleanup_source_diagnostics
@@ -133,17 +146,24 @@ if [[ -n "$ENV_FILE" ]]; then
   }
   SOURCE_DRAIN_PID="$SOURCE_OUTPUT_DRAIN_PID"
   SOURCE_DRAIN_FD="${SOURCE_OUTPUT_DRAIN[1]}"
+  exec {SOURCE_PUBLIC_ERR_FD}>&2
+  readonly SOURCE_ERROR_FD="$SOURCE_PUBLIC_ERR_FD"
   set -a
   # shellcheck source=/dev/null
-  source_status=0
-  source "$SELECTED_ENV_FILE" >&"$SOURCE_DRAIN_FD" || source_status=$?
+  # Keep source as a direct command: placing it in a conditional or command
+  # list would suppress errexit for unhandled failures inside the private file.
+  # EXIT also covers fatal shell errors (notably readonly-name assignments)
+  # that terminate Bash without dispatching an ERR trap.
+  trap source_load_error ERR EXIT
+  source "$SELECTED_ENV_FILE" >&"$SOURCE_DRAIN_FD"
+  trap - ERR EXIT
   set +a
   eval "exec ${SOURCE_DRAIN_FD}>&-"
   SOURCE_DRAIN_FD=""
   source_output_status=0
   wait "$SOURCE_DRAIN_PID" || source_output_status=$?
   SOURCE_DRAIN_PID=""
-  if [[ "$source_status" -ne 0 || "$source_output_status" -ne 0 ]]; then
+  if [[ "$source_output_status" -ne 0 ]]; then
     cleanup_source_diagnostics
     trap - EXIT INT TERM
     printf 'ERROR: Phase 2 private configuration could not be loaded.\n' >&2

--- a/scripts/nmkr-phase2-test-runner.sh
+++ b/scripts/nmkr-phase2-test-runner.sh
@@ -407,6 +407,12 @@ if (( ${#missing[@]} > 0 )); then
   exit 1
 fi
 
+# These values are required by the runner and by its Playwright/WP-CLI child
+# processes. Private configuration may use ordinary shell assignments; do not
+# require operators to add export statements to make the validated values
+# available downstream.
+export WP_BASE_URL WP_ADMIN_USER WP_ADMIN_PASSWORD WP_PATH
+
 # Resolve the private root before creation. It must remain outside web, checkout,
 # and public Playwright output trees, including through symlinks.
 CONFIGURED_LOG_PARENT="${NMKR_PHASE2_LOG_DIR:-${XDG_STATE_HOME:-$HOME/.local/state}/nmkr-connect}"

--- a/scripts/nmkr-wpcli-smoke.sh
+++ b/scripts/nmkr-wpcli-smoke.sh
@@ -87,8 +87,17 @@ if [[ -f "$log_path" ]]; then
     :
   else
     classifier_status=$?
-    (( classifier_status == 1 )) || fail "Could not classify debug.log entries safely."
-    fail "Fresh or timestamp-unclassified debug.log entries contain PHP or NMKR plugin errors. Review the VM-local log manually."
+    case "$classifier_status" in
+      1)
+        fail "Fresh or timestamp-unclassified debug.log entries contain PHP or NMKR plugin errors. Review the VM-local log manually."
+        ;;
+      3)
+        info "Recent third-party vendor warnings/notices were detected and did not block validation."
+        ;;
+      *)
+        fail "Could not classify debug.log entries safely."
+        ;;
+    esac
   fi
 else
   info "debug.log was not found; skipping log scan."


### PR DESCRIPTION
### Motivation

- Provide a safe, explicit operator workflow to run private Phase 2 pre-merge/post-merge validations without rebuilding or allowing private env to override operator choices.

### Description

- Add a documented unified operator workflow in `docs/testing-phase-2.md` and an operator contract in `docs/validation-policy.md` describing required CLI options and semantics for `pre-merge`/`post-merge` stages.
- Implement operator-mode CLI parsing and validation in `scripts/nmkr-phase2-test-runner.sh`, including strict argument parsing, fail-closed checks, environment conflict detection, and forced toggles (`RUN_REAL_SYNC=false`, `PW_SAVE_ARTIFACTS=false`, `NMKR_PHASE2_INSTALL_DEPS=false`, `NMKR_PHASE2_INSTALL_BROWSER=false`).
- Enforce pre-merge/post-merge semantics and tree equivalence checks for reviewed/deployed SHAs, add `run`/`skip` deployment modes with private `NMKR_DEPLOY_COMMAND` handling, and adapt readonly/profile logic and integrity checks to operator flows.
- Extend `scripts/nmkr-phase2-profile-regression.sh` to exercise operator-mode scenarios, assert operator conflicts, validate preserved selections across env sourcing, verify deploy invocation behavior, and test reviewed-tree-equivalence behavior; also update output summary to expose operator fields and report `rollback: NOT_ATTEMPTED` for operator runs.

### Testing

- Ran the updated regression harness `scripts/nmkr-phase2-profile-regression.sh`, which exercises operator argument validation, conflict paths, `run`/`skip` deployment behavior, and reviewed-tree-equivalence checks, and all scripted assertions completed successfully.
- The modified `nmkr-phase2-test-runner.sh` behavior was validated by the regression script's greps and exit-status checks and produced the expected summary fields and logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7d8cf6acb883339ed5e9aedec83c01)