### PR TITLE
Add finite token image fallback and packaged PNG placeholders

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -149,7 +149,7 @@ Only the following deliberate hooks and ordinary WordPress registrations should 
 | Hook/registration | Kind | Purpose | Caveat |
 | --- | --- | --- | --- |
 | `wnc_fs_loaded` | Action | Signals that the Freemius SDK has been initialized. | Runs early during bootstrap; callbacks must tolerate plugin activation/update contexts and must not expose licensing data. |
-| `nmkr_ipfs_gateway_base` | Filter | Replaces the base used when normalizing IPFS media URLs. | Return a trusted HTTPS base; the helper normalizes it to end in `/ipfs/`, but consumers remain responsible for availability, privacy, and compatibility. |
+| `nmkr_ipfs_gateway_base` | Filter | Supplies the optional base used for a one-time IPFS token-image fallback. | The default is empty. Return a trusted, credential-free HTTPS base; shared public gateways can be slow, rate-limited, blocked, or unavailable. The helper validates and normalizes the base to end in `/ipfs/`, but consumers remain responsible for availability, privacy, and compatibility. |
 | `nmkr_marketing_allowed_submenus` | Filter | Adjusts the submenu slug allowlist visible to restricted users. | Visibility is not authorization. Never use this to grant access; page and AJAX capability checks must remain authoritative. |
 | WordPress plugin lifecycle hooks | Core registrations | Activation establishes schema/defaults/capabilities; deactivation clears volatile state; uninstall performs configured cleanup. | Do not call callbacks directly or assume uninstall removes every possible plugin-owned state key. |
 | `init` shortcode registrations | Core registrations | Registers `[nmkr-grid]`, `[nmkr-token-list]`, `[nmkr-carousel]`, `[nmkr-token]`, and `[nmkr-project]`. | Preserve registered attributes, escaping, plan gates, local-data behavior, and compatibility when altering callbacks. |
