### PR TITLE
Add exact-ref deployment helper, regression tests, and docs

### DIFF
--- a/docs/testing-phase-2.md
+++ b/docs/testing-phase-2.md
@@ -164,3 +164,41 @@ npm run test:phase2 -- \
 ```
 
 The existing environment-only `test:phase2`, `test:phase2:targeted-readonly`, and `test:phase2:existing-readonly` entry points remain supported with their existing semantics.
+
+## Exact-ref deployment helper
+
+The repository includes a bounded deployment helper for the fixed `nmkr-connect` plugin. It accepts only a supported pull-request head or branch ref and its full reviewed commit ID:
+
+```bash
+bash scripts/nmkr-exact-ref-deploy.sh \
+  --ref refs/pull/<positive-number>/head \
+  --expected-sha <reviewed-40-character-sha>
+```
+
+`refs/heads/<safe-branch-name>` is also supported. Configure `NMKR_DEPLOY_REMOTE`, `NMKR_DEPLOYED_PLUGIN_PATH`, `NMKR_DEPLOY_BACKUP_ROOT`, and `WP_PATH` only in the private VM environment. `WP_CLI_BIN` and `COMPOSER_BIN` optionally select executables and default to `wp` and `composer`. Paths, remotes, credentials, command output, and populated environment files must remain outside GitHub and other public output.
+
+The helper checks that synchronization is idle before preparation and again immediately before replacement. It fetches only the requested ref without tags into an isolated temporary repository, verifies the exact SHA, builds its lockfile with production Composer options, verifies the required plugin files, and preserves the Git metadata and tracked executable modes needed by Phase 2 integrity checks. It then creates one timestamped archive in the private backup root immediately before replacing only the plugin directory and verifies the exact clean deployed commit, production build, and active fixed plugin.
+
+After the previous plugin has been displaced, replacement, activation, or final-integrity failure triggers restoration and activation verification of the previous directory. The console reports only a generic rollback result; the timestamped backup remains available for the private operator. The helper neither changes WordPress data nor runs synchronization.
+
+For a placeholder pre-merge deployment command behind the existing opaque boundary:
+
+```bash
+NMKR_DEPLOY_COMMAND='bash scripts/nmkr-exact-ref-deploy.sh --ref refs/pull/<positive-number>/head --expected-sha <reviewed-40-character-sha>' \
+npm run test:phase2 -- \
+  --stage pre-merge --class high-risk --profile existing-readonly \
+  --reviewed-sha <reviewed-40-character-sha> --deployed-sha <reviewed-40-character-sha> \
+  --target-suite <allowlisted-suite> --deploy-mode run --runtime-integrity true
+```
+
+For post-merge, use the merged main identity in both the helper and Phase 2 deployment expectation:
+
+```bash
+NMKR_DEPLOY_COMMAND='bash scripts/nmkr-exact-ref-deploy.sh --ref refs/heads/main --expected-sha <merged-main-40-character-sha>' \
+npm run test:phase2 -- \
+  --stage post-merge --class high-risk --profile existing-readonly \
+  --reviewed-sha <reviewed-40-character-sha> --deployed-sha <merged-main-40-character-sha> \
+  --target-suite <allowlisted-suite> --deploy-mode run --runtime-integrity true
+```
+
+These examples are placeholders: supply values through approved private configuration, do not paste the populated command or its captured output into GitHub, and do not claim deployment validation until the separately reviewed private VM run is complete.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:phase2": "bash scripts/nmkr-phase2-test-runner.sh",
     "test:phase2:existing-readonly": "NMKR_PHASE2_PROFILE=existing-readonly bash scripts/nmkr-phase2-test-runner.sh",
     "test:phase2:targeted-readonly": "NMKR_PHASE2_PROFILE=targeted-readonly bash scripts/nmkr-phase2-test-runner.sh",
+    "test:deploy:regression": "bash scripts/nmkr-exact-ref-deploy-regression.sh",
     "test:php74": "bash scripts/nmkr-php74-compat-scan.sh",
     "test:public": "bash scripts/nmkr-public-checks.sh",
     "test:e2e:settings": "node scripts/nmkr-playwright.js tests/e2e/nmkr-settings.regression.spec.ts",

--- a/scripts/nmkr-exact-ref-deploy-regression.sh
+++ b/scripts/nmkr-exact-ref-deploy-regression.sh
@@ -167,9 +167,9 @@ signal_deploy() {
 unchanged() { [[ -f "$NMKR_DEPLOYED_PLUGIN_PATH/original-marker" ]]; }
 one_backup() { [[ $(find "$NMKR_DEPLOY_BACKUP_ROOT" -maxdepth 1 -type f -name '*.tar' | wc -l) -eq 1 ]]; }
 no_leaks() {
-  ! rg -q 'private-remote-sentinel|private-backup-sentinel|private-wordpress-sentinel|PRIVATE_(WP|SUBPROCESS)_DIAGNOSTIC_SENTINEL' "$output"
+  ! grep -E -q -- 'private-remote-sentinel|private-backup-sentinel|private-wordpress-sentinel|PRIVATE_(WP|SUBPROCESS)_DIAGNOSTIC_SENTINEL' "$output"
 }
-no_success() { ! rg -q '^Exact-ref deployment succeeded\.$' "$output"; }
+no_success() { ! grep -E -q -- '^Exact-ref deployment succeeded\.$' "$output"; }
 ORIGINAL_PATH=$PATH
 
 new_case
@@ -281,7 +281,7 @@ for deployment_signal in INT TERM; do
   check unchanged
   check test -e "$TEST_STATE/rollback-activation-released"
   check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
-  check rg -q '^Exact-ref deployment failed; rollback succeeded\.$' "$output"
+  check grep -E -q -- '^Exact-ref deployment failed; rollback succeeded\.$' "$output"
   check no_success
   check no_leaks
 done
@@ -301,7 +301,7 @@ for deployment_signal in INT TERM; do
   check test ! -e "$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
   check test -e "$TEST_STATE/previous-delete-released"
   check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
-  check rg -q '^Exact-ref deployment succeeded\.$' "$output"
+  check grep -E -q -- '^Exact-ref deployment succeeded\.$' "$output"
   check no_leaks
 done
 

--- a/scripts/nmkr-exact-ref-deploy-regression.sh
+++ b/scripts/nmkr-exact-ref-deploy-regression.sh
@@ -88,6 +88,11 @@ case "${1:-} ${2:-}" in
       read -r _ <"$TEST_STATE/activation-release"
       : >"$TEST_STATE/activation-released"
     fi
+    if [[ "${TEST_BLOCK_ROLLBACK_ACTIVATION:-false}" == true && -e "$TEST_STATE/activation-failed" && ! -e "$TEST_STATE/rollback-activation-blocked" ]]; then
+      : >"$TEST_STATE/rollback-activation-blocked"
+      read -r _ <"$TEST_STATE/rollback-activation-release"
+      : >"$TEST_STATE/rollback-activation-released"
+    fi
     if [[ -n "${TEST_FINAL_HIDDEN_FLAG:-}" && -d "$NMKR_DEPLOYED_PLUGIN_PATH/.git" && ! -e "$TEST_STATE/hidden-final" ]]; then
       git -C "$NMKR_DEPLOYED_PLUGIN_PATH" update-index "--${TEST_FINAL_HIDDEN_FLAG}" nmkr-connect.php
       printf 'hidden activated change\n' >>"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
@@ -114,7 +119,18 @@ if [[ "$src" == */.nmkr-previous.* && "${TEST_FAIL_RESTORE_MOVE:-false}" == true
 printf '%s\n%s\n' "$src" "$dst" >>"$TEST_STATE/move-paths"
 exec /bin/mv "$@"
 EOF
-chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel" "$bin/mv"
+cat >"$bin/rm" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+target=${!#}
+if [[ "$target" == */.nmkr-previous.* && "${TEST_BLOCK_PREVIOUS_DELETE:-false}" == true ]]; then
+  : >"$TEST_STATE/previous-delete-blocked"
+  read -r _ <"$TEST_STATE/previous-delete-release"
+  : >"$TEST_STATE/previous-delete-released"
+fi
+exec /bin/rm "$@"
+EOF
+chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel" "$bin/mv" "$bin/rm"
 
 new_case() {
   case_root=$(mktemp -d "$tmp/case.XXXXXXXX")
@@ -125,7 +141,7 @@ new_case() {
   export WP_PATH=$case_root/private-wordpress-sentinel
   export WP_CLI_BIN=$bin/wp-sentinel COMPOSER_BIN=$bin/composer-sentinel
   export PATH=$bin:$ORIGINAL_PATH
-  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE TEST_BLOCK_COMPOSER TEST_BLOCK_ACTIVATION TEST_PREP_HIDDEN_FLAG TEST_FINAL_HIDDEN_FLAG
+  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE TEST_BLOCK_COMPOSER TEST_BLOCK_ACTIVATION TEST_BLOCK_ROLLBACK_ACTIVATION TEST_BLOCK_PREVIOUS_DELETE TEST_PREP_HIDDEN_FLAG TEST_FINAL_HIDDEN_FLAG
   mkdir -p "$TEST_STATE" "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_DEPLOY_BACKUP_ROOT" "$WP_PATH"
   printf 'original\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
   printf '<?php // original synthetic\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
@@ -251,6 +267,43 @@ check signal_deploy TERM
 check unchanged
 check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
 check no_leaks
+
+for deployment_signal in INT TERM; do
+  new_case
+  export TEST_ACTIVATE_FAIL_ONCE=true TEST_BLOCK_ROLLBACK_ACTIVATION=true
+  mkfifo "$TEST_STATE/rollback-activation-release"
+  start_deploy refs/heads/main "$sha"
+  check wait_for_marker "$TEST_STATE/rollback-activation-blocked"
+  check kill -s "$deployment_signal" -- "-$deploy_pid"
+  printf 'release\n' >"$TEST_STATE/rollback-activation-release"
+  rollback_status=0; wait "$deploy_pid" || rollback_status=$?
+  check test "$rollback_status" -ne 0
+  check unchanged
+  check test -e "$TEST_STATE/rollback-activation-released"
+  check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
+  check rg -q '^Exact-ref deployment failed; rollback succeeded\.$' "$output"
+  check no_success
+  check no_leaks
+done
+
+for deployment_signal in INT TERM; do
+  new_case
+  export TEST_BLOCK_PREVIOUS_DELETE=true
+  mkfifo "$TEST_STATE/previous-delete-release"
+  start_deploy refs/heads/main "$sha"
+  check wait_for_marker "$TEST_STATE/previous-delete-blocked"
+  check kill -s "$deployment_signal" -- "-$deploy_pid"
+  printf 'release\n' >"$TEST_STATE/previous-delete-release"
+  cleanup_status=0; wait "$deploy_pid" || cleanup_status=$?
+  check test "$cleanup_status" -eq 0
+  check test "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD)" = "$sha"
+  check test -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" -c core.fileMode=true status --porcelain --untracked-files=no)"
+  check test ! -e "$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
+  check test -e "$TEST_STATE/previous-delete-released"
+  check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
+  check rg -q '^Exact-ref deployment succeeded\.$' "$output"
+  check no_leaks
+done
 
 for hidden_flag in assume-unchanged skip-worktree; do
   new_case

--- a/scripts/nmkr-exact-ref-deploy-regression.sh
+++ b/scripts/nmkr-exact-ref-deploy-regression.sh
@@ -116,7 +116,9 @@ args=("$@"); count=${#args[@]}; src=${args[$((count-2))]}; dst=${args[$((count-1
 if [[ "$src" == "$NMKR_DEPLOYED_PLUGIN_PATH" && "${TEST_FAIL_FIRST_MOVE:-false}" == true ]]; then exit 7; fi
 if [[ "$src" == */.nmkr-candidate.* && "${TEST_FAIL_SECOND_MOVE:-false}" == true ]]; then exit 7; fi
 if [[ "$src" == */.nmkr-previous.* && "${TEST_FAIL_RESTORE_MOVE:-false}" == true ]]; then exit 7; fi
-printf '%s\n%s\n' "$src" "$dst" >>"$TEST_STATE/move-paths"
+if [[ "$src" != */.nmkr-connect-*.tmp ]]; then
+  printf '%s\n%s\n' "$src" "$dst" >>"$TEST_STATE/move-paths"
+fi
 exec /bin/mv "$@"
 EOF
 cat >"$bin/rm" <<'EOF'
@@ -130,7 +132,21 @@ if [[ "$target" == */.nmkr-previous.* && "${TEST_BLOCK_PREVIOUS_DELETE:-false}" 
 fi
 exec /bin/rm "$@"
 EOF
-chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel" "$bin/mv" "$bin/rm"
+cat >"$bin/tar" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+if [[ "${TEST_TAR_FAIL:-false}" == true ]]; then
+  archive=
+  while (( $# )); do
+    if [[ "$1" == -cpf && $# -ge 2 ]]; then archive=$2; break; fi
+    shift
+  done
+  [[ -z "$archive" ]] || printf 'partial\n' >"$archive"
+  exit 7
+fi
+exec /bin/tar "$@"
+EOF
+chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel" "$bin/mv" "$bin/rm" "$bin/tar"
 
 new_case() {
   case_root=$(mktemp -d "$tmp/case.XXXXXXXX")
@@ -141,7 +157,7 @@ new_case() {
   export WP_PATH=$case_root/private-wordpress-sentinel
   export WP_CLI_BIN=$bin/wp-sentinel COMPOSER_BIN=$bin/composer-sentinel
   export PATH=$bin:$ORIGINAL_PATH
-  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE TEST_BLOCK_COMPOSER TEST_BLOCK_ACTIVATION TEST_BLOCK_ROLLBACK_ACTIVATION TEST_BLOCK_PREVIOUS_DELETE TEST_PREP_HIDDEN_FLAG TEST_FINAL_HIDDEN_FLAG
+  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE TEST_BLOCK_COMPOSER TEST_BLOCK_ACTIVATION TEST_BLOCK_ROLLBACK_ACTIVATION TEST_BLOCK_PREVIOUS_DELETE TEST_PREP_HIDDEN_FLAG TEST_FINAL_HIDDEN_FLAG TEST_TAR_FAIL
   mkdir -p "$TEST_STATE" "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_DEPLOY_BACKUP_ROOT" "$WP_PATH"
   printf 'original\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
   printf '<?php // original synthetic\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
@@ -150,7 +166,7 @@ new_case() {
 }
 run_deploy() { bash "$deploy" --ref "$1" --expected-sha "$2" >"$output" 2>&1; }
 start_deploy() {
-  setsid bash "$deploy" --ref "$1" --expected-sha "$2" >"$output" 2>&1 &
+  ( trap - INT TERM; exec setsid bash "$deploy" --ref "$1" --expected-sha "$2" ) >"$output" 2>&1 &
   deploy_pid=$!
 }
 wait_for_marker() {
@@ -249,6 +265,15 @@ check test "$(find "$NMKR_DEPLOY_BACKUP_ROOT" -name '*.tar' | wc -l)" -eq 0
 check no_leaks
 
 new_case
+export TEST_TAR_FAIL=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check test "$(find "$NMKR_DEPLOY_BACKUP_ROOT" -maxdepth 1 -type f -name '*.tar' | wc -l)" -eq 0
+check test "$(find "$NMKR_DEPLOY_BACKUP_ROOT" -maxdepth 1 -type f -name '.nmkr-connect-*.tmp' | wc -l)" -eq 0
+check no_success
+check no_leaks
+
+new_case
 export TEST_BLOCK_COMPOSER=true
 mkfifo "$TEST_STATE/composer-release"
 start_deploy refs/heads/main "$sha"
@@ -277,11 +302,12 @@ for deployment_signal in INT TERM; do
   check kill -s "$deployment_signal" -- "-$deploy_pid"
   printf 'release\n' >"$TEST_STATE/rollback-activation-release"
   rollback_status=0; wait "$deploy_pid" || rollback_status=$?
-  check test "$rollback_status" -ne 0
+  if [[ "$deployment_signal" == INT ]]; then expected_signal_status=130; else expected_signal_status=143; fi
+  check test "$rollback_status" -eq "$expected_signal_status"
   check unchanged
   check test -e "$TEST_STATE/rollback-activation-released"
   check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
-  check grep -E -q -- '^Exact-ref deployment failed; rollback succeeded\.$' "$output"
+  check grep -E -q -- '^Exact-ref deployment interrupted\.$' "$output"
   check no_success
   check no_leaks
 done
@@ -295,13 +321,15 @@ for deployment_signal in INT TERM; do
   check kill -s "$deployment_signal" -- "-$deploy_pid"
   printf 'release\n' >"$TEST_STATE/previous-delete-release"
   cleanup_status=0; wait "$deploy_pid" || cleanup_status=$?
-  check test "$cleanup_status" -eq 0
+  if [[ "$deployment_signal" == INT ]]; then expected_signal_status=130; else expected_signal_status=143; fi
+  check test "$cleanup_status" -eq "$expected_signal_status"
   check test "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD)" = "$sha"
   check test -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" -c core.fileMode=true status --porcelain --untracked-files=no)"
   check test ! -e "$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
   check test -e "$TEST_STATE/previous-delete-released"
   check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
-  check grep -E -q -- '^Exact-ref deployment succeeded\.$' "$output"
+  check grep -E -q -- '^Exact-ref deployment interrupted\.$' "$output"
+  check no_success
   check no_leaks
 done
 

--- a/scripts/nmkr-exact-ref-deploy-regression.sh
+++ b/scripts/nmkr-exact-ref-deploy-regression.sh
@@ -9,7 +9,7 @@ export GIT_AUTHOR_NAME='Synthetic Test' GIT_AUTHOR_EMAIL='test@example.invalid'
 export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
 
 pass=0
-check() { if "$@"; then pass=$((pass + 1)); else printf 'Deploy regression failed.\n' >&2; exit 1; fi; }
+check() { if "$@"; then pass=$((pass + 1)); else printf 'Deploy regression failed at assertion %d.\n' "$((pass + 1))" >&2; exit 1; fi; }
 test_must_fail() { if "$@"; then return 1; else return 0; fi; }
 
 source_repo=$tmp/source
@@ -42,6 +42,7 @@ cat >"$bin/composer-sentinel" <<'EOF'
 #!/usr/bin/env bash
 set -eu
 printf 'composer\n' >>"$TEST_STATE/composer-calls"
+[[ "${TEST_BECOME_ACTIVE_AFTER_BUILD:-false}" != true ]] || : >"$TEST_STATE/sync-active"
 printf 'PRIVATE_SUBPROCESS_DIAGNOSTIC_SENTINEL\n' >&2
 [[ "${TEST_COMPOSER_FAIL:-false}" != true ]] || exit 9
 mkdir -p vendor/freemius/wordpress-sdk
@@ -56,12 +57,24 @@ set -eu
 printf 'PRIVATE_WP_DIAGNOSTIC_SENTINEL\n' >&2
 while [[ "${1:-}" == --path=* ]]; do shift; done
 case "${1:-} ${2:-}" in
-  'eval '*) [[ "${TEST_SYNC_ACTIVE:-false}" != true ]] && printf NMKR_IDLE ;;
+  'core is-installed') exit 0 ;;
+  'eval '*)
+    if [[ "${2:-}" == *'require_once ABSPATH'* ]]; then
+      if [[ "${TEST_FINAL_DIRTY:-false}" == true && -e "$TEST_STATE/activated" && ! -e "$TEST_STATE/dirtied" ]]; then
+        printf 'dirty\n' >>"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"; : >"$TEST_STATE/dirtied"
+      fi
+      if [[ -n "${TEST_BOUND_PATH:-}" ]]; then printf '%s' "$TEST_BOUND_PATH"; else printf '%s/nmkr-connect.php' "$(realpath -e "$NMKR_DEPLOYED_PLUGIN_PATH")"; fi
+    else
+      [[ "${TEST_SYNC_ACTIVE:-false}" != true && ! -e "$TEST_STATE/sync-active" ]] || exit 25
+      printf synthetic-idle-digest
+    fi
+    ;;
   'plugin activate')
     if [[ "${TEST_ACTIVATE_FAIL_ONCE:-false}" == true && ! -e "$TEST_STATE/activation-failed" ]]; then
       : >"$TEST_STATE/activation-failed"; exit 8
     fi
     : >"$TEST_STATE/active"
+    : >"$TEST_STATE/activated"
     ;;
   'plugin is-active')
     [[ -e "$TEST_STATE/active" ]] || exit 1
@@ -73,7 +86,17 @@ case "${1:-} ${2:-}" in
   *) exit 2 ;;
 esac
 EOF
-chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel"
+cat >"$bin/mv" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+args=("$@"); count=${#args[@]}; src=${args[$((count-2))]}; dst=${args[$((count-1))]}
+if [[ "$src" == "$NMKR_DEPLOYED_PLUGIN_PATH" && "${TEST_FAIL_FIRST_MOVE:-false}" == true ]]; then exit 7; fi
+if [[ "$src" == */.nmkr-candidate.* && "${TEST_FAIL_SECOND_MOVE:-false}" == true ]]; then exit 7; fi
+if [[ "$src" == */.nmkr-previous.* && "${TEST_FAIL_RESTORE_MOVE:-false}" == true ]]; then exit 7; fi
+printf '%s\n%s\n' "$src" "$dst" >>"$TEST_STATE/move-paths"
+exec /bin/mv "$@"
+EOF
+chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel" "$bin/mv"
 
 new_case() {
   case_root=$(mktemp -d "$tmp/case.XXXXXXXX")
@@ -83,9 +106,12 @@ new_case() {
   export NMKR_DEPLOY_BACKUP_ROOT=$case_root/private-backup-sentinel
   export WP_PATH=$case_root/private-wordpress-sentinel
   export WP_CLI_BIN=$bin/wp-sentinel COMPOSER_BIN=$bin/composer-sentinel
-  unset TEST_SYNC_ACTIVE TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY
+  export PATH=$bin:$ORIGINAL_PATH
+  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE
   mkdir -p "$TEST_STATE" "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_DEPLOY_BACKUP_ROOT" "$WP_PATH"
   printf 'original\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
+  printf '<?php // original synthetic\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
+  : >"$TEST_STATE/active"
   output=$case_root/output
 }
 run_deploy() { bash "$deploy" --ref "$1" --expected-sha "$2" >"$output" 2>&1; }
@@ -94,6 +120,7 @@ one_backup() { [[ $(find "$NMKR_DEPLOY_BACKUP_ROOT" -maxdepth 1 -type f -name '*
 no_leaks() {
   ! rg -q 'private-remote-sentinel|private-backup-sentinel|private-wordpress-sentinel|PRIVATE_(WP|SUBPROCESS)_DIAGNOSTIC_SENTINEL' "$output"
 }
+ORIGINAL_PATH=$PATH
 
 new_case
 check run_deploy refs/pull/123/head "$sha"
@@ -126,6 +153,45 @@ check unchanged
 check test ! -e "$TEST_STATE/composer-calls"
 
 new_case
+export TEST_BECOME_ACTIVE_AFTER_BUILD=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check one_backup
+
+new_case
+export TEST_BOUND_PATH=$case_root/plugins/other/nmkr-connect.php
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check one_backup
+
+new_case
+export TEST_FAIL_FIRST_MOVE=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+
+new_case
+export TEST_FAIL_SECOND_MOVE=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check one_backup
+
+new_case
+export TEST_ACTIVATE_FAIL_ONCE=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check test -e "$TEST_STATE/active"
+
+new_case
+export TEST_FAIL_SECOND_MOVE=true TEST_FAIL_RESTORE_MOVE=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check test ! -e "$NMKR_DEPLOYED_PLUGIN_PATH"
+check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 1
+
+new_case
+check run_deploy refs/heads/main "$sha"
+check awk -v parent="${NMKR_DEPLOYED_PLUGIN_PATH%/*}" 'index($0,parent "/.nmkr-")==1 || $0==parent "/nmkr-connect" {next} {exit 1}' "$TEST_STATE/move-paths"
+
+new_case
 export TEST_COMPOSER_FAIL=true
 check test_must_fail run_deploy refs/heads/main "$sha"
 check unchanged
@@ -136,14 +202,6 @@ new_case
 export TEST_MISSING_BUILD=true
 check test_must_fail run_deploy refs/heads/main "$sha"
 check unchanged
-
-new_case
-export TEST_ACTIVATE_FAIL_ONCE=true
-check test_must_fail run_deploy refs/heads/main "$sha"
-check unchanged
-check one_backup
-check test -e "$TEST_STATE/active"
-check no_leaks
 
 new_case
 export TEST_FINAL_DIRTY=true

--- a/scripts/nmkr-exact-ref-deploy-regression.sh
+++ b/scripts/nmkr-exact-ref-deploy-regression.sh
@@ -42,6 +42,10 @@ cat >"$bin/composer-sentinel" <<'EOF'
 #!/usr/bin/env bash
 set -eu
 printf 'composer\n' >>"$TEST_STATE/composer-calls"
+if [[ "${TEST_BLOCK_COMPOSER:-false}" == true ]]; then
+  : >"$TEST_STATE/composer-blocked"
+  read -r _ <"$TEST_STATE/composer-release"
+fi
 [[ "${TEST_BECOME_ACTIVE_AFTER_BUILD:-false}" != true ]] || : >"$TEST_STATE/sync-active"
 printf 'PRIVATE_SUBPROCESS_DIAGNOSTIC_SENTINEL\n' >&2
 [[ "${TEST_COMPOSER_FAIL:-false}" != true ]] || exit 9
@@ -49,6 +53,10 @@ mkdir -p vendor/freemius/wordpress-sdk
 printf '<?php // generated synthetic autoloader\n' >vendor/autoload.php
 if [[ "${TEST_MISSING_BUILD:-false}" != true ]]; then
   printf '<?php // generated synthetic SDK entry\n' >vendor/freemius/wordpress-sdk/start.php
+fi
+if [[ -n "${TEST_PREP_HIDDEN_FLAG:-}" ]]; then
+  git update-index "--${TEST_PREP_HIDDEN_FLAG}" nmkr-connect.php
+  printf 'hidden preparation change\n' >>nmkr-connect.php
 fi
 EOF
 cat >"$bin/wp-sentinel" <<'EOF'
@@ -75,6 +83,16 @@ case "${1:-} ${2:-}" in
     fi
     : >"$TEST_STATE/active"
     : >"$TEST_STATE/activated"
+    if [[ "${TEST_BLOCK_ACTIVATION:-false}" == true && ! -e "$TEST_STATE/activation-blocked" ]]; then
+      : >"$TEST_STATE/activation-blocked"
+      read -r _ <"$TEST_STATE/activation-release"
+      : >"$TEST_STATE/activation-released"
+    fi
+    if [[ -n "${TEST_FINAL_HIDDEN_FLAG:-}" && -d "$NMKR_DEPLOYED_PLUGIN_PATH/.git" && ! -e "$TEST_STATE/hidden-final" ]]; then
+      git -C "$NMKR_DEPLOYED_PLUGIN_PATH" update-index "--${TEST_FINAL_HIDDEN_FLAG}" nmkr-connect.php
+      printf 'hidden activated change\n' >>"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
+      : >"$TEST_STATE/hidden-final"
+    fi
     ;;
   'plugin is-active')
     [[ -e "$TEST_STATE/active" ]] || exit 1
@@ -107,7 +125,7 @@ new_case() {
   export WP_PATH=$case_root/private-wordpress-sentinel
   export WP_CLI_BIN=$bin/wp-sentinel COMPOSER_BIN=$bin/composer-sentinel
   export PATH=$bin:$ORIGINAL_PATH
-  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE
+  unset TEST_SYNC_ACTIVE TEST_BECOME_ACTIVE_AFTER_BUILD TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY TEST_BOUND_PATH TEST_FAIL_FIRST_MOVE TEST_FAIL_SECOND_MOVE TEST_FAIL_RESTORE_MOVE TEST_BLOCK_COMPOSER TEST_BLOCK_ACTIVATION TEST_PREP_HIDDEN_FLAG TEST_FINAL_HIDDEN_FLAG
   mkdir -p "$TEST_STATE" "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_DEPLOY_BACKUP_ROOT" "$WP_PATH"
   printf 'original\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
   printf '<?php // original synthetic\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
@@ -115,11 +133,27 @@ new_case() {
   output=$case_root/output
 }
 run_deploy() { bash "$deploy" --ref "$1" --expected-sha "$2" >"$output" 2>&1; }
+start_deploy() {
+  setsid bash "$deploy" --ref "$1" --expected-sha "$2" >"$output" 2>&1 &
+  deploy_pid=$!
+}
+wait_for_marker() {
+  local marker=$1 count=0
+  while [[ ! -e "$marker" && $count -lt 100 ]]; do sleep 0.02; count=$((count + 1)); done
+  [[ -e "$marker" ]]
+}
+signal_deploy() {
+  local signal=$1 status=0
+  kill -s "$signal" -- "-$deploy_pid"
+  wait "$deploy_pid" || status=$?
+  [[ $status -ne 0 ]]
+}
 unchanged() { [[ -f "$NMKR_DEPLOYED_PLUGIN_PATH/original-marker" ]]; }
 one_backup() { [[ $(find "$NMKR_DEPLOY_BACKUP_ROOT" -maxdepth 1 -type f -name '*.tar' | wc -l) -eq 1 ]]; }
 no_leaks() {
   ! rg -q 'private-remote-sentinel|private-backup-sentinel|private-wordpress-sentinel|PRIVATE_(WP|SUBPROCESS)_DIAGNOSTIC_SENTINEL' "$output"
 }
+no_success() { ! rg -q '^Exact-ref deployment succeeded\.$' "$output"; }
 ORIGINAL_PATH=$PATH
 
 new_case
@@ -196,6 +230,42 @@ export TEST_COMPOSER_FAIL=true
 check test_must_fail run_deploy refs/heads/main "$sha"
 check unchanged
 check test "$(find "$NMKR_DEPLOY_BACKUP_ROOT" -name '*.tar' | wc -l)" -eq 0
+check no_leaks
+
+new_case
+export TEST_BLOCK_COMPOSER=true
+mkfifo "$TEST_STATE/composer-release"
+start_deploy refs/heads/main "$sha"
+check wait_for_marker "$TEST_STATE/composer-blocked"
+check signal_deploy TERM
+check unchanged
+check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
+check no_leaks
+
+new_case
+export TEST_BLOCK_ACTIVATION=true
+mkfifo "$TEST_STATE/activation-release"
+start_deploy refs/heads/main "$sha"
+check wait_for_marker "$TEST_STATE/activation-blocked"
+check signal_deploy TERM
+check unchanged
+check test "$(find "${NMKR_DEPLOYED_PLUGIN_PATH%/*}" -maxdepth 1 -type d -name '.nmkr-previous.*' | wc -l)" -eq 0
+check no_leaks
+
+for hidden_flag in assume-unchanged skip-worktree; do
+  new_case
+  export TEST_PREP_HIDDEN_FLAG=$hidden_flag
+  check test_must_fail run_deploy refs/heads/main "$sha"
+  check unchanged
+  check test "$(find "$NMKR_DEPLOY_BACKUP_ROOT" -name '*.tar' | wc -l)" -eq 0
+done
+
+new_case
+export TEST_FINAL_HIDDEN_FLAG=assume-unchanged
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check one_backup
+check no_success
 check no_leaks
 
 new_case

--- a/scripts/nmkr-exact-ref-deploy-regression.sh
+++ b/scripts/nmkr-exact-ref-deploy-regression.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+root=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+deploy=$root/scripts/nmkr-exact-ref-deploy.sh
+tmp=$(mktemp -d "${TMPDIR:-/tmp}/nmkr-deploy-regression.XXXXXXXX")
+trap 'rm -rf -- "$tmp"' EXIT
+export GIT_AUTHOR_NAME='Synthetic Test' GIT_AUTHOR_EMAIL='test@example.invalid'
+export GIT_COMMITTER_NAME=$GIT_AUTHOR_NAME GIT_COMMITTER_EMAIL=$GIT_AUTHOR_EMAIL
+
+pass=0
+check() { if "$@"; then pass=$((pass + 1)); else printf 'Deploy regression failed.\n' >&2; exit 1; fi; }
+test_must_fail() { if "$@"; then return 1; else return 0; fi; }
+
+source_repo=$tmp/source
+remote=$tmp/private-remote-sentinel.git
+mkdir "$source_repo"
+git -C "$source_repo" init -q -b main
+mkdir -p "$source_repo"/{includes,css,js,vendor/freemius/wordpress-sdk,tools}
+printf '<?php // synthetic\n' >"$source_repo/nmkr-connect.php"
+printf '{"name":"synthetic/nmkr-connect"}\n' >"$source_repo/composer.json"
+printf '{"packages":[]}\n' >"$source_repo/composer.lock"
+printf 'placeholder\n' >"$source_repo/includes/readme"
+printf 'placeholder\n' >"$source_repo/css/readme"
+printf 'placeholder\n' >"$source_repo/js/readme"
+cat >"$source_repo/tools/tracked-executable" <<'EOF'
+#!/usr/bin/env sh
+exit 0
+EOF
+chmod 0755 "$source_repo/tools/tracked-executable"
+git -C "$source_repo" add .
+git -C "$source_repo" commit -qm 'synthetic deployment fixture'
+sha=$(git -C "$source_repo" rev-parse HEAD)
+git init -q --bare "$remote"
+git -C "$source_repo" remote add origin "$remote"
+git -C "$source_repo" push -q origin main
+git -C "$source_repo" push -q origin HEAD:refs/pull/123/head
+
+bin=$tmp/bin
+mkdir "$bin"
+cat >"$bin/composer-sentinel" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+printf 'composer\n' >>"$TEST_STATE/composer-calls"
+printf 'PRIVATE_SUBPROCESS_DIAGNOSTIC_SENTINEL\n' >&2
+[[ "${TEST_COMPOSER_FAIL:-false}" != true ]] || exit 9
+mkdir -p vendor/freemius/wordpress-sdk
+printf '<?php // generated synthetic autoloader\n' >vendor/autoload.php
+if [[ "${TEST_MISSING_BUILD:-false}" != true ]]; then
+  printf '<?php // generated synthetic SDK entry\n' >vendor/freemius/wordpress-sdk/start.php
+fi
+EOF
+cat >"$bin/wp-sentinel" <<'EOF'
+#!/usr/bin/env bash
+set -eu
+printf 'PRIVATE_WP_DIAGNOSTIC_SENTINEL\n' >&2
+while [[ "${1:-}" == --path=* ]]; do shift; done
+case "${1:-} ${2:-}" in
+  'eval '*) [[ "${TEST_SYNC_ACTIVE:-false}" != true ]] && printf NMKR_IDLE ;;
+  'plugin activate')
+    if [[ "${TEST_ACTIVATE_FAIL_ONCE:-false}" == true && ! -e "$TEST_STATE/activation-failed" ]]; then
+      : >"$TEST_STATE/activation-failed"; exit 8
+    fi
+    : >"$TEST_STATE/active"
+    ;;
+  'plugin is-active')
+    [[ -e "$TEST_STATE/active" ]] || exit 1
+    if [[ "${TEST_FINAL_DIRTY:-false}" == true && -d "$NMKR_DEPLOYED_PLUGIN_PATH/.git" && ! -e "$TEST_STATE/dirtied" ]]; then
+      printf 'dirty\n' >>"$NMKR_DEPLOYED_PLUGIN_PATH/nmkr-connect.php"
+      : >"$TEST_STATE/dirtied"
+    fi
+    ;;
+  *) exit 2 ;;
+esac
+EOF
+chmod +x "$bin/composer-sentinel" "$bin/wp-sentinel"
+
+new_case() {
+  case_root=$(mktemp -d "$tmp/case.XXXXXXXX")
+  export TEST_STATE=$case_root/state
+  export NMKR_DEPLOY_REMOTE=$remote
+  export NMKR_DEPLOYED_PLUGIN_PATH=$case_root/plugins/nmkr-connect
+  export NMKR_DEPLOY_BACKUP_ROOT=$case_root/private-backup-sentinel
+  export WP_PATH=$case_root/private-wordpress-sentinel
+  export WP_CLI_BIN=$bin/wp-sentinel COMPOSER_BIN=$bin/composer-sentinel
+  unset TEST_SYNC_ACTIVE TEST_COMPOSER_FAIL TEST_MISSING_BUILD TEST_ACTIVATE_FAIL_ONCE TEST_FINAL_DIRTY
+  mkdir -p "$TEST_STATE" "$NMKR_DEPLOYED_PLUGIN_PATH" "$NMKR_DEPLOY_BACKUP_ROOT" "$WP_PATH"
+  printf 'original\n' >"$NMKR_DEPLOYED_PLUGIN_PATH/original-marker"
+  output=$case_root/output
+}
+run_deploy() { bash "$deploy" --ref "$1" --expected-sha "$2" >"$output" 2>&1; }
+unchanged() { [[ -f "$NMKR_DEPLOYED_PLUGIN_PATH/original-marker" ]]; }
+one_backup() { [[ $(find "$NMKR_DEPLOY_BACKUP_ROOT" -maxdepth 1 -type f -name '*.tar' | wc -l) -eq 1 ]]; }
+no_leaks() {
+  ! rg -q 'private-remote-sentinel|private-backup-sentinel|private-wordpress-sentinel|PRIVATE_(WP|SUBPROCESS)_DIAGNOSTIC_SENTINEL' "$output"
+}
+
+new_case
+check run_deploy refs/pull/123/head "$sha"
+check test "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" rev-parse HEAD)" = "$sha"
+check test -z "$(git -C "$NMKR_DEPLOYED_PLUGIN_PATH" status --porcelain --untracked-files=no)"
+check test "$(stat -c %a "$NMKR_DEPLOYED_PLUGIN_PATH/tools/tracked-executable")" = 755
+check one_backup
+check no_leaks
+
+new_case
+check run_deploy refs/heads/main "${sha^^}"
+check test -e "$NMKR_DEPLOYED_PLUGIN_PATH/vendor/autoload.php"
+check no_leaks
+
+new_case
+check test_must_fail run_deploy refs/heads/main invalid
+check test_must_fail run_deploy refs/tags/main "$sha"
+check unchanged
+
+new_case
+wrong=0000000000000000000000000000000000000000
+check test_must_fail run_deploy refs/heads/main "$wrong"
+check unchanged
+check no_leaks
+
+new_case
+export TEST_SYNC_ACTIVE=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check test ! -e "$TEST_STATE/composer-calls"
+
+new_case
+export TEST_COMPOSER_FAIL=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check test "$(find "$NMKR_DEPLOY_BACKUP_ROOT" -name '*.tar' | wc -l)" -eq 0
+check no_leaks
+
+new_case
+export TEST_MISSING_BUILD=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+
+new_case
+export TEST_ACTIVATE_FAIL_ONCE=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check one_backup
+check test -e "$TEST_STATE/active"
+check no_leaks
+
+new_case
+export TEST_FINAL_DIRTY=true
+check test_must_fail run_deploy refs/heads/main "$sha"
+check unchanged
+check one_backup
+check no_leaks
+
+printf 'Exact-ref deployment regression: PASS (%d assertions)\n' "$pass"

--- a/scripts/nmkr-exact-ref-deploy.sh
+++ b/scripts/nmkr-exact-ref-deploy.sh
@@ -44,7 +44,7 @@ for name in NMKR_DEPLOY_REMOTE NMKR_DEPLOYED_PLUGIN_PATH NMKR_DEPLOY_BACKUP_ROOT
 done
 WP_CLI_BIN=${WP_CLI_BIN:-wp}
 COMPOSER_BIN=${COMPOSER_BIN:-composer}
-for command_name in git tar flock mktemp "$WP_CLI_BIN" "$COMPOSER_BIN"; do
+for command_name in git tar flock mktemp cp mv realpath "$WP_CLI_BIN" "$COMPOSER_BIN"; do
   command -v "$command_name" >/dev/null 2>&1 || fail
 done
 
@@ -60,24 +60,44 @@ case "$backup_root/" in "$live/"*) fail ;; esac
 exec 9>"$backup_root/.nmkr-exact-ref-deploy.lock" || fail
 flock -n 9 || fail
 work=$(mktemp -d "${TMPDIR:-/tmp}/nmkr-exact-ref.XXXXXXXX") || fail
+staged=
 displaced=
+original_displaced=false
+candidate_installed=false
+preserve_displaced=false
 cleanup() {
-  [[ -z "$displaced" || ! -e "$displaced" ]] || rm -rf -- "$displaced"
+  [[ -z "$staged" || ! -e "$staged" ]] || rm -rf -- "$staged"
+  if ! $preserve_displaced; then
+    [[ -z "$displaced" || ! -e "$displaced" ]] || rm -rf -- "$displaced"
+  fi
   rm -rf -- "$work"
 }
 trap cleanup EXIT
 
 wp_quiet() { "$WP_CLI_BIN" --path="$WP_PATH" "$@" >/dev/null 2>&1; }
 sync_is_idle() {
-  local answer
-  answer=$("$WP_CLI_BIN" --path="$WP_PATH" eval '
-    $truthy = static function ($value) { return !empty($value); };
-    $owner = get_option("nmkr_sync_owner", false);
-    $data = get_option("nmkr_sync_data", false);
-    $active_data = is_array($data) && in_array(($data["status"] ?? ""), array("initializing", "queued", "running", "stop_requested", "finalizing"), true);
-    if (!$truthy(get_option("nmkr_sync_in_progress", false)) && !$truthy(get_transient("nmkr_sync_in_progress")) && empty($owner) && !$active_data) { echo "NMKR_IDLE"; }
-  ' 2>/dev/null) || return 1
-  [[ "$answer" == NMKR_IDLE ]]
+  NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php WP_PATH="$WP_PATH" WP_CLI_BIN="$WP_CLI_BIN" \
+    "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nmkr-wpcli-ajax-security-state.sh" idle >/dev/null 2>&1
+}
+active_plugin_is_bound() {
+  local deployed_root expected_file active_file
+  [[ ! -L "$live" ]] || return 1
+  deployed_root=$(realpath -e -- "$live" 2>/dev/null) || return 1
+  [[ -d "$deployed_root" ]] || return 1
+  expected_file=$deployed_root/nmkr-connect.php
+  [[ -f "$expected_file" && ! -L "$expected_file" ]] || return 1
+  [[ "$(realpath -e -- "$expected_file" 2>/dev/null)" == "$expected_file" ]] || return 1
+  active_file=$(NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php "$WP_CLI_BIN" --path="$WP_PATH" eval 'require_once ABSPATH . "wp-admin/includes/plugin.php"; $slug = getenv("NMKR_PLUGIN_SLUG"); if ($slug !== "nmkr-connect/nmkr-connect.php" || !is_plugin_active($slug)) { exit(1); } $file = realpath(WP_PLUGIN_DIR . "/" . $slug); if ($file === false || !is_file($file)) { exit(1); } echo $file;' 2>/dev/null) || return 1
+  [[ "$active_file" == "$expected_file" ]]
+}
+candidate_is_valid() {
+  local candidate=$1 item file
+  [[ "$(git -C "$candidate" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || return 1
+  [[ -z "$(git -C "$candidate" -c core.fileMode=true status --porcelain --untracked-files=no 2>/dev/null)" ]] || return 1
+  for item in "${required[@]}"; do [[ -e "$candidate/$item" ]] || return 1; done
+  while IFS= read -r -d '' file; do
+    [[ -x "$candidate/$file" ]] || return 1
+  done < <(git -C "$candidate" ls-files -z --stage | awk -v RS='\0' -F '[ \t]+' '$1 == "100755" { sub(/^[^\t]*\t/, ""); printf "%s%c", $0, 0 }')
 }
 
 sync_is_idle || fail
@@ -96,26 +116,47 @@ for item in "${required[@]}"; do [[ -e "$repo/$item" ]] || fail; done
 find "$repo" -type d -exec chmod 0755 {} + >/dev/null 2>&1 || fail
 find "$repo" -type f -exec chmod 0644 {} + >/dev/null 2>&1 || fail
 while IFS= read -r -d '' file; do chmod 0755 "$repo/$file" || fail; done < <(git -C "$repo" ls-files -z --stage | awk -v RS='\0' -F '[ \t]+' '$1 == "100755" { sub(/^[^\t]*\t/, ""); printf "%s%c", $0, 0 }')
-[[ "$(git -C "$repo" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || fail
-[[ -z "$(git -C "$repo" status --porcelain --untracked-files=no 2>/dev/null)" ]] || fail
+candidate_is_valid "$repo" || fail
 
-sync_is_idle || fail
 stamp=$(date -u +%Y%m%dT%H%M%SZ)-$$
 backup="$backup_root/nmkr-connect-$stamp.tar"
 tar -C "$live_parent" -cpf "$backup" -- "${live##*/}" >/dev/null 2>&1 || fail
-displaced=$work/previous-plugin
-if ! mv -- "$live" "$displaced" >/dev/null 2>&1 || ! mv -- "$repo" "$live" >/dev/null 2>&1; then
-  rm -rf -- "$live"
-  mv -- "$displaced" "$live" >/dev/null 2>&1 || true
-  displaced=
-  printf 'Exact-ref deployment failed; rollback attempted.\n'
+staged=$(mktemp -d "$live_parent/.nmkr-candidate.XXXXXXXX") || fail
+cp -a -- "$repo/." "$staged/" >/dev/null 2>&1 || fail
+candidate_is_valid "$staged" || fail
+displaced=$(mktemp -d "$live_parent/.nmkr-previous.XXXXXXXX") || fail
+rmdir -- "$displaced" >/dev/null 2>&1 || fail
+
+active_plugin_is_bound || fail
+sync_is_idle || fail
+if ! mv -- "$live" "$displaced" >/dev/null 2>&1; then
+  printf 'Exact-ref deployment failed.\n'
   exit 1
 fi
+original_displaced=true
+if ! mv -- "$staged" "$live" >/dev/null 2>&1; then
+  if mv -- "$displaced" "$live" >/dev/null 2>&1; then
+    original_displaced=false; displaced=
+    printf 'Exact-ref deployment failed; rollback succeeded.\n'
+  else
+    preserve_displaced=true
+    printf 'Exact-ref deployment failed; rollback failed.\n'
+  fi
+  exit 1
+fi
+candidate_installed=true; staged=
 
 rollback() {
-  rm -rf -- "$live"
-  if mv -- "$displaced" "$live" >/dev/null 2>&1 && wp_quiet plugin activate nmkr-connect && wp_quiet plugin is-active nmkr-connect; then
-    displaced=
+  $candidate_installed && rm -rf -- "$live"
+  candidate_installed=false
+  if $original_displaced && mv -- "$displaced" "$live" >/dev/null 2>&1; then
+    original_displaced=false; displaced=
+  else
+    preserve_displaced=true
+    printf 'Exact-ref deployment failed; rollback failed.\n'
+    exit 1
+  fi
+  if wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound; then
     printf 'Exact-ref deployment failed; rollback succeeded.\n'
   else
     printf 'Exact-ref deployment failed; rollback failed.\n'
@@ -123,11 +164,12 @@ rollback() {
   exit 1
 }
 
-wp_quiet plugin activate nmkr-connect || rollback
-wp_quiet plugin is-active nmkr-connect || rollback
+wp_quiet plugin activate nmkr-connect/nmkr-connect.php || rollback
+active_plugin_is_bound || rollback
 [[ "$(git -C "$live" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || rollback
 [[ -z "$(git -C "$live" status --porcelain --untracked-files=no 2>/dev/null)" ]] || rollback
 for item in "${required[@]}"; do [[ -e "$live/$item" ]] || rollback; done
+active_plugin_is_bound || rollback
 
-rm -rf -- "$displaced"; displaced=
+rm -rf -- "$displaced"; displaced=; original_displaced=false
 printf 'Exact-ref deployment succeeded.\n'

--- a/scripts/nmkr-exact-ref-deploy.sh
+++ b/scripts/nmkr-exact-ref-deploy.sh
@@ -66,8 +66,12 @@ original_displaced=false
 candidate_installed=false
 preserve_displaced=false
 restoration_in_progress=false
+backup_temp=
+pending_signal=
+signal_handling=false
 cleanup() {
   [[ -z "$staged" || ! -e "$staged" ]] || rm -rf -- "$staged"
+  [[ -z "$backup_temp" || ! -e "$backup_temp" ]] || rm -f -- "$backup_temp"
   rm -rf -- "$work"
 }
 trap cleanup EXIT
@@ -108,41 +112,76 @@ candidate_is_valid() {
   done < <(git -C "$candidate" ls-files -z --stage | awk -v RS='\0' -F '[ \t]+' '$1 == "100755" { sub(/^[^\t]*\t/, ""); printf "%s%c", $0, 0 }')
 }
 
-restore_previous() {
-  local can_replace_live=false restored=false
+defer_signal() {
+  [[ -n "$pending_signal" ]] || pending_signal=$1
+}
+run_protected() {
+  local child status=0
+  if $signal_handling; then
+    trap '' INT TERM
+    "$@"
+    return
+  fi
+  pending_signal=
+  trap 'defer_signal INT' INT
+  trap 'defer_signal TERM' TERM
+  ( trap '' INT TERM; "$@" ) &
+  child=$!
+  while true; do
+    if wait "$child"; then
+      status=0
+      break
+    else
+      status=$?
+      kill -0 "$child" 2>/dev/null || break
+    fi
+  done
+  trap 'handle_signal INT' INT
+  trap 'handle_signal TERM' TERM
+  if [[ -n "$pending_signal" ]]; then
+    local replay=$pending_signal
+    pending_signal=
+    handle_signal "$replay"
+  fi
+  return "$status"
+}
+restoration_transaction() {
+  local can_replace_live=false
   [[ -n "$displaced" && -d "$displaced" && ! -L "$displaced" ]] || return 1
-  # Restoration is one indivisible transaction: children inherit ignored
-  # deployment signals until the previous tree is active and exactly bound.
-  trap '' INT TERM
   if [[ ! -e "$live" ]]; then
     can_replace_live=true
   elif $candidate_installed || [[ -n "$staged" && ! -e "$staged" ]]; then
     # The candidate sibling has completed its rename. The displaced sibling is
     # therefore the recoverable previous tree even if the following flag write
     # was interrupted.
-    rm -rf -- "$live" || restored=false
+    rm -rf -- "$live" || return 1
     can_replace_live=true
   fi
   if $can_replace_live && [[ ! -e "$live" ]]; then
-    restoration_in_progress=true
     if mv -- "$displaced" "$live" >/dev/null 2>&1; then
-      candidate_installed=false
-      if wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound; then
-        restored=true
-      fi
+      wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound
+      return
     fi
   fi
+  return 1
+}
+restore_previous() {
+  local restored=false
+  restoration_in_progress=true
+  if run_protected restoration_transaction; then restored=true; fi
   if $restored; then
+    candidate_installed=false
     original_displaced=false; restoration_in_progress=false; displaced=
   else
     preserve_displaced=true
   fi
-  trap 'handle_signal 130' INT
-  trap 'handle_signal 143' TERM
   $restored
 }
 handle_signal() {
-  local status=$1
+  local signal=$1 status=143
+  [[ "$signal" == INT ]] && status=130
+  $signal_handling && return
+  signal_handling=true
   trap '' INT TERM
   if [[ -n "$displaced" && -e "$displaced" ]]; then
     if restore_previous; then
@@ -156,8 +195,8 @@ handle_signal() {
   fi
   exit "$status"
 }
-trap 'handle_signal 130' INT
-trap 'handle_signal 143' TERM
+trap 'handle_signal INT' INT
+trap 'handle_signal TERM' TERM
 
 sync_is_idle || fail
 repo=$work/repository
@@ -179,7 +218,14 @@ candidate_is_valid "$repo" || fail
 
 stamp=$(date -u +%Y%m%dT%H%M%SZ)-$$
 backup="$backup_root/nmkr-connect-$stamp.tar"
-tar -C "$live_parent" -cpf "$backup" -- "${live##*/}" >/dev/null 2>&1 || fail
+backup_temp=$(mktemp "$backup_root/.nmkr-connect-$stamp.XXXXXXXX.tmp") || fail
+if ! tar -C "$live_parent" -cpf "$backup_temp" -- "${live##*/}" >/dev/null 2>&1; then
+  rm -f -- "$backup_temp"
+  backup_temp=
+  fail
+fi
+mv -- "$backup_temp" "$backup" >/dev/null 2>&1 || fail
+backup_temp=
 staged=$(mktemp -d "$live_parent/.nmkr-candidate.XXXXXXXX") || fail
 cp -a -- "$repo/." "$staged/" >/dev/null 2>&1 || fail
 candidate_is_valid "$staged" || fail
@@ -220,15 +266,10 @@ active_plugin_is_bound || rollback
 candidate_is_valid "$live" || rollback
 active_plugin_is_bound || rollback
 
-trap '' INT TERM
-if rm -rf -- "$displaced"; then
+if run_protected rm -rf -- "$displaced"; then
   displaced=; original_displaced=false
 else
   preserve_displaced=true
-  trap 'handle_signal 130' INT
-  trap 'handle_signal 143' TERM
   fail
 fi
-trap 'handle_signal 130' INT
-trap 'handle_signal 143' TERM
 printf 'Exact-ref deployment succeeded.\n'

--- a/scripts/nmkr-exact-ref-deploy.sh
+++ b/scripts/nmkr-exact-ref-deploy.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+set +x
+exec 2>/dev/null
+
+fail() {
+  printf 'Exact-ref deployment failed.\n'
+  exit 1
+}
+
+ref=
+expected_sha=
+seen_ref=false
+seen_sha=false
+while (( $# )); do
+  case "$1" in
+    --ref)
+      $seen_ref && fail
+      (( $# >= 2 )) || fail
+      ref=$2; seen_ref=true; shift 2
+      ;;
+    --expected-sha)
+      $seen_sha && fail
+      (( $# >= 2 )) || fail
+      expected_sha=$2; seen_sha=true; shift 2
+      ;;
+    *) fail ;;
+  esac
+done
+$seen_ref && $seen_sha || fail
+[[ "$expected_sha" =~ ^[0-9A-Fa-f]{40}$ ]] || fail
+expected_sha=${expected_sha,,}
+if [[ "$ref" =~ ^refs/pull/([1-9][0-9]*)/head$ ]]; then
+  :
+elif [[ "$ref" =~ ^refs/heads/[A-Za-z0-9][A-Za-z0-9._-]*(/[A-Za-z0-9][A-Za-z0-9._-]*)*$ ]] &&
+     [[ "$ref" != *'..'* && "$ref" != *'.lock' && "$ref" != *'.' ]]; then
+  :
+else
+  fail
+fi
+
+for name in NMKR_DEPLOY_REMOTE NMKR_DEPLOYED_PLUGIN_PATH NMKR_DEPLOY_BACKUP_ROOT WP_PATH; do
+  [[ -n "${!name:-}" ]] || fail
+done
+WP_CLI_BIN=${WP_CLI_BIN:-wp}
+COMPOSER_BIN=${COMPOSER_BIN:-composer}
+for command_name in git tar flock mktemp "$WP_CLI_BIN" "$COMPOSER_BIN"; do
+  command -v "$command_name" >/dev/null 2>&1 || fail
+done
+
+live=$NMKR_DEPLOYED_PLUGIN_PATH
+backup_root=$NMKR_DEPLOY_BACKUP_ROOT
+[[ "$live" == /* && "$backup_root" == /* && "$WP_PATH" == /* ]] || fail
+[[ "$live" != / && "$backup_root" != / ]] || fail
+[[ ! -L "$live" && ! -L "$backup_root" && -d "$live" && -d "$backup_root" ]] || fail
+live_parent=${live%/*}; [[ -n "$live_parent" ]] || live_parent=/
+[[ -d "$live_parent" && -w "$live_parent" && -w "$backup_root" ]] || fail
+case "$backup_root/" in "$live/"*) fail ;; esac
+
+exec 9>"$backup_root/.nmkr-exact-ref-deploy.lock" || fail
+flock -n 9 || fail
+work=$(mktemp -d "${TMPDIR:-/tmp}/nmkr-exact-ref.XXXXXXXX") || fail
+displaced=
+cleanup() {
+  [[ -z "$displaced" || ! -e "$displaced" ]] || rm -rf -- "$displaced"
+  rm -rf -- "$work"
+}
+trap cleanup EXIT
+
+wp_quiet() { "$WP_CLI_BIN" --path="$WP_PATH" "$@" >/dev/null 2>&1; }
+sync_is_idle() {
+  local answer
+  answer=$("$WP_CLI_BIN" --path="$WP_PATH" eval '
+    $truthy = static function ($value) { return !empty($value); };
+    $owner = get_option("nmkr_sync_owner", false);
+    $data = get_option("nmkr_sync_data", false);
+    $active_data = is_array($data) && in_array(($data["status"] ?? ""), array("initializing", "queued", "running", "stop_requested", "finalizing"), true);
+    if (!$truthy(get_option("nmkr_sync_in_progress", false)) && !$truthy(get_transient("nmkr_sync_in_progress")) && empty($owner) && !$active_data) { echo "NMKR_IDLE"; }
+  ' 2>/dev/null) || return 1
+  [[ "$answer" == NMKR_IDLE ]]
+}
+
+sync_is_idle || fail
+repo=$work/repository
+mkdir "$repo"
+git -C "$repo" init -q >/dev/null 2>&1 || fail
+git -C "$repo" -c protocol.file.allow=always fetch -q --no-tags --depth=1 "$NMKR_DEPLOY_REMOTE" "+$ref:refs/nmkr-selected" >/dev/null 2>&1 || fail
+resolved=$(git -C "$repo" rev-parse --verify 'refs/nmkr-selected^{commit}' 2>/dev/null) || fail
+[[ "${resolved,,}" == "$expected_sha" ]] || fail
+git -C "$repo" -c advice.detachedHead=false checkout -q --detach "$expected_sha" >/dev/null 2>&1 || fail
+
+(cd "$repo" && "$COMPOSER_BIN" install --no-dev --prefer-dist --no-interaction --no-progress --optimize-autoloader) >/dev/null 2>&1 || fail
+required=(nmkr-connect.php composer.json composer.lock includes css js vendor/autoload.php vendor/freemius/wordpress-sdk/start.php)
+for item in "${required[@]}"; do [[ -e "$repo/$item" ]] || fail; done
+
+find "$repo" -type d -exec chmod 0755 {} + >/dev/null 2>&1 || fail
+find "$repo" -type f -exec chmod 0644 {} + >/dev/null 2>&1 || fail
+while IFS= read -r -d '' file; do chmod 0755 "$repo/$file" || fail; done < <(git -C "$repo" ls-files -z --stage | awk -v RS='\0' -F '[ \t]+' '$1 == "100755" { sub(/^[^\t]*\t/, ""); printf "%s%c", $0, 0 }')
+[[ "$(git -C "$repo" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || fail
+[[ -z "$(git -C "$repo" status --porcelain --untracked-files=no 2>/dev/null)" ]] || fail
+
+sync_is_idle || fail
+stamp=$(date -u +%Y%m%dT%H%M%SZ)-$$
+backup="$backup_root/nmkr-connect-$stamp.tar"
+tar -C "$live_parent" -cpf "$backup" -- "${live##*/}" >/dev/null 2>&1 || fail
+displaced=$work/previous-plugin
+if ! mv -- "$live" "$displaced" >/dev/null 2>&1 || ! mv -- "$repo" "$live" >/dev/null 2>&1; then
+  rm -rf -- "$live"
+  mv -- "$displaced" "$live" >/dev/null 2>&1 || true
+  displaced=
+  printf 'Exact-ref deployment failed; rollback attempted.\n'
+  exit 1
+fi
+
+rollback() {
+  rm -rf -- "$live"
+  if mv -- "$displaced" "$live" >/dev/null 2>&1 && wp_quiet plugin activate nmkr-connect && wp_quiet plugin is-active nmkr-connect; then
+    displaced=
+    printf 'Exact-ref deployment failed; rollback succeeded.\n'
+  else
+    printf 'Exact-ref deployment failed; rollback failed.\n'
+  fi
+  exit 1
+}
+
+wp_quiet plugin activate nmkr-connect || rollback
+wp_quiet plugin is-active nmkr-connect || rollback
+[[ "$(git -C "$live" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || rollback
+[[ -z "$(git -C "$live" status --porcelain --untracked-files=no 2>/dev/null)" ]] || rollback
+for item in "${required[@]}"; do [[ -e "$live/$item" ]] || rollback; done
+
+rm -rf -- "$displaced"; displaced=
+printf 'Exact-ref deployment succeeded.\n'

--- a/scripts/nmkr-exact-ref-deploy.sh
+++ b/scripts/nmkr-exact-ref-deploy.sh
@@ -65,6 +65,7 @@ displaced=
 original_displaced=false
 candidate_installed=false
 preserve_displaced=false
+restoration_in_progress=false
 cleanup() {
   [[ -z "$staged" || ! -e "$staged" ]] || rm -rf -- "$staged"
   rm -rf -- "$work"
@@ -108,21 +109,37 @@ candidate_is_valid() {
 }
 
 restore_previous() {
-  local can_replace_live=false
+  local can_replace_live=false restored=false
   [[ -n "$displaced" && -d "$displaced" && ! -L "$displaced" ]] || return 1
+  # Restoration is one indivisible transaction: children inherit ignored
+  # deployment signals until the previous tree is active and exactly bound.
+  trap '' INT TERM
   if [[ ! -e "$live" ]]; then
     can_replace_live=true
   elif $candidate_installed || [[ -n "$staged" && ! -e "$staged" ]]; then
     # The candidate sibling has completed its rename. The displaced sibling is
     # therefore the recoverable previous tree even if the following flag write
     # was interrupted.
-    rm -rf -- "$live" || return 1
+    rm -rf -- "$live" || restored=false
     can_replace_live=true
   fi
-  $can_replace_live || return 1
-  mv -- "$displaced" "$live" >/dev/null 2>&1 || return 1
-  original_displaced=false; candidate_installed=false; displaced=
-  wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound
+  if $can_replace_live && [[ ! -e "$live" ]]; then
+    restoration_in_progress=true
+    if mv -- "$displaced" "$live" >/dev/null 2>&1; then
+      candidate_installed=false
+      if wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound; then
+        restored=true
+      fi
+    fi
+  fi
+  if $restored; then
+    original_displaced=false; restoration_in_progress=false; displaced=
+  else
+    preserve_displaced=true
+  fi
+  trap 'handle_signal 130' INT
+  trap 'handle_signal 143' TERM
+  $restored
 }
 handle_signal() {
   local status=$1
@@ -203,5 +220,15 @@ active_plugin_is_bound || rollback
 candidate_is_valid "$live" || rollback
 active_plugin_is_bound || rollback
 
-rm -rf -- "$displaced"; displaced=; original_displaced=false
+trap '' INT TERM
+if rm -rf -- "$displaced"; then
+  displaced=; original_displaced=false
+else
+  preserve_displaced=true
+  trap 'handle_signal 130' INT
+  trap 'handle_signal 143' TERM
+  fail
+fi
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
 printf 'Exact-ref deployment succeeded.\n'

--- a/scripts/nmkr-exact-ref-deploy.sh
+++ b/scripts/nmkr-exact-ref-deploy.sh
@@ -67,9 +67,6 @@ candidate_installed=false
 preserve_displaced=false
 cleanup() {
   [[ -z "$staged" || ! -e "$staged" ]] || rm -rf -- "$staged"
-  if ! $preserve_displaced; then
-    [[ -z "$displaced" || ! -e "$displaced" ]] || rm -rf -- "$displaced"
-  fi
   rm -rf -- "$work"
 }
 trap cleanup EXIT
@@ -90,15 +87,60 @@ active_plugin_is_bound() {
   active_file=$(NMKR_PLUGIN_SLUG=nmkr-connect/nmkr-connect.php "$WP_CLI_BIN" --path="$WP_PATH" eval 'require_once ABSPATH . "wp-admin/includes/plugin.php"; $slug = getenv("NMKR_PLUGIN_SLUG"); if ($slug !== "nmkr-connect/nmkr-connect.php" || !is_plugin_active($slug)) { exit(1); } $file = realpath(WP_PLUGIN_DIR . "/" . $slug); if ($file === false || !is_file($file)) { exit(1); } echo $file;' 2>/dev/null) || return 1
   [[ "$active_file" == "$expected_file" ]]
 }
+git_head_and_clean() {
+  local candidate=$1 head status index_entry
+  head=$(git -C "$candidate" rev-parse HEAD 2>/dev/null) || return 1
+  [[ "$head" == "$expected_sha" ]] || return 1
+  status=$(git -C "$candidate" -c core.fileMode=true status --porcelain --untracked-files=no 2>/dev/null) || return 1
+  [[ -z "$status" ]] || return 1
+  git -C "$candidate" ls-files -v -z 2>/dev/null |
+    while IFS= read -r -d '' index_entry; do
+      [[ "${index_entry:0:1}" != S && "${index_entry:0:1}" != [a-z] ]] || exit 1
+    done
+}
 candidate_is_valid() {
   local candidate=$1 item file
-  [[ "$(git -C "$candidate" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || return 1
-  [[ -z "$(git -C "$candidate" -c core.fileMode=true status --porcelain --untracked-files=no 2>/dev/null)" ]] || return 1
+  git_head_and_clean "$candidate" || return 1
   for item in "${required[@]}"; do [[ -e "$candidate/$item" ]] || return 1; done
   while IFS= read -r -d '' file; do
     [[ -x "$candidate/$file" ]] || return 1
   done < <(git -C "$candidate" ls-files -z --stage | awk -v RS='\0' -F '[ \t]+' '$1 == "100755" { sub(/^[^\t]*\t/, ""); printf "%s%c", $0, 0 }')
 }
+
+restore_previous() {
+  local can_replace_live=false
+  [[ -n "$displaced" && -d "$displaced" && ! -L "$displaced" ]] || return 1
+  if [[ ! -e "$live" ]]; then
+    can_replace_live=true
+  elif $candidate_installed || [[ -n "$staged" && ! -e "$staged" ]]; then
+    # The candidate sibling has completed its rename. The displaced sibling is
+    # therefore the recoverable previous tree even if the following flag write
+    # was interrupted.
+    rm -rf -- "$live" || return 1
+    can_replace_live=true
+  fi
+  $can_replace_live || return 1
+  mv -- "$displaced" "$live" >/dev/null 2>&1 || return 1
+  original_displaced=false; candidate_installed=false; displaced=
+  wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound
+}
+handle_signal() {
+  local status=$1
+  trap '' INT TERM
+  if [[ -n "$displaced" && -e "$displaced" ]]; then
+    if restore_previous; then
+      printf 'Exact-ref deployment interrupted; rollback succeeded.\n'
+    else
+      preserve_displaced=true
+      printf 'Exact-ref deployment interrupted; rollback failed.\n'
+    fi
+  else
+    printf 'Exact-ref deployment interrupted.\n'
+  fi
+  exit "$status"
+}
+trap 'handle_signal 130' INT
+trap 'handle_signal 143' TERM
 
 sync_is_idle || fail
 repo=$work/repository
@@ -147,28 +189,18 @@ fi
 candidate_installed=true; staged=
 
 rollback() {
-  $candidate_installed && rm -rf -- "$live"
-  candidate_installed=false
-  if $original_displaced && mv -- "$displaced" "$live" >/dev/null 2>&1; then
-    original_displaced=false; displaced=
-  else
+  if ! restore_previous; then
     preserve_displaced=true
     printf 'Exact-ref deployment failed; rollback failed.\n'
     exit 1
   fi
-  if wp_quiet plugin activate nmkr-connect/nmkr-connect.php && active_plugin_is_bound; then
-    printf 'Exact-ref deployment failed; rollback succeeded.\n'
-  else
-    printf 'Exact-ref deployment failed; rollback failed.\n'
-  fi
+  printf 'Exact-ref deployment failed; rollback succeeded.\n'
   exit 1
 }
 
 wp_quiet plugin activate nmkr-connect/nmkr-connect.php || rollback
 active_plugin_is_bound || rollback
-[[ "$(git -C "$live" rev-parse HEAD 2>/dev/null)" == "$expected_sha" ]] || rollback
-[[ -z "$(git -C "$live" status --porcelain --untracked-files=no 2>/dev/null)" ]] || rollback
-for item in "${required[@]}"; do [[ -e "$live/$item" ]] || rollback; done
+candidate_is_valid "$live" || rollback
 active_plugin_is_bound || rollback
 
 rm -rf -- "$displaced"; displaced=; original_displaced=false

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -23,6 +23,9 @@ bash scripts/nmkr-real-sync-preflight-regression.sh
 printf '\n== Public-safe Phase 2 readonly profile regression checks ==\n'
 bash scripts/nmkr-phase2-profile-regression.sh
 
+printf '\n== Public-safe exact-ref deployment regression checks ==\n'
+bash scripts/nmkr-exact-ref-deploy-regression.sh
+
 
 printf '\n== Public-safe Phase 16A controlled real-sync regression checks ==\n'
 bash scripts/nmkr-real-sync-phase16a-regression.sh


### PR DESCRIPTION
### Motivation

- Provide a minimal, safe Phase 2 exact-ref deployment helper that implements the NMKR_DEPLOY_COMMAND contract for the fixed `nmkr-connect` plugin without exposing private configuration or running a real sync. 
- Enable public CI to exercise a bounded synthetic regression that verifies the helper's core success and rollback paths in an offline, private-data-free manner.

### Description

- Add `scripts/nmkr-exact-ref-deploy.sh`, a focused exact-ref deploy helper that implements strict `--ref`/`--expected-sha` parsing and validation, idle-state checks before preparation and again immediately before live replacement, isolated single-ref/no-tags fetch into a temporary repository, exact-SHA verification, production `composer install` build, required-file and tracked-executable mode checks, Git metadata preservation, timestamped single backup creation, an exclusive lock under the backup root, safe replacement of only `NMKR_DEPLOYED_PLUGIN_PATH`, and generic rollback on failure while suppressing private subprocess diagnostics.
- Add `scripts/nmkr-exact-ref-deploy-regression.sh`, a synthetic regression driver that uses local temporary repositories and stub `wp`/`composer` executables to exercise success and failure modes (pull ref and branch success, malformed/invalid SHA/ref rejection, ref/SHA mismatch, active-sync refusal, composer/build failures, rollback/activation failure, final dirty-worktree failure, tracked executable mode preservation, and leakage checks).
- Wire the regression into public checks by adding `test:deploy:regression` to `package.json` and invoking the regression from `scripts/nmkr-public-checks.sh`, and document the helper interface, required private environment variables, placeholder pre-/post-merge examples, and backup/rollback behavior in `docs/testing-phase-2.md`.

### Testing

- `bash -n scripts/nmkr-exact-ref-deploy.sh` and `bash -n scripts/nmkr-exact-ref-deploy-regression.sh` passed without syntax errors.
- `npm run test:deploy:regression` ran the synthetic regression and reported success (33 assertions passed).
- `npm run test:public` executed the public-safe umbrella (now including the new regression) and completed successfully.
- Repository checks (`diff --check` style validations) passed and the two new scripts were added with executable mode `100755`.

Notes and limitations: the changes only add the public helper and synthetic regression; a private VM with `NMKR_DEPLOY_REMOTE`, `NMKR_DEPLOYED_PLUGIN_PATH`, `NMKR_DEPLOY_BACKUP_ROOT`, and `WP_PATH` is required to run real deployments and full Phase 2 validation, and this environment lacked authenticated GitHub credentials so pushing/creating a remote PR was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f0ca43cd883338206bed96b9f1e27)