### PR TITLE
Sanitize AJAX error payloads and hide internal diagnostics from client

### DIFF
--- a/includes/pages/dashboard/nmkr-dashboard-ajax.php
+++ b/includes/pages/dashboard/nmkr-dashboard-ajax.php
@@ -444,7 +444,8 @@ function nmkr_clear_all_logs_ajax() {
         
         wp_send_json_success(['message' => 'All logs cleared successfully']);
     } catch (Exception $e) {
-        wp_send_json_error(['message' => 'Failed to clear logs: ' . $e->getMessage()]);
+        error_log('NMKR log-clear operation failed: ' . $e->getMessage());
+        wp_send_json_error(['message' => __('Logs could not be cleared.', 'nmkr-connect'), 'error_code' => 'log_clear_failed']);
     }
     
     wp_die();
@@ -493,7 +494,8 @@ function nmkr_clear_section_logs_ajax() {
         
         wp_send_json_success(['message' => ucfirst($log_type) . ' logs cleared successfully', 'log_type' => $log_type]);
     } catch (Exception $e) {
-        wp_send_json_error(['message' => 'Failed to clear ' . $log_type . ' logs: ' . $e->getMessage()]);
+        error_log('NMKR section log-clear operation failed: ' . $e->getMessage());
+        wp_send_json_error(['message' => __('The selected logs could not be cleared.', 'nmkr-connect'), 'error_code' => 'section_log_clear_failed']);
     }
     
     wp_die();

--- a/includes/pages/dashboard/nmkr-dashboard-ui.php
+++ b/includes/pages/dashboard/nmkr-dashboard-ui.php
@@ -1222,7 +1222,7 @@ function nmkr_render_dashboard_scripts($dashboard_nonce) {
                     }
                 },
                 error: function(xhr) {
-                    console.error('API status check error:', xhr.responseText);
+                    console.error('API status check failed (HTTP ' + (xhr.status || 0) + ').');
                     $('#api-status').html('⚠️ Unable to check API status. Please try refreshing the page.');
                     
                     // Log API status check error
@@ -1303,7 +1303,7 @@ function nmkr_render_dashboard_scripts($dashboard_nonce) {
                         }
                     },
                     error: function(xhr) {
-                        console.error('API status refresh error:', xhr.responseText);
+                        console.error('API status refresh failed (HTTP ' + (xhr.status || 0) + ').');
                         $('#api-status').html('⚠️ Unable to check API status. Please try refreshing the page.');
                         
                         // Log API status refresh error
@@ -2028,4 +2028,4 @@ function nmkr_render_dashboard_scripts($dashboard_nonce) {
         });
     </script>
     <?php
-}    
+}

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -45,6 +45,14 @@ function nmkr_is_verified_failed_terminal_for_progress($sync_data, $has_active_d
         && nmkr_verify_sync_terminal_result($sync_data, 'failed');
 }
 