@@ -158,7 +158,7 @@ Synthetic filter examples:
 
 ```php
 add_filter( 'nmkr_ipfs_gateway_base', function () {
-    return 'https://gateway.example/ipfs/';
+    return 'https://dedicated-gateway.example/ipfs/';
 } );
 
 add_filter( 'nmkr_marketing_allowed_submenus', function ( $slugs ) {

--- a/includes/helpers/nmkr-media-helpers.php
+++ b/includes/helpers/nmkr-media-helpers.php
@@ -85,8 +85,8 @@ if (!function_exists('nmkr_is_probably_image_url')) {
  * $token is t.* + td.* from JOIN of nmkr_tokens (t) and nmkr_token_details (td).
  *
  * Priority:
- *   1) t.gateway_link (with IPFS path extraction)
- *   2) t.ipfs_link
+ *   1) t.ipfs_link
+ *   2) t.gateway_link (with IPFS path extraction)
  *   3) t.metadata.image
  *
  * @param object $t
@@ -96,8 +96,13 @@ if (!function_exists('nmkr_get_token_image_url')) {
     function nmkr_get_token_image_url( $t ) {
         $url = '';
 
-        // 1) Prefer gateway_link if present.
-        if ( ! empty( $t->gateway_link ) && is_string( $t->gateway_link ) ) {
+        // 1) Prefer the canonical IPFS source so it uses the configured gateway.
+        if ( ! empty( $t->ipfs_link ) && is_string( $t->ipfs_link ) ) {
+            $url = nmkr_resolve_ipfs_url( $t->ipfs_link );
+        }
+
+        // 2) Fall back to gateway_link if no usable ipfs_link is present.
+        if ( empty( $url ) && ! empty( $t->gateway_link ) && is_string( $t->gateway_link ) ) {
             $gw   = trim( $t->gateway_link );
             $path = parse_url( $gw, PHP_URL_PATH );
 
@@ -120,11 +125,6 @@ if (!function_exists('nmkr_get_token_image_url')) {
                     $url = $gw;
                 }
             }
-        }
-
-        // 2) If still empty, try ipfs_link directly.
-        if ( empty( $url ) && ! empty( $t->ipfs_link ) && is_string( $t->ipfs_link ) ) {
-            $url = nmkr_resolve_ipfs_url( $t->ipfs_link );
         }
 
         // 3) Then metadata.image (ipfs://, CID, or https).

--- a/includes/helpers/nmkr-media-helpers.php
+++ b/includes/helpers/nmkr-media-helpers.php
@@ -21,7 +21,30 @@ if (!function_exists('nmkr_str_ends_with')) {
 }
 
 /**
- * Convert ipfs://, /ipfs/, or bare CIDs to an HTTP(S) gateway URL.
+ * Validate and normalize the configured IPFS gateway base.
+ *
+ * @param mixed $base
+ * @return string
+ */
+if (!function_exists('nmkr_normalize_ipfs_gateway_base')) {
+    function nmkr_normalize_ipfs_gateway_base($base) {
+        if (!is_string($base) || '' === $base || preg_match('/[\x00-\x1F\x7F]/', $base)) return '';
+        if (trim($base) !== $base || false === filter_var($base, FILTER_VALIDATE_URL)) return '';
+
+        $parts = parse_url($base);
+        if (!is_array($parts) || 'https' !== strtolower(isset($parts['scheme']) ? $parts['scheme'] : '') || empty($parts['host'])) return '';
+        if (isset($parts['user']) || isset($parts['pass']) || isset($parts['query']) || isset($parts['fragment'])) return '';
+
+        $origin = 'https://' . $parts['host'];
+        if (isset($parts['port'])) $origin .= ':' . $parts['port'];
+        $path = isset($parts['path']) ? $parts['path'] : '';
+        $path = preg_replace('#(?:/ipfs)+/?$#i', '', rtrim($path, '/'));
+        return esc_url_raw($origin . rtrim($path, '/') . '/ipfs/');
+    }
+}
+
+/**
+ * Convert ipfs://, /ipfs/, or bare CIDs to an HTTPS gateway URL.
  * Override base via:
  *   add_filter('nmkr_ipfs_gateway_base', function() { return 'https://gateway.example/ipfs/'; });
  *
@@ -33,16 +56,14 @@ if (!function_exists('nmkr_resolve_ipfs_url')) {
         if (empty($url)) return '';
         $url = trim((string) $url);
 
-        // Already http(s)
-        if (stripos($url, 'http://') === 0 || stripos($url, 'https://') === 0) {
-            return esc_url_raw($url);
+        // Preserve usable direct HTTPS inputs unchanged.
+        if (stripos($url, 'https://') === 0) {
+            return nmkr_is_valid_https_url($url) ? $url : '';
         }
 
-        // Configurable gateway base; ensure it ends with /ipfs/
-        $base = apply_filters('nmkr_ipfs_gateway_base', 'https://gateway.pinata.cloud/ipfs/');
-        if (!nmkr_str_ends_with($base, '/ipfs/')) {
-            $base = rtrim($base, '/') . '/ipfs/';
-        }
+        // Empty by default: production installations should configure a trusted gateway.
+        $base = nmkr_normalize_ipfs_gateway_base(apply_filters('nmkr_ipfs_gateway_base', ''));
+        if ('' === $base) return '';
 
         // Strip common prefixes
         $path = preg_replace('#^ipfs://#i', '', $url);
@@ -51,6 +72,16 @@ if (!function_exists('nmkr_resolve_ipfs_url')) {
 
         // Avoid double slashes
         return esc_url_raw(rtrim($base, '/') . '/' . $path);
+    }
+}
+
+/** Validate an absolute, credential-free HTTPS URL for public image markup. */
+if (!function_exists('nmkr_is_valid_https_url')) {
+    function nmkr_is_valid_https_url($url) {
+        if (!is_string($url) || '' === $url || trim($url) !== $url || preg_match('/[\x00-\x1F\x7F]/', $url)) return false;
+        if (false === filter_var($url, FILTER_VALIDATE_URL)) return false;
+        $parts = parse_url($url);
+        return is_array($parts) && 'https' === strtolower(isset($parts['scheme']) ? $parts['scheme'] : '') && !empty($parts['host']) && !isset($parts['user']) && !isset($parts['pass']);
     }
 }
 
@@ -122,64 +153,53 @@ if (!function_exists('nmkr_is_usable_ipfs_image_input')) {
 }
 
 /**
- * Pick the best token image URL from stored fields, normalized to HTTP(S).
+ * Build the finite token-image candidate set.
  * $token is t.* + td.* from JOIN of nmkr_tokens (t) and nmkr_token_details (td).
  *
  * Priority:
- *   1) t.ipfs_link
- *   2) t.gateway_link (with IPFS path extraction)
+ *   1) t.gateway_link, preserved unchanged
+ *   2) t.ipfs_link through a configured gateway
  *   3) t.metadata.image
  *
  * @param object $t
- * @return string Normalized image URL or '' if none
+ * @return array Primary, optional fallback, and packaged placeholder URLs
  */
+if (!function_exists('nmkr_get_token_image_candidates')) {
+    function nmkr_get_token_image_candidates($t) {
+        $remote = array();
+        if (isset($t->gateway_link) && is_string($t->gateway_link)) {
+            $provider = trim($t->gateway_link);
+            if (nmkr_is_valid_https_url($provider)) $remote[] = $provider;
+        }
+        if (count($remote) < 2 && isset($t->ipfs_link) && is_string($t->ipfs_link) && nmkr_is_usable_ipfs_image_input($t->ipfs_link)) {
+            $ipfs = nmkr_resolve_ipfs_url(trim($t->ipfs_link));
+            if (nmkr_is_valid_https_url($ipfs) && !in_array($ipfs, $remote, true)) $remote[] = $ipfs;
+        }
+        if (count($remote) < 2 && isset($t->metadata->image) && is_string($t->metadata->image)) {
+            $metadata = nmkr_resolve_ipfs_url(trim($t->metadata->image));
+            if (nmkr_is_valid_https_url($metadata) && !in_array($metadata, $remote, true)) $remote[] = $metadata;
+        }
+        $placeholder = plugins_url('images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE);
+        return array('primary' => isset($remote[0]) ? $remote[0] : $placeholder, 'fallback' => isset($remote[1]) ? $remote[1] : '', 'placeholder' => $placeholder);
+    }
+}
+
 if (!function_exists('nmkr_get_token_image_url')) {
-    function nmkr_get_token_image_url( $t ) {
-        $url = '';
+    function nmkr_get_token_image_url($t) {
+        $candidates = nmkr_get_token_image_candidates($t);
+        return $candidates['primary'];
+    }
+}
 
-        // 1) Prefer the canonical IPFS source so it uses the configured gateway.
-        if ( isset( $t->ipfs_link ) && is_string( $t->ipfs_link ) ) {
-            $ipfs_link = trim( $t->ipfs_link );
-            $candidate = nmkr_is_usable_ipfs_image_input( $ipfs_link ) ? nmkr_resolve_ipfs_url( $ipfs_link ) : '';
-
-            if ( nmkr_is_probably_image_url( $candidate ) ) {
-                $url = $candidate;
-            }
-        }
-
-        // 2) Fall back to gateway_link if no usable ipfs_link is present.
-        if ( empty( $url ) && ! empty( $t->gateway_link ) && is_string( $t->gateway_link ) ) {
-            $gw   = trim( $t->gateway_link );
-            $path = parse_url( $gw, PHP_URL_PATH );
-
-            // Strict match: /ipfs|ipns/<cid>[/rest]
-            if ( is_string( $path ) && preg_match('~/(ipfs|ipns)/([A-Za-z0-9]+)(/.*)?$~', $path, $m) ) {
-                $ns   = $m[1];                // ipfs|ipns
-                $cid  = $m[2];
-                $rest = isset($m[3]) ? $m[3] : '';
-                $url  = nmkr_resolve_ipfs_url( $ns . '://' . $cid . $rest );
-            } else {
-                // Fallback: hunt for a CID anywhere in the URL and re-base to the configured gateway
-                if ( preg_match('~(Qm[1-9A-HJ-NP-Za-km-z]{44,})~', $gw, $m) ) {
-                    // CIDv0 (base58btc)
-                    $url = nmkr_resolve_ipfs_url( 'ipfs://' . $m[1] );
-                } elseif ( preg_match('~([a-z0-9]{46,})~', $gw, $m) ) {
-                    // very loose CIDv1 (base32) heuristic
-                    $url = nmkr_resolve_ipfs_url( 'ipfs://' . $m[1] );
-                } else {
-                    // last resort: use gateway_link as-is (non-standard provider path)
-                    $url = $gw;
-                }
-            }
-        }
-
-        // 3) Then metadata.image (ipfs://, CID, or https).
-        if ( empty( $url ) && ! empty( $t->metadata->image ) ) {
-            $url = nmkr_resolve_ipfs_url( $t->metadata->image );
-        }
-
-        // 4) Return trimmed; caller will esc_url() on output.
-        return is_string( $url ) ? trim( $url ) : '';
+/** Render shared token image markup and enqueue its finite fallback handler. */
+if (!function_exists('nmkr_get_token_image_markup')) {
+    function nmkr_get_token_image_markup($t, $alt, $class, $attributes = '') {
+        $sources = nmkr_get_token_image_candidates($t);
+        $script = 'js/nmkr-token-image-fallback.js';
+        wp_enqueue_script('nmkr-token-image-fallback', plugins_url($script, NMKR_CONNECT_PLUGIN_FILE), array(), @filemtime(plugin_dir_path(NMKR_CONNECT_PLUGIN_FILE) . $script) ?: '1.0', true);
+        return '<img src="' . esc_url($sources['primary']) . '" alt="' . esc_attr($alt) . '" class="' . esc_attr($class) . '" loading="lazy" decoding="async" onclick="openLightbox(this.src)" data-nmkr-token-image="1"'
+            . ('' !== $sources['fallback'] ? ' data-nmkr-fallback-src="' . esc_url($sources['fallback']) . '"' : '')
+            . ' data-nmkr-placeholder-src="' . esc_url($sources['placeholder']) . '" ' . $attributes . ' />';
     }
 }
 

--- a/includes/helpers/nmkr-media-helpers.php
+++ b/includes/helpers/nmkr-media-helpers.php
@@ -81,6 +81,45 @@ if (!function_exists('nmkr_is_probably_image_url')) {
 }
 
 /**
+ * Check whether a stored IPFS image value has a supported raw shape.
+ *
+ * @param string $url
+ * @return bool
+ */
+if (!function_exists('nmkr_is_usable_ipfs_image_input')) {
+    function nmkr_is_usable_ipfs_image_input( $url ) {
+        $url = trim( (string) $url );
+        if ( '' === $url ) return false;
+
+        if ( preg_match( '#^https?://#i', $url ) ) {
+            $candidate = esc_url_raw( $url );
+            if ( '' === $candidate ) return false;
+
+            $path = (string) parse_url( $candidate, PHP_URL_PATH );
+            if ( nmkr_is_probably_image_url( $candidate ) && false === stripos( $path, '/ipfs/' ) ) {
+                return true;
+            }
+
+            $path = preg_replace( '#^.*?/ipfs/#i', '', $path );
+        } else {
+            $path = preg_replace( '#^ipfs://#i', '', $url );
+            $path = preg_replace( '#^/ipfs/#i', '', $path );
+        }
+
+        $path = ltrim( (string) $path, '/' );
+        if ( 0 === stripos( $path, 'ipfs/' ) ) {
+            $path = substr( $path, 5 );
+        }
+
+        $cid = strtok( $path, '/' );
+        return is_string( $cid ) && (
+            1 === preg_match( '/^Qm[1-9A-HJ-NP-Za-km-z]{44}$/', $cid ) ||
+            1 === preg_match( '/^b[a-z2-7]{45,}$/i', $cid )
+        );
+    }
+}
+
+/**
  * Pick the best token image URL from stored fields, normalized to HTTP(S).
  * $token is t.* + td.* from JOIN of nmkr_tokens (t) and nmkr_token_details (td).
  *
@@ -99,7 +138,7 @@ if (!function_exists('nmkr_get_token_image_url')) {
         // 1) Prefer the canonical IPFS source so it uses the configured gateway.
         if ( isset( $t->ipfs_link ) && is_string( $t->ipfs_link ) ) {
             $ipfs_link = trim( $t->ipfs_link );
-            $candidate = '' !== $ipfs_link ? nmkr_resolve_ipfs_url( $ipfs_link ) : '';
+            $candidate = nmkr_is_usable_ipfs_image_input( $ipfs_link ) ? nmkr_resolve_ipfs_url( $ipfs_link ) : '';
 
             if ( nmkr_is_probably_image_url( $candidate ) ) {
                 $url = $candidate;

--- a/includes/helpers/nmkr-media-helpers.php
+++ b/includes/helpers/nmkr-media-helpers.php
@@ -23,7 +23,7 @@ if (!function_exists('nmkr_str_ends_with')) {
 /**
  * Convert ipfs://, /ipfs/, or bare CIDs to an HTTP(S) gateway URL.
  * Override base via:
- *   add_filter('nmkr_ipfs_gateway_base', function() { return 'https://ipfs.io/ipfs/'; });
+ *   add_filter('nmkr_ipfs_gateway_base', function() { return 'https://gateway.example/ipfs/'; });
  *
  * @param string $url
  * @return string Normalized HTTP(S) URL or empty string
@@ -39,7 +39,7 @@ if (!function_exists('nmkr_resolve_ipfs_url')) {
         }
 
         // Configurable gateway base; ensure it ends with /ipfs/
-        $base = apply_filters('nmkr_ipfs_gateway_base', 'https://ipfs.io/ipfs/');
+        $base = apply_filters('nmkr_ipfs_gateway_base', 'https://gateway.pinata.cloud/ipfs/');
         if (!nmkr_str_ends_with($base, '/ipfs/')) {
             $base = rtrim($base, '/') . '/ipfs/';
         }

--- a/includes/helpers/nmkr-media-helpers.php
+++ b/includes/helpers/nmkr-media-helpers.php
@@ -97,8 +97,13 @@ if (!function_exists('nmkr_get_token_image_url')) {
         $url = '';
 
         // 1) Prefer the canonical IPFS source so it uses the configured gateway.
-        if ( ! empty( $t->ipfs_link ) && is_string( $t->ipfs_link ) ) {
-            $url = nmkr_resolve_ipfs_url( $t->ipfs_link );
+        if ( isset( $t->ipfs_link ) && is_string( $t->ipfs_link ) ) {
+            $ipfs_link = trim( $t->ipfs_link );
+            $candidate = '' !== $ipfs_link ? nmkr_resolve_ipfs_url( $ipfs_link ) : '';
+
+            if ( nmkr_is_probably_image_url( $candidate ) ) {
+                $url = $candidate;
+            }
         }
 
         // 2) Fall back to gateway_link if no usable ipfs_link is present.

--- a/includes/helpers/nmkr-media-helpers.php
+++ b/includes/helpers/nmkr-media-helpers.php
@@ -114,7 +114,9 @@ if (!function_exists('nmkr_is_usable_ipfs_image_input')) {
         $cid = strtok( $path, '/' );
         return is_string( $cid ) && (
             1 === preg_match( '/^Qm[1-9A-HJ-NP-Za-km-z]{44}$/', $cid ) ||
-            1 === preg_match( '/^b[a-z2-7]{45,}$/i', $cid )
+            1 === preg_match( '/^b[a-z2-7]{45,}$/i', $cid ) ||
+            1 === preg_match( '/^z[1-9A-HJ-NP-Za-km-z]{40,}$/', $cid ) ||
+            1 === preg_match( '/^k[0-9a-z]{45,}$/', $cid )
         );
     }
 }

--- a/includes/shortcodes/nmkr-shortcode-carousel.php
+++ b/includes/shortcodes/nmkr-shortcode-carousel.php
@@ -410,7 +410,7 @@ function nmkr_shortcode_carousel($atts) {
             // --- BEGIN: normalized slide image for [nmkr-carousel] ---
             $img = nmkr_get_token_image_url( $token );
             if ( empty( $img ) ) {
-                $img = plugins_url( 'images/placeholder.jpg', NMKR_CONNECT_PLUGIN_FILE );
+                $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
             }
 
             $alt = '';

--- a/includes/shortcodes/nmkr-shortcode-carousel.php
+++ b/includes/shortcodes/nmkr-shortcode-carousel.php
@@ -408,11 +408,6 @@ function nmkr_shortcode_carousel($atts) {
         foreach ($tokens as $token) {
             
             // --- BEGIN: normalized slide image for [nmkr-carousel] ---
-            $img = nmkr_get_token_image_url( $token );
-            if ( empty( $img ) ) {
-                $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
-            }
-
             $alt = '';
             if ( ! empty( $token->name ) ) {
                 $alt = $token->name;
@@ -430,7 +425,7 @@ function nmkr_shortcode_carousel($atts) {
                 . ' data-nmkr-token-uid="' . esc_attr(!empty($token->token_uid) ? $token->token_uid : '') . '"'
                 . ' data-nmkr-id="carousel:' . esc_attr(!empty($token->token_uid) ? $token->token_uid : $active_project_uid) . '"'
                 . '>';
-            $output .= '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $alt ) . '" class="token-image" style="max-width: 100%; height: auto; margin-bottom: 10px;" onclick="openLightbox(this.src)" loading="lazy" decoding="async" />';
+            $output .= nmkr_get_token_image_markup( $token, $alt, 'token-image', 'style="max-width: 100%; height: auto; margin-bottom: 10px;"' );
             $output .= '<h4>' . esc_html($token->token_name) . '</h4>';
             $price_html = nmkr_render_token_price_badges( $token );
             if ( $price_html ) { $output .= $price_html; }

--- a/includes/shortcodes/nmkr-shortcode-grid.php
+++ b/includes/shortcodes/nmkr-shortcode-grid.php
@@ -287,7 +287,7 @@ function nmkr_shortcode_grid($atts) {
         
         // Token image
         $img = nmkr_get_token_image_url($token);
-        $ph  = plugins_url('images/placeholder.jpg', NMKR_CONNECT_PLUGIN_FILE);
+        $ph  = plugins_url('images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE);
         $alt = !empty($token->token_name) ? $token->token_name : (!empty($token->asset_name) ? $token->asset_name : 'Token');
         
         $output .= '<img'

--- a/includes/shortcodes/nmkr-shortcode-grid.php
+++ b/includes/shortcodes/nmkr-shortcode-grid.php
@@ -286,18 +286,8 @@ function nmkr_shortcode_grid($atts) {
             . '>';
         
         // Token image
-        $img = nmkr_get_token_image_url($token);
-        $ph  = plugins_url('images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE);
         $alt = !empty($token->token_name) ? $token->token_name : (!empty($token->asset_name) ? $token->asset_name : 'Token');
-        
-        $output .= '<img'
-            . ' src="' . esc_url($img ? $img : $ph) . '"'
-            . ' alt="' . esc_attr($alt) . '"'
-            . ' class="nmkr-token-image"'
-            . ' loading="lazy"'
-            . ' decoding="async"'
-            . ' onclick="openLightbox(this.src)"'
-            . ' />';
+        $output .= nmkr_get_token_image_markup($token, $alt, 'nmkr-token-image');
         
         // Token title
         $output .= '<h3 class="nmkr-token-title">' . esc_html($token->token_name) . '</h3>';

--- a/includes/shortcodes/nmkr-shortcode-list.php
+++ b/includes/shortcodes/nmkr-shortcode-list.php
@@ -286,12 +286,12 @@ function nmkr_shortcode_list($atts) {
         
         // --- BEGIN: normalized token thumbnail for [nmkr-token-list] ---
         
-        // Resolve image URL via helper (gateway_link → re-based HTTPS; or ipfs_link; or metadata.image).
+        // Resolve image URL via helper (ipfs_link; or gateway_link; or metadata.image).
         $img = nmkr_get_token_image_url( $token );
         
         // Fallback to bundled placeholder if nothing resolves.
         if ( empty( $img ) ) {
-            $img = plugins_url( 'images/placeholder.jpg', NMKR_CONNECT_PLUGIN_FILE );
+            $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
         }
         
         // Sensible alt text.

--- a/includes/shortcodes/nmkr-shortcode-list.php
+++ b/includes/shortcodes/nmkr-shortcode-list.php
@@ -286,14 +286,6 @@ function nmkr_shortcode_list($atts) {
         
         // --- BEGIN: normalized token thumbnail for [nmkr-token-list] ---
         
-        // Resolve image URL via helper (ipfs_link; or gateway_link; or metadata.image).
-        $img = nmkr_get_token_image_url( $token );
-        
-        // Fallback to bundled placeholder if nothing resolves.
-        if ( empty( $img ) ) {
-            $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
-        }
-        
         // Sensible alt text.
         $alt = '';
         if ( ! empty( $token->token_name ) ) {
@@ -304,7 +296,7 @@ function nmkr_shortcode_list($atts) {
             $alt = 'Token';
         }
         
-        $output .= '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $alt ) . '" loading="lazy" decoding="async" class="nmkr-token-image" onclick="openLightbox(this.src)">';
+        $output .= nmkr_get_token_image_markup( $token, $alt, 'nmkr-token-image' );
         
         // --- END: normalized token thumbnail for [nmkr-token-list] ---
         

--- a/includes/shortcodes/nmkr-shortcode-project.php
+++ b/includes/shortcodes/nmkr-shortcode-project.php
@@ -248,11 +248,7 @@ function nmkr_shortcode_project($atts) {
         $output .= '<h5>' . esc_html__( 'Featured Token', 'nmkr-connect' ) . '</h5>';
         
         // Token image (opens lightbox)
-        $img = nmkr_get_token_image_url( $featured );
-        if ( empty( $img ) ) {
-            $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
-        }
-        $output .= '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $featured->token_name ) . '" onclick="openLightbox(this.src)" />';
+        $output .= nmkr_get_token_image_markup( $featured, $featured->token_name, '' );
         
         $output .= '<h6>' . esc_html( $featured->token_name ) . '</h6>';
         

--- a/includes/shortcodes/nmkr-shortcode-project.php
+++ b/includes/shortcodes/nmkr-shortcode-project.php
@@ -189,7 +189,7 @@ function nmkr_shortcode_project($atts) {
     // --- BEGIN: normalized project logo for [nmkr-project] ---
     $logo = nmkr_get_project_logo_url( $project );
     if ( empty( $logo ) ) {
-        $logo = plugins_url( 'images/placeholder.jpg', NMKR_CONNECT_PLUGIN_FILE );
+        $logo = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
     }
 
     $alt = '';
@@ -250,7 +250,7 @@ function nmkr_shortcode_project($atts) {
         // Token image (opens lightbox)
         $img = nmkr_get_token_image_url( $featured );
         if ( empty( $img ) ) {
-            $img = plugins_url( 'images/placeholder.jpg', NMKR_CONNECT_PLUGIN_FILE );
+            $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
         }
         $output .= '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $featured->token_name ) . '" onclick="openLightbox(this.src)" />';
         

--- a/includes/shortcodes/nmkr-shortcode-token.php
+++ b/includes/shortcodes/nmkr-shortcode-token.php
@@ -183,14 +183,6 @@ function nmkr_shortcode_token($atts) {
 
     // --- BEGIN: normalized main token image for [nmkr-token] ---
     
-    // Resolve image URL via helper (ipfs_link; or gateway_link; or metadata.image).
-    $img = nmkr_get_token_image_url( $token );
-    
-    // Fallback to bundled placeholder if nothing resolves.
-    if ( empty( $img ) ) {
-        $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
-    }
-    
     // Alt text preference order.
     $alt = '';
     if ( ! empty( $token->token_name ) ) {
@@ -202,7 +194,7 @@ function nmkr_shortcode_token($atts) {
     }
     
     // Display token image with lightbox functionality
-    $output .= '<img src="' . esc_url( $img ) . '" alt="' . esc_attr( $alt ) . '" class="nmkr-token-image" loading="lazy" decoding="async" onclick="openLightbox(this.src)">';
+    $output .= nmkr_get_token_image_markup( $token, $alt, 'nmkr-token-image' );
     
     // --- END: normalized main token image for [nmkr-token] ---
 

--- a/includes/shortcodes/nmkr-shortcode-token.php
+++ b/includes/shortcodes/nmkr-shortcode-token.php
@@ -183,12 +183,12 @@ function nmkr_shortcode_token($atts) {
 
     // --- BEGIN: normalized main token image for [nmkr-token] ---
     
-    // Resolve image URL via helper (gateway_link → re-based HTTPS; or ipfs_link; or metadata.image).
+    // Resolve image URL via helper (ipfs_link; or gateway_link; or metadata.image).
     $img = nmkr_get_token_image_url( $token );
     
     // Fallback to bundled placeholder if nothing resolves.
     if ( empty( $img ) ) {
-        $img = plugins_url( 'images/placeholder.jpg', NMKR_CONNECT_PLUGIN_FILE );
+        $img = plugins_url( 'images/placeholder.png', NMKR_CONNECT_PLUGIN_FILE );
     }
     
     // Alt text preference order.

--- a/js/nmkr-token-image-fallback.js
+++ b/js/nmkr-token-image-fallback.js
@@ -1,8 +1,7 @@
 (function () {
     'use strict';
 
-    document.addEventListener('error', function (event) {
-        var image = event.target;
+    function transitionFailedImage(image) {
         if (!image || !image.matches || !image.matches('img[data-nmkr-token-image]')) {
             return;
         }
@@ -29,5 +28,15 @@
                 image.src = placeholder;
             }
         }
+    }
+
+    document.addEventListener('error', function (event) {
+        transitionFailedImage(event.target);
     }, true);
+
+    Array.prototype.forEach.call(document.querySelectorAll('img[data-nmkr-token-image]'), function (image) {
+        if (image.complete === true && image.naturalWidth === 0) {
+            transitionFailedImage(image);
+        }
+    });
 }());

--- a/js/nmkr-token-image-fallback.js
+++ b/js/nmkr-token-image-fallback.js
@@ -1,0 +1,33 @@
+(function () {
+    'use strict';
+
+    document.addEventListener('error', function (event) {
+        var image = event.target;
+        if (!image || !image.matches || !image.matches('img[data-nmkr-token-image]')) {
+            return;
+        }
+
+        var state = image.getAttribute('data-nmkr-fallback-state') || 'primary';
+        var failed = image.currentSrc || image.src;
+
+        if (state === 'primary') {
+            var fallback = image.getAttribute('data-nmkr-fallback-src') || '';
+            image.setAttribute('data-nmkr-fallback-state', 'fallback');
+            image.removeAttribute('data-nmkr-fallback-src');
+            if (fallback && fallback !== failed) {
+                image.src = fallback;
+                return;
+            }
+        }
+
+        if (state !== 'terminal') {
+            var placeholder = image.getAttribute('data-nmkr-placeholder-src') || '';
+            image.setAttribute('data-nmkr-fallback-state', 'terminal');
+            image.removeAttribute('data-nmkr-fallback-src');
+            image.removeAttribute('data-nmkr-placeholder-src');
+            if (placeholder && placeholder !== failed) {
+                image.src = placeholder;
+            }
+        }
+    }, true);
+}());

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -68,3 +68,4 @@ npm run test:php74
 
 printf '\n== Shortcode image-source regression ==\n'
 php scripts/nmkr-shortcode-image-regression.php
+node scripts/nmkr-token-image-fallback-regression.js

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -65,3 +65,6 @@ php scripts/nmkr-sync-pagination-regression.php
 
 printf '\n== Public-safe PHP 7.4 compatibility guard ==\n'
 npm run test:php74
+
+printf '\n== Shortcode image-source regression ==\n'
+php scripts/nmkr-shortcode-image-regression.php

--- a/scripts/nmkr-shortcode-image-regression.php
+++ b/scripts/nmkr-shortcode-image-regression.php
@@ -42,6 +42,24 @@ nmkr_image_assert_same(
     'https://provider.example.test/image.png',
     nmkr_get_token_image_url( (object) array(
         'gateway_link' => 'https://provider.example.test/image.png',
+        'ipfs_link'    => " \t\n ",
+    ) ),
+    'whitespace-only ipfs_link must not suppress gateway_link'
+);
+
+nmkr_image_assert_same(
+    'https://provider.example.test/image.png',
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => 'https://provider.example.test/image.png',
+        'ipfs_link'    => 'not a usable image source',
+    ) ),
+    'malformed ipfs_link must not suppress gateway_link'
+);
+
+nmkr_image_assert_same(
+    'https://provider.example.test/image.png',
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => 'https://provider.example.test/image.png',
     ) ),
     'gateway_link must remain the fallback'
 );

--- a/scripts/nmkr-shortcode-image-regression.php
+++ b/scripts/nmkr-shortcode-image-regression.php
@@ -14,7 +14,8 @@ function apply_filters( $hook, $value ) {
 }
 
 function esc_url_raw( $url ) {
-    return filter_var( $url, FILTER_VALIDATE_URL ) ? $url : '';
+    $url = str_replace( ' ', '%20', trim( $url ) );
+    return preg_match( '#^https?://#i', $url ) && filter_var( $url, FILTER_VALIDATE_URL ) ? $url : '';
 }
 
 require_once __DIR__ . '/../includes/helpers/nmkr-media-helpers.php';
@@ -51,7 +52,7 @@ nmkr_image_assert_same(
     'https://provider.example.test/image.png',
     nmkr_get_token_image_url( (object) array(
         'gateway_link' => 'https://provider.example.test/image.png',
-        'ipfs_link'    => 'not a usable image source',
+        'ipfs_link'    => 'not-a-cid',
     ) ),
     'malformed ipfs_link must not suppress gateway_link'
 );

--- a/scripts/nmkr-shortcode-image-regression.php
+++ b/scripts/nmkr-shortcode-image-regression.php
@@ -6,7 +6,7 @@
 define( 'ABSPATH', __DIR__ . '/../' );
 
 function apply_filters( $hook, $value ) {
-    if ( 'nmkr_ipfs_gateway_base' === $hook ) {
+    if ( 'nmkr_ipfs_gateway_base' === $hook && ! empty( $GLOBALS['nmkr_test_custom_gateway'] ) ) {
         return 'https://gateway.example.test/content';
     }
 
@@ -31,6 +31,14 @@ $cid = 'QmYwAPJzv5CZsnAzt8auVZRnGi2C9B7F9hTQYxA9Z9n2mR';
 $normalized = 'https://gateway.example.test/content/ipfs/' . $cid . '/token.png';
 $base58_cid = 'zdj7WVRuyEiwKpFdZU8UPrxcX9KtmQTzkbR4nUWfu7D9DWycA';
 $base36_cid = 'k2jmtxrd43ukk1y7sbez98gxlwwbobotav868thdas64o6xu8eqxruvz';
+
+nmkr_image_assert_same(
+    'https://gateway.pinata.cloud/ipfs/' . $cid . '/token.png',
+    nmkr_resolve_ipfs_url( 'ipfs://' . $cid . '/token.png' ),
+    'IPFS paths must use the Pinata gateway by default'
+);
+
+$GLOBALS['nmkr_test_custom_gateway'] = true;
 
 nmkr_image_assert_same(
     $normalized,

--- a/scripts/nmkr-shortcode-image-regression.php
+++ b/scripts/nmkr-shortcode-image-regression.php
@@ -1,134 +1,75 @@
 <?php
-/**
- * Synthetic, public-safe regression checks for shortcode token images.
- */
+/** Public-safe token image source and markup regression. */
+define('ABSPATH', __DIR__ . '/../');
+define('NMKR_CONNECT_PLUGIN_FILE', __DIR__ . '/../nmkr-connect.php');
 
-define( 'ABSPATH', __DIR__ . '/../' );
-
-function apply_filters( $hook, $value ) {
-    if ( 'nmkr_ipfs_gateway_base' === $hook && ! empty( $GLOBALS['nmkr_test_custom_gateway'] ) ) {
-        return 'https://gateway.example.test/content';
-    }
-
-    return $value;
-}
-
-function esc_url_raw( $url ) {
-    $url = str_replace( ' ', '%20', trim( $url ) );
-    return preg_match( '#^https?://#i', $url ) && filter_var( $url, FILTER_VALIDATE_URL ) ? $url : '';
-}
-
+$GLOBALS['nmkr_test_gateway'] = '';
+function apply_filters($hook, $value) { return 'nmkr_ipfs_gateway_base' === $hook ? $GLOBALS['nmkr_test_gateway'] : $value; }
+function esc_url_raw($url) { return is_string($url) && preg_match('#^https://#i', $url) && filter_var($url, FILTER_VALIDATE_URL) ? $url : ''; }
+function esc_url($url) { return esc_url_raw($url); }
+function esc_attr($value) { return htmlspecialchars((string) $value, ENT_QUOTES, 'UTF-8'); }
+function plugins_url($path) { return 'https://plugin.example.test/' . ltrim($path, '/'); }
+function plugin_dir_path() { return __DIR__ . '/../'; }
+function wp_enqueue_script($handle) { $GLOBALS['nmkr_enqueued'][$handle] = true; }
 require_once __DIR__ . '/../includes/helpers/nmkr-media-helpers.php';
 
-function nmkr_image_assert_same( $expected, $actual, $message ) {
-    if ( $expected !== $actual ) {
-        fwrite( STDERR, "FAIL: {$message}\n" );
-        exit( 1 );
-    }
+function nmkr_image_assert($condition, $message) {
+    if (!$condition) { fwrite(STDERR, "FAIL: {$message}\n"); exit(1); }
 }
+function nmkr_image_same($expected, $actual, $message) { nmkr_image_assert($expected === $actual, $message); }
 
-$cid = 'QmYwAPJzv5CZsnAzt8auVZRnGi2C9B7F9hTQYxA9Z9n2mR';
-$normalized = 'https://gateway.example.test/content/ipfs/' . $cid . '/token.png';
-$base58_cid = 'zdj7WVRuyEiwKpFdZU8UPrxcX9KtmQTzkbR4nUWfu7D9DWycA';
-$base36_cid = 'k2jmtxrd43ukk1y7sbez98gxlwwbobotav868thdas64o6xu8eqxruvz';
+$cid0 = 'QmYwAPJzv5CZsnAzt8auVZRnGi2C9B7F9hTQYxA9Z9n2mR';
+$cid32 = 'bafybeigdyrzt5sfp7udm7hu76uh7y26nf3ditjj7guc2v7qxu3qvbnvwya';
+$cid58 = 'zdj7WVRuyEiwKpFdZU8UPrxcX9KtmQTzkbR4nUWfu7D9DWycA';
+$cid36 = 'k2jmtxrd43ukk1y7sbez98gxlwwbobotav868thdas64o6xu8eqxruvz';
+$provider = 'https://provider.example.test/ipfs/original/image.png';
+$placeholder = 'https://plugin.example.test/images/placeholder.png';
 
-nmkr_image_assert_same(
-    'https://gateway.pinata.cloud/ipfs/' . $cid . '/token.png',
-    nmkr_resolve_ipfs_url( 'ipfs://' . $cid . '/token.png' ),
-    'IPFS paths must use the Pinata gateway by default'
+nmkr_image_same('', nmkr_resolve_ipfs_url('ipfs://' . $cid0), 'empty default must disable IPFS fallback');
+$accepted = array(
+    'https://gateway.example.test' => 'https://gateway.example.test/ipfs/',
+    'https://gateway.example.test/' => 'https://gateway.example.test/ipfs/',
+    'https://gateway.example.test/ipfs' => 'https://gateway.example.test/ipfs/',
+    'https://gateway.example.test/ipfs/' => 'https://gateway.example.test/ipfs/',
+    'https://gateway.example.test/content/' => 'https://gateway.example.test/content/ipfs/',
 );
+foreach ($accepted as $input => $expected) nmkr_image_same($expected, nmkr_normalize_ipfs_gateway_base($input), 'gateway normalization: ' . $input);
+$rejected = array('', ' http://gateway.test', 'http://gateway.test', '//gateway.test', '/relative', 'javascript:alert(1)', 'data:text/plain,x', 'file:///tmp/x', 'https://', "https://gateway.test/\n", 'https://user:pass@gateway.test', 'https://gateway.test/path?q=1', 'https://gateway.test/path#x', array('x'), (object) array('x' => 1));
+foreach ($rejected as $input) nmkr_image_same('', nmkr_normalize_ipfs_gateway_base($input), 'unsafe gateway must be rejected');
 
-$GLOBALS['nmkr_test_custom_gateway'] = true;
-
-nmkr_image_assert_same(
-    $normalized,
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => 'https://provider.example.test/image.png',
-        'ipfs_link'    => 'ipfs://' . $cid . '/token.png',
-    ) ),
-    'ipfs_link must take priority over gateway_link'
-);
-
-nmkr_image_assert_same(
-    'https://gateway.example.test/content/ipfs/' . $base58_cid . '/token.png',
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => 'https://provider.example.test/image.png',
-        'ipfs_link'    => 'ipfs://' . $base58_cid . '/token.png',
-    ) ),
-    'base58btc CIDv1 ipfs_link must take priority over gateway_link'
-);
-
-nmkr_image_assert_same(
-    'https://gateway.example.test/content/ipfs/' . $base36_cid . '/token.png',
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => 'https://provider.example.test/image.png',
-        'ipfs_link'    => '/ipfs/' . $base36_cid . '/token.png',
-    ) ),
-    'base36 CIDv1 ipfs_link must take priority over gateway_link'
-);
-
-nmkr_image_assert_same(
-    'https://provider.example.test/image.png',
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => 'https://provider.example.test/image.png',
-        'ipfs_link'    => " \t\n ",
-    ) ),
-    'whitespace-only ipfs_link must not suppress gateway_link'
-);
-
-nmkr_image_assert_same(
-    'https://provider.example.test/image.png',
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => 'https://provider.example.test/image.png',
-        'ipfs_link'    => 'not-a-cid',
-    ) ),
-    'malformed ipfs_link must not suppress gateway_link'
-);
-
-nmkr_image_assert_same(
-    'https://provider.example.test/image.png',
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => 'https://provider.example.test/image.png',
-    ) ),
-    'gateway_link must remain the fallback'
-);
-
-nmkr_image_assert_same(
-    'https://static.example.test/token.webp',
-    nmkr_resolve_ipfs_url( 'https://static.example.test/token.webp' ),
-    'existing HTTPS URLs must remain unchanged'
-);
-nmkr_image_assert_same(
-    $normalized,
-    nmkr_resolve_ipfs_url( '/ipfs/' . $cid . '/token.png' ),
-    'IPFS paths must use the configured gateway'
-);
-nmkr_image_assert_same(
-    '',
-    nmkr_get_token_image_url( (object) array(
-        'gateway_link' => array( 'not-a-string' ),
-        'ipfs_link'    => '',
-        'metadata'     => (object) array( 'image' => '' ),
-    ) ),
-    'empty or unusable fields must return an empty value'
-);
-
-$shortcodes = array( 'grid', 'list', 'carousel', 'token', 'project' );
-foreach ( $shortcodes as $shortcode ) {
-    $source = file_get_contents( __DIR__ . '/../includes/shortcodes/nmkr-shortcode-' . $shortcode . '.php' );
-    if ( false === $source || false === strpos( $source, "images/placeholder.png" ) ) {
-        fwrite( STDERR, "FAIL: {$shortcode} shortcode must reference images/placeholder.png\n" );
-        exit( 1 );
-    }
-    if ( false !== strpos( $source, "images/placeholder.jpg" ) ) {
-        fwrite( STDERR, "FAIL: {$shortcode} shortcode references missing placeholder JPG\n" );
-        exit( 1 );
-    }
+$GLOBALS['nmkr_test_gateway'] = 'https://gateway.example.test/content';
+foreach (array($cid0, $cid32, $cid58, $cid36) as $cid) {
+    nmkr_image_assert(nmkr_is_usable_ipfs_image_input('ipfs://' . $cid . '/token.png'), 'supported CID must remain accepted');
+    nmkr_image_same('https://gateway.example.test/content/ipfs/' . $cid . '/token.png', nmkr_resolve_ipfs_url('/ipfs/' . $cid . '/token.png'), 'CID path must be preserved');
 }
+nmkr_image_assert(!nmkr_is_usable_ipfs_image_input('not-a-cid') && !nmkr_is_usable_ipfs_image_input(" \t\n"), 'malformed IPFS inputs must be rejected');
 
-if ( ! is_file( __DIR__ . '/../images/placeholder.png' ) ) {
-    fwrite( STDERR, "FAIL: packaged placeholder PNG is missing\n" );
-    exit( 1 );
+$both = (object) array('gateway_link' => $provider, 'ipfs_link' => 'ipfs://' . $cid0 . '/token.png');
+$set = nmkr_get_token_image_candidates($both);
+nmkr_image_same($provider, $set['primary'], 'provider must be primary and unchanged');
+nmkr_image_same('https://gateway.example.test/content/ipfs/' . $cid0 . '/token.png', $set['fallback'], 'configured IPFS must be fallback');
+nmkr_image_same($placeholder, $set['placeholder'], 'packaged placeholder must be terminal');
+nmkr_image_same($provider, nmkr_get_token_image_url($both), 'compatibility helper must return primary');
+nmkr_image_same($provider, nmkr_get_token_image_url((object) array('gateway_link' => $provider)), 'provider-only source');
+nmkr_image_same('https://gateway.example.test/content/ipfs/' . $cid0, nmkr_get_token_image_url((object) array('ipfs_link' => $cid0)), 'configured-IPFS-only source');
+nmkr_image_same($provider, nmkr_get_token_image_url((object) array('gateway_link' => $provider, 'ipfs_link' => " \t\n")), 'whitespace IPFS must not suppress provider');
+nmkr_image_same($provider, nmkr_get_token_image_url((object) array('gateway_link' => $provider, 'ipfs_link' => 'not-a-cid')), 'malformed IPFS must not suppress provider');
+nmkr_image_same($placeholder, nmkr_get_token_image_url((object) array('gateway_link' => 'http://unsafe.test/x.png', 'ipfs_link' => 'not-a-cid')), 'malformed sources use placeholder');
+nmkr_image_same('https://metadata.example.test/image.webp', nmkr_get_token_image_url((object) array('metadata' => (object) array('image' => 'https://metadata.example.test/image.webp'))), 'metadata fallback');
+nmkr_image_same('https://direct.example.test/image.png', nmkr_get_token_image_url((object) array('ipfs_link' => 'https://direct.example.test/image.png')), 'direct HTTPS input');
+$dedup = nmkr_get_token_image_candidates((object) array('gateway_link' => $provider, 'metadata' => (object) array('image' => $provider)));
+nmkr_image_same('', $dedup['fallback'], 'duplicate URLs must be removed');
+
+$markup = nmkr_get_token_image_markup($both, 'Synthetic "token"', 'token-image', 'data-test="kept"');
+foreach (array('data-nmkr-token-image="1"', 'data-nmkr-fallback-src=', 'data-nmkr-placeholder-src=', 'loading="lazy"', 'decoding="async"', 'onclick="openLightbox(this.src)"', 'data-test="kept"') as $needle) nmkr_image_assert(false !== strpos($markup, $needle), 'shared markup state: ' . $needle);
+nmkr_image_assert(!empty($GLOBALS['nmkr_enqueued']['nmkr-token-image-fallback']), 'fallback script must be enqueued');
+
+foreach (array('grid', 'list', 'carousel', 'token', 'project') as $shortcode) {
+    $source = file_get_contents(__DIR__ . '/../includes/shortcodes/nmkr-shortcode-' . $shortcode . '.php');
+    nmkr_image_assert(false !== strpos($source, 'nmkr_get_token_image_markup'), $shortcode . ' must use shared token markup');
+    nmkr_image_assert(false === strpos($source, 'images/placeholder.jpg'), $shortcode . ' must not use missing JPG');
 }
-
+$project_source = file_get_contents(__DIR__ . '/../includes/shortcodes/nmkr-shortcode-project.php');
+nmkr_image_assert(false !== strpos($project_source, 'class="nmkr-project-logo"') && false !== strpos($project_source, 'nmkr_get_project_logo_url'), 'project logo must remain separate');
+nmkr_image_assert(is_file(__DIR__ . '/../images/placeholder.png'), 'packaged placeholder must exist');
 echo "Shortcode image-source regression: PASS\n";

--- a/scripts/nmkr-shortcode-image-regression.php
+++ b/scripts/nmkr-shortcode-image-regression.php
@@ -29,6 +29,8 @@ function nmkr_image_assert_same( $expected, $actual, $message ) {
 
 $cid = 'QmYwAPJzv5CZsnAzt8auVZRnGi2C9B7F9hTQYxA9Z9n2mR';
 $normalized = 'https://gateway.example.test/content/ipfs/' . $cid . '/token.png';
+$base58_cid = 'zdj7WVRuyEiwKpFdZU8UPrxcX9KtmQTzkbR4nUWfu7D9DWycA';
+$base36_cid = 'k2jmtxrd43ukk1y7sbez98gxlwwbobotav868thdas64o6xu8eqxruvz';
 
 nmkr_image_assert_same(
     $normalized,
@@ -37,6 +39,24 @@ nmkr_image_assert_same(
         'ipfs_link'    => 'ipfs://' . $cid . '/token.png',
     ) ),
     'ipfs_link must take priority over gateway_link'
+);
+
+nmkr_image_assert_same(
+    'https://gateway.example.test/content/ipfs/' . $base58_cid . '/token.png',
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => 'https://provider.example.test/image.png',
+        'ipfs_link'    => 'ipfs://' . $base58_cid . '/token.png',
+    ) ),
+    'base58btc CIDv1 ipfs_link must take priority over gateway_link'
+);
+
+nmkr_image_assert_same(
+    'https://gateway.example.test/content/ipfs/' . $base36_cid . '/token.png',
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => 'https://provider.example.test/image.png',
+        'ipfs_link'    => '/ipfs/' . $base36_cid . '/token.png',
+    ) ),
+    'base36 CIDv1 ipfs_link must take priority over gateway_link'
 );
 
 nmkr_image_assert_same(

--- a/scripts/nmkr-shortcode-image-regression.php
+++ b/scripts/nmkr-shortcode-image-regression.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Synthetic, public-safe regression checks for shortcode token images.
+ */
+
+define( 'ABSPATH', __DIR__ . '/../' );
+
+function apply_filters( $hook, $value ) {
+    if ( 'nmkr_ipfs_gateway_base' === $hook ) {
+        return 'https://gateway.example.test/content';
+    }
+
+    return $value;
+}
+
+function esc_url_raw( $url ) {
+    return filter_var( $url, FILTER_VALIDATE_URL ) ? $url : '';
+}
+
+require_once __DIR__ . '/../includes/helpers/nmkr-media-helpers.php';
+
+function nmkr_image_assert_same( $expected, $actual, $message ) {
+    if ( $expected !== $actual ) {
+        fwrite( STDERR, "FAIL: {$message}\n" );
+        exit( 1 );
+    }
+}
+
+$cid = 'QmYwAPJzv5CZsnAzt8auVZRnGi2C9B7F9hTQYxA9Z9n2mR';
+$normalized = 'https://gateway.example.test/content/ipfs/' . $cid . '/token.png';
+
+nmkr_image_assert_same(
+    $normalized,
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => 'https://provider.example.test/image.png',
+        'ipfs_link'    => 'ipfs://' . $cid . '/token.png',
+    ) ),
+    'ipfs_link must take priority over gateway_link'
+);
+
+nmkr_image_assert_same(
+    'https://provider.example.test/image.png',
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => 'https://provider.example.test/image.png',
+    ) ),
+    'gateway_link must remain the fallback'
+);
+
+nmkr_image_assert_same(
+    'https://static.example.test/token.webp',
+    nmkr_resolve_ipfs_url( 'https://static.example.test/token.webp' ),
+    'existing HTTPS URLs must remain unchanged'
+);
+nmkr_image_assert_same(
+    $normalized,
+    nmkr_resolve_ipfs_url( '/ipfs/' . $cid . '/token.png' ),
+    'IPFS paths must use the configured gateway'
+);
+nmkr_image_assert_same(
+    '',
+    nmkr_get_token_image_url( (object) array(
+        'gateway_link' => array( 'not-a-string' ),
+        'ipfs_link'    => '',
+        'metadata'     => (object) array( 'image' => '' ),
+    ) ),
+    'empty or unusable fields must return an empty value'
+);
+
+$shortcodes = array( 'grid', 'list', 'carousel', 'token', 'project' );
+foreach ( $shortcodes as $shortcode ) {
+    $source = file_get_contents( __DIR__ . '/../includes/shortcodes/nmkr-shortcode-' . $shortcode . '.php' );
+    if ( false === $source || false === strpos( $source, "images/placeholder.png" ) ) {
+        fwrite( STDERR, "FAIL: {$shortcode} shortcode must reference images/placeholder.png\n" );
+        exit( 1 );
+    }
+    if ( false !== strpos( $source, "images/placeholder.jpg" ) ) {
+        fwrite( STDERR, "FAIL: {$shortcode} shortcode references missing placeholder JPG\n" );
+        exit( 1 );
+    }
+}
+
+if ( ! is_file( __DIR__ . '/../images/placeholder.png' ) ) {
+    fwrite( STDERR, "FAIL: packaged placeholder PNG is missing\n" );
+    exit( 1 );
+}
+
+echo "Shortcode image-source regression: PASS\n";

--- a/scripts/nmkr-token-image-fallback-regression.js
+++ b/scripts/nmkr-token-image-fallback-regression.js
@@ -1,18 +1,61 @@
 'use strict';
 const assert = require('assert');
 let handler;
-global.document = { addEventListener: (name, callback, capture) => { assert.strictEqual(name, 'error'); assert.strictEqual(capture, true); handler = callback; } };
+let existingImages = [];
+global.document = {
+    addEventListener: (name, callback, capture) => {
+        assert.strictEqual(name, 'error');
+        assert.strictEqual(capture, true);
+        handler = callback;
+    },
+    querySelectorAll: selector => {
+        assert.strictEqual(selector, 'img[data-nmkr-token-image]');
+        return existingImages;
+    }
+};
+
+function image(src, fallback, placeholder, complete, naturalWidth) {
+    const attrs = { 'data-nmkr-token-image': '1', 'data-nmkr-fallback-src': fallback, 'data-nmkr-placeholder-src': placeholder };
+    let assignedSrc = src;
+    const assignments = [];
+    return {
+        currentSrc: src,
+        complete,
+        naturalWidth,
+        matches: selector => selector === 'img[data-nmkr-token-image]',
+        getAttribute: key => attrs[key] || '',
+        setAttribute: (key, value) => { attrs[key] = value; },
+        removeAttribute: key => { delete attrs[key]; },
+        get src() { return assignedSrc; },
+        set src(value) { assignedSrc = value; assignments.push(value); },
+        attrs,
+        assignments
+    };
+}
+
+const alreadyFailed = image('primary', 'fallback', 'placeholder', true, 0);
+const pending = image('pending', 'pending-fallback', 'placeholder', false, 0);
+const loaded = image('loaded', 'loaded-fallback', 'placeholder', true, 640);
+existingImages = [alreadyFailed, pending, loaded];
 require('../js/nmkr-token-image-fallback.js');
 
-function image(src, fallback, placeholder) {
-    const attrs = { 'data-nmkr-token-image': '1', 'data-nmkr-fallback-src': fallback, 'data-nmkr-placeholder-src': placeholder };
-    return { src, currentSrc: src, matches: () => true, getAttribute: key => attrs[key] || '', setAttribute: (key, value) => { attrs[key] = value; }, removeAttribute: key => { delete attrs[key]; }, attrs };
-}
+assert.deepStrictEqual(alreadyFailed.assignments, ['fallback']);
+assert.deepStrictEqual(pending.assignments, []);
+assert.deepStrictEqual(loaded.assignments, []);
+
 let img = image('primary', 'fallback', 'placeholder');
 assert.strictEqual(img.src, 'primary'); // primary success makes no transition.
 img = image('primary', 'fallback', 'placeholder'); handler({ target: img }); assert.strictEqual(img.src, 'fallback');
 img.currentSrc = 'fallback'; handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
 img.currentSrc = 'placeholder'; handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
-img = image('primary', '', 'placeholder'); handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
+assert.deepStrictEqual(img.assignments, ['fallback', 'placeholder']);
+img = image('primary', '', 'placeholder'); handler({ target: img }); assert.deepStrictEqual(img.assignments, ['placeholder']);
 img.currentSrc = 'placeholder'; handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
+assert.deepStrictEqual(img.assignments, ['placeholder']);
+img = image('primary', 'primary', 'placeholder'); handler({ target: img }); assert.deepStrictEqual(img.assignments, ['placeholder']);
+img.currentSrc = 'placeholder'; handler({ target: img }); assert.deepStrictEqual(img.assignments, ['placeholder']);
+const unrelated = image('unrelated', 'fallback', 'placeholder');
+unrelated.matches = () => false;
+handler({ target: unrelated });
+assert.deepStrictEqual(unrelated.assignments, []);
 console.log('Token image fallback regression: PASS');

--- a/scripts/nmkr-token-image-fallback-regression.js
+++ b/scripts/nmkr-token-image-fallback-regression.js
@@ -1,0 +1,18 @@
+'use strict';
+const assert = require('assert');
+let handler;
+global.document = { addEventListener: (name, callback, capture) => { assert.strictEqual(name, 'error'); assert.strictEqual(capture, true); handler = callback; } };
+require('../js/nmkr-token-image-fallback.js');
+
+function image(src, fallback, placeholder) {
+    const attrs = { 'data-nmkr-token-image': '1', 'data-nmkr-fallback-src': fallback, 'data-nmkr-placeholder-src': placeholder };
+    return { src, currentSrc: src, matches: () => true, getAttribute: key => attrs[key] || '', setAttribute: (key, value) => { attrs[key] = value; }, removeAttribute: key => { delete attrs[key]; }, attrs };
+}
+let img = image('primary', 'fallback', 'placeholder');
+assert.strictEqual(img.src, 'primary'); // primary success makes no transition.
+img = image('primary', 'fallback', 'placeholder'); handler({ target: img }); assert.strictEqual(img.src, 'fallback');
+img.currentSrc = 'fallback'; handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
+img.currentSrc = 'placeholder'; handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
+img = image('primary', '', 'placeholder'); handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
+img.currentSrc = 'placeholder'; handler({ target: img }); assert.strictEqual(img.src, 'placeholder');
+console.log('Token image fallback regression: PASS');


### PR DESCRIPTION
### Motivation

- Some stored provider `gateway_link` URLs are valid HTTPS images but can be blocked by Chromium when embedded cross-origin.
- Shared public IPFS gateways are independently variable and should not be an unconditional production default.
- Several shortcode fallbacks referenced a missing `images/placeholder.jpg` instead of the packaged `images/placeholder.png`.

### Description

- Preserve a validated provider `gateway_link` unchanged as the primary token-image source.
- Support one optional IPFS fallback through the existing `nmkr_ipfs_gateway_base` filter; the default is now empty.
- Strictly validate and normalize configured gateway bases as credential-free absolute HTTPS URLs ending in `/ipfs/`.
- Preserve supported CIDv0 and CIDv1 forms, including base32, base58btc (`z...`), and base36 (`k...`).
- Add a shared token-image markup helper used by grid, list, carousel, single-token, and project featured-token output.
- Add a finite browser fallback handler: primary → optional IPFS fallback → packaged local placeholder, with terminal state preventing loops.
- Recover token images that failed before the footer-enqueued handler initialized, while leaving pending, loaded, and unrelated images untouched.
- Keep project-logo handling separate from token fallback behavior.
- Replace missing `.jpg` placeholder references with the packaged `.png` asset.
- Document trusted gateway configuration and the limitations of shared public gateways.
- Add public-safe PHP and JavaScript regressions and include them in the public check umbrella.

No network probes, proxy endpoints, caching, DB writes, synchronization changes, settings persistence, dependencies, or generated artifacts were added.

### Changed files

- `docs/developer-guide.md`
- `includes/helpers/nmkr-media-helpers.php`
- `includes/shortcodes/nmkr-shortcode-grid.php`
- `includes/shortcodes/nmkr-shortcode-list.php`
- `includes/shortcodes/nmkr-shortcode-carousel.php`
- `includes/shortcodes/nmkr-shortcode-token.php`
- `includes/shortcodes/nmkr-shortcode-project.php`
- `js/nmkr-token-image-fallback.js`
- `scripts/nmkr-public-checks.sh`
- `scripts/nmkr-shortcode-image-regression.php`
- `scripts/nmkr-token-image-fallback-regression.js`

Base SHA: `6a3f81558177f24275032a30391eae3f1c6bfebc`
Current head SHA: `24851f9a3abf0d24c78b4530b31d44fb536784f1`

### Testing

- Phase 4 CI run #260 passed on the current head.
- Public-safe regression coverage includes gateway validation, candidate ordering, supported CID forms, deduplication, shared shortcode markup, placeholder packaging, pre-initialization failure recovery, and finite JavaScript fallback transitions.
- The fresh full Codex review finding was corrected in a narrow follow-up, independently inspected, and all review threads are resolved.
- Exact-head private VM validation passed:
  - deployed source matched the PR head;
  - all five shortcode pages rendered valid token images;
  - deterministic browser fallback checks passed for pre-initialization recovery, live fallback, placeholder terminalization, duplicate/missing fallback, and no-loop behavior;
  - public-safe tests, full non-mutating Playwright suite, PHP/JavaScript checks, WP-CLI smoke, DB-state checks, readiness, and debug-log review passed;
  - `RUN_REAL_SYNC=false`; no real NMKR sync ran;
  - private test artifacts were removed.

Pre-merge validated SHA: `24851f9a3abf0d24c78b4530b31d44fb536784f1`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8576e1826483339e8b12621148770e)