+/** Replace a verified failed terminal's private diagnostic with public-safe copy. */
+function nmkr_public_failed_terminal_progress_response($response_data) {
+    $response_data['error'] = __('Synchronization failed. Review the private server diagnostics for details.', 'nmkr-connect');
+    $response_data['error_code'] = 'sync_terminal_failed';
+    unset($response_data['technical_details']);
+    return $response_data;
+}
+
 /** Return a fixed browser-safe message for a synchronization error code. */
 function nmkr_public_sync_error_message($code, $fallback) {
     $messages = array(
@@ -647,9 +655,8 @@ function nmkr_sync_progress_handler() {
             $response_data['terminal_outcome'] = $terminal_status;
             $response_data['finished'] = $terminal_status === 'completed' ? $canonically_finished : false;
             $response_data['aborted'] = $terminal_status === 'stopped';
-            if ($terminal_status === 'failed' && $response_data['error'] === '') {
-                $response_data['error'] = __('Synchronization failed. Review the private server diagnostics for details.', 'nmkr-connect');
-                $response_data['error_code'] = 'sync_terminal_failed';
+            if ($terminal_status === 'failed') {
+                $response_data = nmkr_public_failed_terminal_progress_response($response_data);
             }
         }
     }

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -45,6 +45,23 @@ function nmkr_is_verified_failed_terminal_for_progress($sync_data, $has_active_d
         && nmkr_verify_sync_terminal_result($sync_data, 'failed');
 }
 
+/** Return a fixed browser-safe message for a synchronization error code. */
+function nmkr_public_sync_error_message($code, $fallback) {
+    $messages = array(
+        'sync_already_owned' => __('A synchronization is already in progress.', 'nmkr-connect'),
+        'sync_finalization_pending' => __('Synchronization finalization is still pending.', 'nmkr-connect'),
+        'direct_stop_requires_cooperative_worker' => __('The active synchronization must be stopped cooperatively.', 'nmkr-connect'),
+        'sync_owner_mismatch' => __('Synchronization ownership no longer matches this run.', 'nmkr-connect'),
+        'invalid_run_id' => __('An exact synchronization run identifier is required.', 'nmkr-connect'),
+        'sync_owner_recovery_required' => __('Synchronization ownership requires recovery.', 'nmkr-connect'),
+        'sync_stop_cleanup_failed' => __('Synchronization cleanup could not be verified.', 'nmkr-connect'),
+        'sync_stop_history_cleanup_failed' => __('Synchronization cleanup could not be verified.', 'nmkr-connect'),
+        'sync_stop_cleanup_pending' => __('Synchronization finalization is still pending.', 'nmkr-connect'),
+        'sync_stopped_finalization_pending' => __('Synchronization finalization is still pending.', 'nmkr-connect'),
+    );
+    return isset($messages[$code]) ? $messages[$code] : $fallback;
+}
+
 /**
  * AJAX handler for starting the synchronization process
  */
@@ -65,7 +82,7 @@ function nmkr_start_sync_handler() {
             $owner_error = is_wp_error($owner) ? $owner : new WP_Error('sync_admission_failed', __('Synchronization admission failed.', 'nmkr-connect'));
             $conflict = in_array($owner_error->get_error_code(), array('sync_already_owned', 'sync_finalization_pending'), true);
             wp_send_json_error(array(
-                'message' => $owner_error->get_error_message(),
+                'message' => nmkr_public_sync_error_message($owner_error->get_error_code(), __('Synchronization admission failed.', 'nmkr-connect')),
                 'error_code' => $owner_error->get_error_code(),
             ), $conflict ? 409 : 503);
             return;
@@ -173,7 +190,7 @@ function nmkr_cleanup_sync_jobs_handler() {
     });
     if (is_wp_error($result)) {
         wp_send_json_error(array(
-            'message' => $result->get_error_message(),
+            'message' => nmkr_public_sync_error_message($result->get_error_code(), __('Synchronization cleanup failed.', 'nmkr-connect')),
             'error_code' => $result->get_error_code(),
         ), in_array($result->get_error_code(), array('direct_stop_requires_cooperative_worker', 'sync_finalization_pending'), true) ? 409 : 503);
     }
@@ -186,7 +203,8 @@ function nmkr_cleanup_sync_jobs_handler() {
         ));
     } else {
         wp_send_json_error(array(
-            'message' => 'Failed to clean up sync jobs: ' . $result['message']
+            'message' => __('Synchronization cleanup failed.', 'nmkr-connect'),
+            'error_code' => isset($result['error_code']) ? $result['error_code'] : 'sync_cleanup_failed',
         ));
     }
     
@@ -302,9 +320,8 @@ function nmkr_sync_progress_handler() {
             if (ob_get_length()) { ob_clean(); }
             if ($__nmkr_prev_display_errors !== false) { @ini_set('display_errors', $__nmkr_prev_display_errors); }
             wp_send_json_error(array(
-                'message' => 'Failed to retrieve synchronization status from database',
-                'error_code' => 'option_retrieval_failed',
-                'technical_details' => $e->getMessage()
+                'message' => __('Synchronization status is temporarily unavailable.', 'nmkr-connect'),
+                'error_code' => 'option_retrieval_failed'
             ));
             return;
         }
@@ -631,7 +648,8 @@ function nmkr_sync_progress_handler() {
             $response_data['finished'] = $terminal_status === 'completed' ? $canonically_finished : false;
             $response_data['aborted'] = $terminal_status === 'stopped';
             if ($terminal_status === 'failed' && $response_data['error'] === '') {
-                $response_data['error'] = (string) ($sync_data['error_message'] ?? __('Synchronization failed.', 'nmkr-connect'));
+                $response_data['error'] = __('Synchronization failed. Review the private server diagnostics for details.', 'nmkr-connect');
+                $response_data['error_code'] = 'sync_terminal_failed';
             }
         }
     }
@@ -645,9 +663,8 @@ function nmkr_sync_progress_handler() {
         if (ob_get_length()) { ob_clean(); }
         if ($__nmkr_prev_display_errors !== false) { @ini_set('display_errors', $__nmkr_prev_display_errors); }
         wp_send_json_error(array(
-            'message' => 'Synchronization encountered a critical error: ' . $error,
+            'message' => __('Synchronization encountered a critical error.', 'nmkr-connect'),
             'error_code' => 'sync_critical_error',
-            'technical_details' => $error,
             'progress' => $progress
         ));
         return;
@@ -716,7 +733,7 @@ function nmkr_stop_sync_handler() {
             wp_send_json_error(array('message' => __('Synchronization ownership no longer matches this run.', 'nmkr-connect'), 'error_code' => 'sync_owner_mismatch'), 409);
         }
         $result = nmkr_request_exact_sync_stop($run_id, 'user_requested');
-        if (is_wp_error($result)) wp_send_json_error(array('message' => $result->get_error_message(), 'error_code' => $result->get_error_code()), 409);
+        if (is_wp_error($result)) wp_send_json_error(array('message' => nmkr_public_sync_error_message($result->get_error_code(), __('Synchronization could not be stopped.', 'nmkr-connect')), 'error_code' => $result->get_error_code()), 409);
         if ($result === true) wp_send_json_success(array('run_id' => $run_id, 'owner_state' => 'released', 'completed' => true, 'terminal_outcome' => 'cancelled'));
         if (is_array($result) && ($result['state'] ?? '') === 'stop_requested') {
             $recovered = nmkr_resume_stopped_sync_recovery($run_id, (int) ($result['sync_stats_id'] ?? ($owner['sync_stats_id'] ?? 0)));
@@ -740,7 +757,7 @@ function nmkr_stop_sync_handler() {
     });
     if (is_wp_error($result)) {
         $code = $result->get_error_code();
-        wp_send_json_error(array('message' => $result->get_error_message(), 'error_code' => $code), 409);
+        wp_send_json_error(array('message' => nmkr_public_sync_error_message($code, __('Synchronization could not be stopped.', 'nmkr-connect')), 'error_code' => $code), 409);
     }
     if (is_array($result) && !empty($result['success'])) wp_send_json_success($result);
     wp_send_json_error(array('message' => __('Synchronization cleanup could not be verified.', 'nmkr-connect'), 'error_code' => 'sync_stop_cleanup_failed'), 503);
@@ -875,9 +892,8 @@ function nmkr_force_stop_sync_handler() {
         } catch (Exception $e) {
             nmkr_log_data_sync('Force stop execution failed: ' . $e->getMessage(), 'error');
             wp_send_json_error(array(
-                'message' => 'Critical error during force stop: ' . $e->getMessage(),
-                'error_code' => 'force_stop_execution_failed',
-                'technical_details' => $e->getMessage()
+                'message' => __('Synchronization could not be force stopped.', 'nmkr-connect'),
+                'error_code' => 'force_stop_execution_failed'
             ));
             wp_die();
         }
@@ -926,7 +942,7 @@ function nmkr_force_stop_sync_handler() {
             nmkr_log_ui_status('UI: Force stop failed, showing error message to user', 'error');
             
             wp_send_json_error(array(
-                'message' => 'Failed to force stop synchronization: ' . $error_message,
+                'message' => nmkr_public_sync_error_message(isset($result['error_code']) ? $result['error_code'] : '', __('Synchronization could not be force stopped.', 'nmkr-connect')),
                 'error_code' => isset($result['error_code']) ? $result['error_code'] : 'force_stop_failed',
                 'context' => $context
             ), in_array(isset($result['error_code']) ? $result['error_code'] : '', array('direct_stop_requires_cooperative_worker', 'sync_finalization_pending'), true) ? 409 : 500);
@@ -944,9 +960,8 @@ function nmkr_force_stop_sync_handler() {
         nmkr_log_ui_status('UI: Critical error during force stop - displaying generic error message', 'error');
         
         wp_send_json_error(array(
-            'message' => 'A critical error occurred while force stopping synchronization',
-            'error_code' => 'force_stop_handler_failure',
-            'technical_details' => $e->getMessage()
+            'message' => __('Synchronization could not be force stopped.', 'nmkr-connect'),
+            'error_code' => 'force_stop_handler_failure'
         ));
     }
     

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -48,6 +48,7 @@ function nmkr_is_verified_failed_terminal_for_progress($sync_data, $has_active_d
 /** Replace a verified failed terminal's private diagnostic with public-safe copy. */
 function nmkr_public_failed_terminal_progress_response($response_data) {
     $response_data['error'] = __('Synchronization failed. Review the private server diagnostics for details.', 'nmkr-connect');
+    $response_data['current_item'] = '';
     $response_data['error_code'] = 'sync_terminal_failed';
     unset($response_data['technical_details']);
     return $response_data;

--- a/js/nmkr-sync-progress.js
+++ b/js/nmkr-sync-progress.js
@@ -1,5 +1,19 @@
 'use strict';
 
+function nmkrFormatTransportError(xhr) {
+    try {
+        var allowed = ['option_retrieval_failed', 'sync_critical_error', 'sync_terminal_failed', 'sync_owner_mismatch', 'invalid_run_id', 'sync_owner_recovery_required', 'sync_finalization_pending', 'sync_already_owned', 'sync_admission_failed', 'sync_schedule_failed', 'sync_schedule_cleanup_pending', 'sync_schedule_owner_changed', 'sync_cleanup_failed', 'sync_stop_cleanup_failed', 'direct_stop_requires_cooperative_worker', 'force_stop_execution_failed', 'force_stop_failed', 'force_stop_handler_failure', 'log_clear_failed', 'section_log_clear_failed'];
+        var code = xhr && xhr.responseJSON && xhr.responseJSON.data ? xhr.responseJSON.data.error_code : '';
+        return 'HTTP ' + Number(xhr && xhr.status || 0) + (allowed.indexOf(code) !== -1 ? ' [' + code + ']' : ' [request_failed]');
+    } catch (e) {
+        return 'HTTP error';
+    }
+}
+
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { nmkrFormatTransportError: nmkrFormatTransportError };
+}
+
 jQuery(document).ready(function($) {
     // --- Polling backoff state (exponential) --------------------------------
     const pollBackoff = {
@@ -32,8 +46,7 @@ jQuery(document).ready(function($) {
     // If the detailed error helper isn't defined globally yet, define it.
     if (typeof window.nmkrHttpErrorString !== 'function') {
         window.nmkrHttpErrorString = function (xhr) {
-            try { return 'HTTP ' + (xhr.status || 0) + ' ' + (xhr.statusText || '') + ' – ' + String(xhr.responseText || '').slice(0, 200); }
-            catch (e) { return 'HTTP error'; }
+            return nmkrFormatTransportError(xhr);
         };
     }
 
@@ -48,11 +61,7 @@ jQuery(document).ready(function($) {
     };
     // Build a concise HTTP error summary from jqXHR
     function nmkrHttpErrorString(xhr) {
-        try {
-            return `HTTP ${xhr.status} ${xhr.statusText} – ${(xhr.responseText || '').slice(0,200)}`;
-        } catch (e) {
-            return 'HTTP error';
-        }
+        return window.nmkrHttpErrorString(xhr);
     }
     // Consolidated polling state variables
     let pollTimeoutId;
@@ -295,7 +304,7 @@ jQuery(document).ready(function($) {
         // Reset backoff on success
         pollBackoff.fails = 0;
         window.lastSyncResponse = response;
-        console.log('JS: Received AJAX response:', response);
+        console.log('JS: Received synchronization progress response');
         
         try {
           if (response.success && response.data) {
@@ -398,8 +407,8 @@ jQuery(document).ready(function($) {
             }
           } else {
             // Handle unsuccessful response
-            const payloadMessage = response && response.data && (response.data.message || response.data.error);
-            handleError(payloadMessage || 'Invalid response from server');
+            const payloadCode = response && response.data ? response.data.error_code : '';
+            handleError('Synchronization request failed' + (payloadCode ? ': ' + nmkrFormatTransportError({ status: 200, responseJSON: response }) : '.'));
             return;
           }
         } catch (e) {

--- a/js/nmkr-sync-progress.js
+++ b/js/nmkr-sync-progress.js
@@ -1,17 +1,32 @@
 'use strict';
 
-function nmkrFormatTransportError(xhr) {
+function nmkrFormatPublicError(data, status) {
     try {
         var allowed = ['option_retrieval_failed', 'sync_critical_error', 'sync_terminal_failed', 'sync_owner_mismatch', 'invalid_run_id', 'sync_owner_recovery_required', 'sync_finalization_pending', 'sync_already_owned', 'sync_admission_failed', 'sync_schedule_failed', 'sync_schedule_cleanup_pending', 'sync_schedule_owner_changed', 'sync_cleanup_failed', 'sync_stop_cleanup_failed', 'direct_stop_requires_cooperative_worker', 'force_stop_execution_failed', 'force_stop_failed', 'force_stop_handler_failure', 'log_clear_failed', 'section_log_clear_failed'];
-        var code = xhr && xhr.responseJSON && xhr.responseJSON.data ? xhr.responseJSON.data.error_code : '';
-        return 'HTTP ' + Number(xhr && xhr.status || 0) + (allowed.indexOf(code) !== -1 ? ' [' + code + ']' : ' [request_failed]');
+        var code = data ? data.error_code : '';
+        var known = allowed.indexOf(code) !== -1;
+        var message = known && typeof data.message === 'string' && data.message.trim() !== '' ? data.message.trim() : '';
+        var prefix = status === null ? '' : 'HTTP ' + Number(status || 0) + (message ? ': ' : ' ');
+        return prefix + (message ? message + ' [' + code + ']' : (known ? '[' + code + ']' : '[request_failed]'));
     } catch (e) {
-        return 'HTTP error';
+        return status === null ? '[request_failed]' : 'HTTP error';
     }
 }
 
+function nmkrFormatTransportError(xhr) {
+    var data = xhr && xhr.responseJSON && xhr.responseJSON.data ? xhr.responseJSON.data : null;
+    return nmkrFormatPublicError(data, Number(xhr && xhr.status || 0));
+}
+
+function nmkrFormatApplicationError(response) {
+    return nmkrFormatPublicError(response && response.data ? response.data : null, null);
+}
+
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { nmkrFormatTransportError: nmkrFormatTransportError };
+    module.exports = {
+        nmkrFormatTransportError: nmkrFormatTransportError,
+        nmkrFormatApplicationError: nmkrFormatApplicationError
+    };
 }
 
 jQuery(document).ready(function($) {
@@ -407,8 +422,7 @@ jQuery(document).ready(function($) {
             }
           } else {
             // Handle unsuccessful response
-            const payloadCode = response && response.data ? response.data.error_code : '';
-            handleError('Synchronization request failed' + (payloadCode ? ': ' + nmkrFormatTransportError({ status: 200, responseJSON: response }) : '.'));
+            handleError('Synchronization request failed: ' + nmkrFormatApplicationError(response));
             return;
           }
         } catch (e) {

--- a/js/nmkr-sync-progress.js
+++ b/js/nmkr-sync-progress.js
@@ -2,7 +2,7 @@
 
 function nmkrFormatPublicError(data, status) {
     try {
-        var allowed = ['option_retrieval_failed', 'sync_critical_error', 'sync_terminal_failed', 'sync_owner_mismatch', 'invalid_run_id', 'sync_owner_recovery_required', 'sync_finalization_pending', 'sync_already_owned', 'sync_admission_failed', 'sync_schedule_failed', 'sync_schedule_cleanup_pending', 'sync_schedule_owner_changed', 'sync_cleanup_failed', 'sync_stop_cleanup_failed', 'direct_stop_requires_cooperative_worker', 'force_stop_execution_failed', 'force_stop_failed', 'force_stop_handler_failure', 'log_clear_failed', 'section_log_clear_failed'];
+        var allowed = ['option_retrieval_failed', 'sync_critical_error', 'sync_terminal_failed', 'sync_owner_mismatch', 'invalid_run_id', 'sync_owner_recovery_required', 'sync_finalization_pending', 'sync_already_owned', 'sync_admission_failed', 'sync_start_rollback_completed', 'sync_start_rollback_lock_unavailable', 'sync_start_rollback_retained', 'sync_start_rollback_owner_changed', 'ajax_handler_failure', 'sync_schedule_failed', 'sync_schedule_cleanup_pending', 'sync_schedule_owner_changed', 'sync_cleanup_failed', 'sync_stop_cleanup_failed', 'direct_stop_requires_cooperative_worker', 'force_stop_execution_failed', 'force_stop_failed', 'force_stop_handler_failure', 'log_clear_failed', 'section_log_clear_failed'];
         var code = data ? data.error_code : '';
         var known = allowed.indexOf(code) !== -1;
         var message = known && typeof data.message === 'string' && data.message.trim() !== '' ? data.message.trim() : '';

--- a/scripts/nmkr-ajax-error-disclosure-regression.php
+++ b/scripts/nmkr-ajax-error-disclosure-regression.php
@@ -36,6 +36,7 @@ try {
         'terminalRunId' => 'abababab-1111-4111-8111-111111111111',
         'progress' => 73,
         'live_metrics' => array('api_requests' => 4),
+        'current_item' => $marker,
         'error' => $marker,
         'technical_details' => $marker,
     ));
@@ -43,6 +44,7 @@ try {
     nmkr_contract_assert($terminal['terminal_outcome'] === 'failed', 'terminal_outcome');
     nmkr_contract_assert($terminal['error_code'] === 'sync_terminal_failed', 'terminal_error_code');
     nmkr_contract_assert($terminal['error'] === 'Synchronization failed. Review the private server diagnostics for details.', 'terminal_public_message');
+    nmkr_contract_assert($terminal['current_item'] === '', 'terminal_public_current_item');
     nmkr_contract_assert(strpos($encoded, $marker) === false, 'terminal_marker_disclosed');
     nmkr_contract_assert(!array_key_exists('technical_details', $terminal), 'terminal_technical_details');
     nmkr_contract_assert(strpos($encoded, '"success":true') !== false, 'terminal_success_contract');

--- a/scripts/nmkr-ajax-error-disclosure-regression.php
+++ b/scripts/nmkr-ajax-error-disclosure-regression.php
@@ -1,0 +1,38 @@
+<?php
+/** Public-safe source-contract regression for privileged AJAX serialization. */
+$sync = file_get_contents(__DIR__ . '/../includes/synchronization/nmkr-sync-ajax-handlers.php');
+$logs = file_get_contents(__DIR__ . '/../includes/pages/dashboard/nmkr-dashboard-ajax.php');
+$ui = file_get_contents(__DIR__ . '/../includes/pages/dashboard/nmkr-dashboard-ui.php');
+
+function nmkr_contract_assert($condition, $case) {
+    if (!$condition) {
+        throw new Exception($case);
+    }
+}
+
+try {
+    $forbidden = array(
+        "'technical_details'",
+        "'message' => \$owner_error->get_error_message()",
+        "'message' => \$result->get_error_message()",
+        "'message' => 'Synchronization encountered a critical error: ' . \$error",
+        "'message' => 'Failed to force stop synchronization: ' . \$error_message",
+    );
+    foreach ($forbidden as $index => $needle) {
+        nmkr_contract_assert(strpos($sync, $needle) === false, 'sync_boundary_' . $index);
+    }
+    nmkr_contract_assert(strpos($sync, "'error_code' => 'option_retrieval_failed'") !== false, 'progress_option_code');
+    nmkr_contract_assert(strpos($sync, "'error_code' => 'sync_critical_error'") !== false, 'critical_code');
+    nmkr_contract_assert(strpos($sync, "'error_code'] = 'sync_terminal_failed'") !== false, 'terminal_code');
+    nmkr_contract_assert(strpos($sync, "'terminal_outcome'") !== false && strpos($sync, "wp_send_json_success(\$response_data)") !== false, 'terminal_success_envelope');
+    nmkr_contract_assert(strpos($sync, "? 409 : 503") !== false && strpos($sync, "? 409 : 500") !== false, 'status_contracts');
+    nmkr_contract_assert(strpos($logs, "'error_code' => 'log_clear_failed'") !== false, 'clear_all_code');
+    nmkr_contract_assert(strpos($logs, "'error_code' => 'section_log_clear_failed'") !== false, 'clear_section_code');
+    nmkr_contract_assert(strpos($logs, "'message' => 'Failed to clear logs: ' . \$e->getMessage()") === false, 'clear_all_boundary');
+    nmkr_contract_assert(strpos($logs, "logs: ' . \$e->getMessage()") === false, 'clear_section_boundary');
+    nmkr_contract_assert(strpos($ui, 'xhr.responseText') === false, 'dashboard_transport_boundary');
+    echo "AJAX error disclosure regression: PASS\n";
+} catch (Throwable $error) {
+    fwrite(STDERR, "AJAX error disclosure regression: FAIL " . $error->getMessage() . "\n");
+    exit(1);
+}

--- a/scripts/nmkr-ajax-error-disclosure-regression.php
+++ b/scripts/nmkr-ajax-error-disclosure-regression.php
@@ -10,9 +10,45 @@ function nmkr_contract_assert($condition, $case) {
     }
 }
 
+function nmkr_extract_function($source, $name) {
+    $start = strpos($source, 'function ' . $name . '(');
+    nmkr_contract_assert($start !== false, 'missing_' . $name);
+    $brace = strpos($source, '{', $start);
+    $depth = 0;
+    $length = strlen($source);
+    for ($index = $brace; $index < $length; $index++) {
+        if ($source[$index] === '{') $depth++;
+        if ($source[$index] === '}' && --$depth === 0) return substr($source, $start, $index - $start + 1);
+    }
+    throw new Exception('unterminated_' . $name);
+}
+
 try {
+    // Execute the production serializer boundary in isolation with a non-empty
+    // private diagnostic. Test output deliberately never includes the marker.
+    if (!function_exists('__')) {
+        function __($message, $domain = null) { return $message; }
+    }
+    eval(nmkr_extract_function($sync, 'nmkr_public_failed_terminal_progress_response'));
+    $marker = implode('_', array('NMKR', 'INTERNAL', 'MARKER', 'DO', 'NOT', 'DISCLOSE'));
+    $terminal = nmkr_public_failed_terminal_progress_response(array(
+        'terminal_outcome' => 'failed',
+        'terminalRunId' => 'abababab-1111-4111-8111-111111111111',
+        'progress' => 73,
+        'live_metrics' => array('api_requests' => 4),
+        'error' => $marker,
+        'technical_details' => $marker,
+    ));
+    $encoded = json_encode(array('success' => true, 'data' => $terminal));
+    nmkr_contract_assert($terminal['terminal_outcome'] === 'failed', 'terminal_outcome');
+    nmkr_contract_assert($terminal['error_code'] === 'sync_terminal_failed', 'terminal_error_code');
+    nmkr_contract_assert($terminal['error'] === 'Synchronization failed. Review the private server diagnostics for details.', 'terminal_public_message');
+    nmkr_contract_assert(strpos($encoded, $marker) === false, 'terminal_marker_disclosed');
+    nmkr_contract_assert(!array_key_exists('technical_details', $terminal), 'terminal_technical_details');
+    nmkr_contract_assert(strpos($encoded, '"success":true') !== false, 'terminal_success_contract');
+    nmkr_contract_assert($terminal['progress'] === 73 && $terminal['live_metrics']['api_requests'] === 4, 'terminal_progress_metrics');
+
     $forbidden = array(
-        "'technical_details'",
         "'message' => \$owner_error->get_error_message()",
         "'message' => \$result->get_error_message()",
         "'message' => 'Synchronization encountered a critical error: ' . \$error",

--- a/scripts/nmkr-public-checks.sh
+++ b/scripts/nmkr-public-checks.sh
@@ -33,6 +33,10 @@ bash scripts/nmkr-sync-terminalization-regression.sh
 printf '\n== Privileged AJAX guard regression ==\n'
 php scripts/nmkr-ajax-guard-regression.php
 
+printf '\n== AJAX error-disclosure regressions ==\n'
+php scripts/nmkr-ajax-error-disclosure-regression.php
+node scripts/nmkr-transport-error-disclosure-regression.js
+
 printf '\n== AJAX security private-boundary regression ==\n'
 bash scripts/nmkr-ajax-security-public-regression.sh
 

--- a/scripts/nmkr-transport-error-disclosure-regression.js
+++ b/scripts/nmkr-transport-error-disclosure-regression.js
@@ -4,7 +4,9 @@
 global.jQuery = function () { return { ready: function () {} }; };
 global.document = {};
 
-const formatter = require('../js/nmkr-sync-progress.js').nmkrFormatTransportError;
+const formatters = require('../js/nmkr-sync-progress.js');
+const formatter = formatters.nmkrFormatTransportError;
+const applicationFormatter = formatters.nmkrFormatApplicationError;
 const secret = ['NMKR', 'INTERNAL', 'MARKER', 'DO', 'NOT', 'DISCLOSE'].join('_');
 
 function assertSafe(name, value) {
@@ -12,14 +14,19 @@ function assertSafe(name, value) {
 }
 
 try {
-    const allowed = formatter({ status: 503, statusText: secret, responseText: secret, responseJSON: { data: { error_code: 'option_retrieval_failed', message: secret } } });
+    const allowed = formatter({ status: 409, responseJSON: { data: { error_code: 'sync_already_owned', message: 'A synchronization is already in progress.' } } });
+    const application = applicationFormatter({ success: false, data: { error_code: 'option_retrieval_failed', message: 'Synchronization options could not be loaded.' } });
     const unknown = formatter({ status: 502, statusText: secret, responseText: secret, responseJSON: { data: { error_code: secret, message: secret } } });
-    const warning = 'Temporary sync hiccup: ' + allowed + '. Retrying soon.';
+    const unknownApplication = applicationFormatter({ success: false, data: { error_code: secret, message: secret } });
+    const warning = 'Temporary sync hiccup: ' + unknown + '. Retrying soon.';
     const consolePayload = ['Progress poll transient failure:', unknown];
-    [allowed, unknown, warning].forEach(function (value, index) { assertSafe('formatted_' + index, value); });
+    [allowed, application, unknown, unknownApplication, warning].forEach(function (value, index) { assertSafe('formatted_' + index, value); });
     consolePayload.forEach(function (value, index) { assertSafe('console_' + index, value); });
-    if (allowed !== 'HTTP 503 [option_retrieval_failed]') throw new Error('allowlisted_code_missing');
+    if (allowed !== 'HTTP 409: A synchronization is already in progress. [sync_already_owned]') throw new Error('allowlisted_message_missing');
+    if (application !== 'Synchronization options could not be loaded. [option_retrieval_failed]') throw new Error('application_message_missing');
+    if (application.indexOf('HTTP') !== -1) throw new Error('application_http_fabricated');
     if (unknown !== 'HTTP 502 [request_failed]') throw new Error('status_classification_missing');
+    if (unknownApplication !== '[request_failed]') throw new Error('application_classification_missing');
     console.log('Transport error disclosure regression: PASS');
 } catch (error) {
     console.error('Transport error disclosure regression: FAIL ' + error.message);

--- a/scripts/nmkr-transport-error-disclosure-regression.js
+++ b/scripts/nmkr-transport-error-disclosure-regression.js
@@ -1,0 +1,27 @@
+'use strict';
+
+// Prevent the browser initializer from running while loading its pure formatter.
+global.jQuery = function () { return { ready: function () {} }; };
+global.document = {};
+
+const formatter = require('../js/nmkr-sync-progress.js').nmkrFormatTransportError;
+const secret = ['NMKR', 'INTERNAL', 'MARKER', 'DO', 'NOT', 'DISCLOSE'].join('_');
+
+function assertSafe(name, value) {
+    if (String(value).indexOf(secret) !== -1) throw new Error(name + '_disclosed');
+}
+
+try {
+    const allowed = formatter({ status: 503, statusText: secret, responseText: secret, responseJSON: { data: { error_code: 'option_retrieval_failed', message: secret } } });
+    const unknown = formatter({ status: 502, statusText: secret, responseText: secret, responseJSON: { data: { error_code: secret, message: secret } } });
+    const warning = 'Temporary sync hiccup: ' + allowed + '. Retrying soon.';
+    const consolePayload = ['Progress poll transient failure:', unknown];
+    [allowed, unknown, warning].forEach(function (value, index) { assertSafe('formatted_' + index, value); });
+    consolePayload.forEach(function (value, index) { assertSafe('console_' + index, value); });
+    if (allowed !== 'HTTP 503 [option_retrieval_failed]') throw new Error('allowlisted_code_missing');
+    if (unknown !== 'HTTP 502 [request_failed]') throw new Error('status_classification_missing');
+    console.log('Transport error disclosure regression: PASS');
+} catch (error) {
+    console.error('Transport error disclosure regression: FAIL ' + error.message);
+    process.exit(1);
+}

--- a/scripts/nmkr-transport-error-disclosure-regression.js
+++ b/scripts/nmkr-transport-error-disclosure-regression.js
@@ -15,6 +15,10 @@ function assertSafe(name, value) {
 
 try {
     const allowed = formatter({ status: 409, responseJSON: { data: { error_code: 'sync_already_owned', message: 'A synchronization is already in progress.' } } });
+    const startFailureCodes = ['sync_start_rollback_completed', 'sync_start_rollback_lock_unavailable', 'sync_start_rollback_retained', 'sync_start_rollback_owner_changed', 'ajax_handler_failure'];
+    const startFailures = startFailureCodes.map(function (code) {
+        return formatter({ status: 500, responseJSON: { data: { error_code: code, message: 'Synchronization could not be initialized safely.' } } });
+    });
     const application = applicationFormatter({ success: false, data: { error_code: 'option_retrieval_failed', message: 'Synchronization options could not be loaded.' } });
     const unknown = formatter({ status: 502, statusText: secret, responseText: secret, responseJSON: { data: { error_code: secret, message: secret } } });
     const unknownApplication = applicationFormatter({ success: false, data: { error_code: secret, message: secret } });
@@ -23,6 +27,10 @@ try {
     [allowed, application, unknown, unknownApplication, warning].forEach(function (value, index) { assertSafe('formatted_' + index, value); });
     consolePayload.forEach(function (value, index) { assertSafe('console_' + index, value); });
     if (allowed !== 'HTTP 409: A synchronization is already in progress. [sync_already_owned]') throw new Error('allowlisted_message_missing');
+    startFailures.forEach(function (value, index) {
+        const expected = 'HTTP 500: Synchronization could not be initialized safely. [' + startFailureCodes[index] + ']';
+        if (value !== expected) throw new Error('start_failure_message_missing_' + index);
+    });
     if (application !== 'Synchronization options could not be loaded. [option_retrieval_failed]') throw new Error('application_message_missing');
     if (application.indexOf('HTTP') !== -1) throw new Error('application_http_fabricated');
     if (unknown !== 'HTTP 502 [request_failed]') throw new Error('status_classification_missing');


### PR DESCRIPTION
### Motivation
- Prevent leakage of internal/technical diagnostics and exception messages through privileged AJAX responses and client-side logs.
- Provide stable, public-safe messages and machine-friendly `error_code` values so UI and integrators can react without exposing server internals.
- Add automated regressions to detect accidental disclosure in future changes.

### Description
- Added `nmkr_public_sync_error_message()` to map internal error codes to safe user-facing messages and replaced direct uses of internal `get_error_message()`/exception text in several AJAX handlers with public-safe messages and `error_code` fields.
- Modified log-clearing handlers to `error_log()` exceptions server-side and return generic failure messages with error codes instead of embedding exception strings in responses.
- Reworked client-side error formatting by adding `nmkrFormatTransportError()` (exported for Node), removed direct uses of `xhr.responseText` in console/UI messages, and updated polling error handling to avoid disclosing raw response bodies.
- Added regression/test helpers: `scripts/nmkr-ajax-error-disclosure-regression.php`, `scripts/nmkr-transport-error-disclosure-regression.js`, and wired them into `scripts/nmkr-public-checks.sh` to catch disclosure regressions.

### Testing
- Executed the AJAX error-disclosure PHP regression `php scripts/nmkr-ajax-error-disclosure-regression.php` which passed.
- Executed the transport formatter smoke test with `node scripts/nmkr-transport-error-disclosure-regression.js` which passed.
- Ran the public preflight suite via `bash scripts/nmkr-public-checks.sh` (which includes the new checks) and observed the added disclosure regressions succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8943ffb8a08333bc9c10c9373711de)