### PR TITLE
security: restrict dashboard mutation authority

### DIFF
--- a/includes/pages/dashboard/nmkr-dashboard-ajax.php
+++ b/includes/pages/dashboard/nmkr-dashboard-ajax.php
@@ -343,8 +343,8 @@ function nmkr_store_active_metrics_ajax() {
         wp_die();
     }
     
-    // Capability: view dashboard
-    if ( ! current_user_can( 'nmkr_view_dashboard' ) ) {
+    // Capability: manage synchronization and its dashboard-side metrics/log writes.
+    if ( ! current_user_can( 'nmkr_manage_sync' ) ) {
         wp_send_json_error( array( 'message' => __( 'Forbidden', 'nmkr-connect' ) ), 403 );
         wp_die();
     }

--- a/includes/pages/dashboard/nmkr-dashboard-core.php
+++ b/includes/pages/dashboard/nmkr-dashboard-core.php
@@ -43,8 +43,10 @@ function nmkr_connect_dashboard_page() {
         }
         wp_die( esc_html__( 'Access denied.', 'nmkr-connect' ) );
     }
+    $can_manage_sync = current_user_can( 'nmkr_manage_sync' );
+
     // Proactive stale-state recovery on dashboard load
-    if ( current_user_can( 'nmkr_manage_sync' ) && function_exists('nmkr_detect_and_recover_stale_sync') ) {
+    if ( $can_manage_sync && function_exists('nmkr_detect_and_recover_stale_sync') ) {
         nmkr_detect_and_recover_stale_sync();
     }
     // Log UI status update for dashboard page load
@@ -63,10 +65,10 @@ function nmkr_connect_dashboard_page() {
         // Render dashboard UI elements
         nmkr_render_dashboard_styles();
         nmkr_render_api_status_panel();
-        nmkr_render_sync_data_panel($dashboard_nonce);
+        nmkr_render_sync_data_panel($dashboard_nonce, $can_manage_sync);
         nmkr_render_sync_statistics_panel($initial_stats);
-        nmkr_render_debug_logs_panel(); // Add debug logs panel at the bottom
-        nmkr_render_dashboard_scripts($dashboard_nonce);
+        nmkr_render_debug_logs_panel($can_manage_sync); // Add debug logs panel at the bottom
+        nmkr_render_dashboard_scripts($dashboard_nonce, $can_manage_sync);
         ?>
     </div>
     <?php
@@ -143,4 +145,4 @@ function nmkr_ensure_last_sync_time() {
 }
 
 // Run the ensure function on admin init
-add_action('admin_init', 'nmkr_ensure_last_sync_time'); 
+add_action('admin_init', 'nmkr_ensure_last_sync_time');

--- a/includes/pages/dashboard/nmkr-dashboard-ui.php
+++ b/includes/pages/dashboard/nmkr-dashboard-ui.php
@@ -759,9 +759,10 @@ function nmkr_render_api_status_panel() {
 /**
  * Render the Sync Data Panel
  * 
- * @param string $dashboard_nonce The nonce for dashboard operations
+ * @param string $dashboard_nonce The nonce for dashboard operations.
+ * @param bool   $can_manage_sync Whether the current user may mutate synchronization state.
  */
-function nmkr_render_sync_data_panel($dashboard_nonce) {
+function nmkr_render_sync_data_panel($dashboard_nonce, $can_manage_sync) {
     ?>
     <!-- Data Synchronization Panel -->
     <div class="panel sync-data" role="region" aria-label="Data Synchronization Controls">
@@ -774,12 +775,14 @@ function nmkr_render_sync_data_panel($dashboard_nonce) {
         
         <div class="sync-controls panel-section">
             <div class="sync-buttons">
+                <?php if ( $can_manage_sync ) : ?>
                 <button id="nmkr-sync-button" class="button button-primary" disabled aria-label="Start Data Synchronization">
                     Start Synchronization
                 </button>
                 <button id="nmkr-stop-sync-button" class="button button-danger" style="display:none;" aria-label="Stop Data Synchronization">
                     Stop Synchronization
                 </button>
+                <?php endif; ?>
             </div>
             
             <input type="hidden" id="nmkr-sync-nonce" value="<?php echo wp_create_nonce('nmkr_sync_nonce'); ?>">
@@ -889,7 +892,7 @@ function nmkr_render_sync_statistics_panel($initial_stats) {
  * Render the Debug Logs Panel
  * Only displayed if log_to_dashboard option is enabled
  */
-function nmkr_render_debug_logs_panel() {
+function nmkr_render_debug_logs_panel($can_manage_sync) {
     // Check if log_to_dashboard is enabled
     $options = get_option('nmkr_connect_options');
     $log_to_dashboard = !empty($options['log_to_dashboard']);
@@ -958,6 +961,7 @@ function nmkr_render_debug_logs_panel() {
              </fieldset>
          </div>
          
+         <?php if ( $can_manage_sync ) : ?>
          <!-- Clear All Logs Button -->
          <div class="clear-logs-controls">
              <?php 
@@ -975,6 +979,7 @@ function nmkr_render_debug_logs_panel() {
                  🧹 Clear All Logs
              </button>
          </div>
+         <?php endif; ?>
          
          <div class="panel-section">
             <!-- Sync Logs Section -->
@@ -989,6 +994,7 @@ function nmkr_render_debug_logs_panel() {
                          $disabled_class = $sync_in_progress ? 'disabled' : '';
                          $tooltip_text = $sync_in_progress ? 'Logs cannot be cleared while sync is in progress.' : 'Clear sync logs';
                          ?>
+                         <?php if ( $can_manage_sync ) : ?>
                          <button type="button" 
                                  class="clear-section-logs-btn <?php echo esc_attr($disabled_class); ?>" 
                                  data-log-type="sync"
@@ -997,6 +1003,7 @@ function nmkr_render_debug_logs_panel() {
                                  data-nonce="<?php echo wp_create_nonce('nmkr_clear_logs_nonce'); ?>">
                              🧹 Clear Logs
                          </button>
+                         <?php endif; ?>
                      </summary>
                     <div class="log-entries">
                                                  <?php if (empty($sync_logs)): ?>
@@ -1035,6 +1042,7 @@ function nmkr_render_debug_logs_panel() {
                          $disabled_class = $sync_in_progress ? 'disabled' : '';
                          $tooltip_text = $sync_in_progress ? 'Logs cannot be cleared while sync is in progress.' : 'Clear API logs';
                          ?>
+                         <?php if ( $can_manage_sync ) : ?>
                          <button type="button" 
                                  class="clear-section-logs-btn <?php echo esc_attr($disabled_class); ?>" 
                                  data-log-type="api"
@@ -1043,6 +1051,7 @@ function nmkr_render_debug_logs_panel() {
                                  data-nonce="<?php echo wp_create_nonce('nmkr_clear_logs_nonce'); ?>">
                              🧹 Clear Logs
                          </button>
+                         <?php endif; ?>
                      </summary>
                     <div class="log-entries">
                                                  <?php if (empty($api_logs)): ?>
@@ -1081,6 +1090,7 @@ function nmkr_render_debug_logs_panel() {
                          $disabled_class = $sync_in_progress ? 'disabled' : '';
                          $tooltip_text = $sync_in_progress ? 'Logs cannot be cleared while sync is in progress.' : 'Clear UI logs';
                          ?>
+                         <?php if ( $can_manage_sync ) : ?>
                          <button type="button" 
                                  class="clear-section-logs-btn <?php echo esc_attr($disabled_class); ?>" 
                                  data-log-type="ui"
@@ -1089,6 +1099,7 @@ function nmkr_render_debug_logs_panel() {
                                  data-nonce="<?php echo wp_create_nonce('nmkr_clear_logs_nonce'); ?>">
                              🧹 Clear Logs
                          </button>
+                         <?php endif; ?>
                      </summary>
                     <div class="log-entries">
                                                  <?php if (empty($ui_logs)): ?>
@@ -1127,6 +1138,7 @@ function nmkr_render_debug_logs_panel() {
                          $disabled_class = $sync_in_progress ? 'disabled' : '';
                          $tooltip_text = $sync_in_progress ? 'Logs cannot be cleared while sync is in progress.' : 'Clear performance logs';
                          ?>
+                         <?php if ( $can_manage_sync ) : ?>
                          <button type="button" 
                                  class="clear-section-logs-btn <?php echo esc_attr($disabled_class); ?>" 
                                  data-log-type="performance"
@@ -1135,6 +1147,7 @@ function nmkr_render_debug_logs_panel() {
                                  data-nonce="<?php echo wp_create_nonce('nmkr_clear_logs_nonce'); ?>">
                              🧹 Clear Logs
                          </button>
+                         <?php endif; ?>
                      </summary>
                     <div class="log-entries">
                                                  <?php if (empty($performance_logs)): ?>
@@ -1185,13 +1198,26 @@ function nmkr_render_debug_logs_panel() {
  *
  * @param string $dashboard_nonce The nonce for dashboard operations
  */
-function nmkr_render_dashboard_scripts($dashboard_nonce) {
+function nmkr_render_dashboard_scripts($dashboard_nonce, $can_manage_sync) {
     ?>
     <script>
         jQuery(document).ready(function($) {
             // Cache nonce values ONCE to avoid repeated DOM queries
             const syncNonce = $('#nmkr-sync-nonce').val();
             const dashboardNonce = $('#nmkr-dashboard-nonce').val();
+            const canManageSync = <?php echo $can_manage_sync ? 'true' : 'false'; ?>;
+
+            // Keep observation polling available while suppressing manager-only telemetry writes.
+            $.ajaxPrefilter(function(options, originalOptions, jqXHR) {
+                const requestData = originalOptions.data || options.data;
+                const action = typeof requestData === 'string'
+                    ? new URLSearchParams(requestData).get('action')
+                    : requestData && requestData.action;
+
+                if (!canManageSync && action === 'nmkr_store_active_metrics') {
+                    jqXHR.abort();
+                }
+            });
             
             // Set default display while loading
             $('#api-status').html('<span class="api-status-loading">Checking connection...</span>');

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -2,25 +2,26 @@
 /** Public-safe executable regression for privileged AJAX guard ordering. */
 define('ABSPATH', __DIR__ . '/synthetic/');
 define('DAY_IN_SECONDS', 86400);
+define('NMKR_SYNC_TRANSIENT_TTL', 3600);
 $GLOBALS['nmkr_calls'] = array();
 $GLOBALS['nmkr_nonce_ok'] = false;
 $GLOBALS['nmkr_caps'] = array();
 $GLOBALS['nmkr_hooks'] = array();
 
-class NmkrAjaxTermination extends Exception { public $kind; public $status; public function __construct($kind, $status = 0) { parent::__construct($kind); $this->kind=$kind; $this->status=$status; } }
+class NmkrAjaxTermination extends Exception { public $kind; public $status; public $data; public function __construct($kind, $status = 0, $data = null) { parent::__construct($kind); $this->kind=$kind; $this->status=$status; $this->data=$data; } }
 function add_action($hook, $callback) { $GLOBALS['nmkr_hooks'][$hook] = $callback; }
 function check_ajax_referer($action, $field) { $GLOBALS['nmkr_calls'][]='nonce:'.$action.':'.$field; if (!$GLOBALS['nmkr_nonce_ok']) throw new NmkrAjaxTermination('nonce'); }
 function wp_verify_nonce($nonce, $action) { $GLOBALS['nmkr_calls'][]='nonce:'.$action.':nonce'; return $GLOBALS['nmkr_nonce_ok']; }
 function current_user_can($cap) { $GLOBALS['nmkr_calls'][]='cap:'.$cap; return !empty($GLOBALS['nmkr_caps'][$cap]); }
-function wp_send_json_error($data=null, $status=0) { throw new NmkrAjaxTermination('error', (int)$status); }
-function wp_send_json_success($data=null, $status=0) { throw new NmkrAjaxTermination('success', (int)$status); }
+function wp_send_json_error($data=null, $status=0) { throw new NmkrAjaxTermination('error', (int)$status, $data); }
+function wp_send_json_success($data=null, $status=0) { throw new NmkrAjaxTermination('success', (int)$status, $data); }
 function wp_die() { throw new NmkrAjaxTermination('die'); }
 function __($text, $domain=null) { return $text; }
 function nocache_headers() { $GLOBALS['nmkr_calls'][]='headers'; }
 function status_header($status) { $GLOBALS['nmkr_calls'][]='status'; }
 function sanitize_text_field($v) { return (string)$v; }
 function wp_unslash($v) { return $v; }
-function get_option($k, $d=false) { $GLOBALS['nmkr_calls'][]='option'; return $d; }
+function get_option($k, $d=false) { $GLOBALS['nmkr_calls'][]='option'; return array_key_exists($k, $GLOBALS['nmkr_options'] ?? array()) ? $GLOBALS['nmkr_options'][$k] : $d; }
 function update_option($k,$v,$a=null) { $GLOBALS['nmkr_calls'][]='option-write'; return true; }
 function delete_option($k) { $GLOBALS['nmkr_calls'][]='option-write'; return true; }
 function get_transient($k) { $GLOBALS['nmkr_calls'][]='transient'; return false; }
@@ -31,12 +32,18 @@ function wp_schedule_single_event($t,$h,$a=array()) { $GLOBALS['nmkr_calls'][]='
 function nmkr_admit_sync_owner($id) { $GLOBALS['nmkr_calls'][]='admission'; return array(); }
 function nmkr_get_sync_owner() { $GLOBALS['nmkr_calls'][]='owner'; return false; }
 function nmkr_is_api_connected() { $GLOBALS['nmkr_calls'][]='api'; return false; }
+function nmkr_log_ui_status($message, $type) { $GLOBALS['nmkr_calls'][]='ui-log'; }
 function wp_json_encode($v) { return json_encode($v); }
 function get_current_blog_id() { return 1; }
 function wp_generate_uuid4() { return '00000000-0000-4000-8000-000000000001'; }
+function wp_create_nonce($action) { return 'synthetic-nonce'; }
+function esc_attr($value) { return (string)$value; }
+function esc_html($value) { return (string)$value; }
+function nmkr_get_log_retention_limit() { return 20; }
 
 require __DIR__.'/../includes/synchronization/nmkr-sync-ajax-handlers.php';
 require __DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ajax.php';
+require __DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ui.php';
 require __DIR__.'/../includes/pages/analytics/nmkr-analytics-ajax.php';
 
 function nmkr_test($name, $handler, $nonce, $caps, $expected, $forbidden) {
@@ -57,12 +64,44 @@ try {
     nmkr_test('stop_cap','nmkr_stop_sync_handler',true,array(),array('cap:nmkr_manage_sync'),array('owner','option','option-write','transient','transient-write','cron'));
     nmkr_test('api_nonce','nmkr_check_api_status',false,array(),array('nonce:nmkr_dashboard_nonce:nonce'),array('cap:nmkr_view_dashboard','option','api'));
     nmkr_test('api_cap','nmkr_check_api_status',true,array(),array('cap:nmkr_view_dashboard'),array('option','api'));
+    nmkr_test('metrics_nonce','nmkr_store_active_metrics_ajax',false,array(),array('nonce:nmkr_dashboard_nonce:nonce'),array('cap:nmkr_manage_sync','transient','transient-write','option','option-write','ui-log'));
+    nmkr_test('metrics_view_only','nmkr_store_active_metrics_ajax',true,array('nmkr_view_dashboard'=>true),array('nonce:nmkr_dashboard_nonce:nonce','cap:nmkr_manage_sync'),array('transient','transient-write','option','option-write','ui-log'));
+
+    $GLOBALS['nmkr_calls']=array(); $GLOBALS['nmkr_nonce_ok']=true; $GLOBALS['nmkr_caps']=array('nmkr_manage_sync'=>true);
+    $_POST=array('nonce'=>'synthetic','metrics'=>array('average_response_time'=>'1.25','api_requests'=>'2','memory_usage'=>'3.5'));
+    try { nmkr_store_active_metrics_ajax(); throw new Exception('metrics_manager_no_termination'); }
+    catch (NmkrAjaxTermination $e) {
+        if ($e->kind !== 'success' || !is_array($e->data) || $e->data['average_response_time'] !== 1.25 || $e->data['api_requests'] !== 2 || $e->data['memory_usage'] !== 3.5) throw new Exception('metrics_manager_response_shape');
+    }
+    foreach (array('cap:nmkr_manage_sync','transient','transient-write','ui-log') as $call) if (!in_array($call,$GLOBALS['nmkr_calls'],true)) throw new Exception('metrics_manager_authorized_path');
     nmkr_test('logs_nonce','nmkr_clear_all_logs_ajax',false,array(),array('nonce:nmkr_clear_logs_nonce:nonce'),array('cap:nmkr_manage_sync','option-write'));
     nmkr_test('logs_cap','nmkr_clear_all_logs_ajax',true,array(),array('nonce:nmkr_clear_logs_nonce:nonce','cap:nmkr_manage_sync'),array('option','option-write','transient','transient-write','cron'));
     nmkr_test('analytics_nonce','nmkr_analytics_kpis_ajax',false,array(),array('nonce:nmkr_dashboard_nonce:nonce'),array('cap:nmkr_view_analytics','transient','option'));
     nmkr_test('analytics_cap','nmkr_analytics_kpis_ajax',true,array(),array('cap:nmkr_view_analytics'),array('transient','option'));
-    $protected=array('nmkr_start_sync','nmkr_sync_progress','nmkr_stop_sync','nmkr_check_sync_health','nmkr_check_api_status','nmkr_clear_all_logs','nmkr_analytics_kpis');
+    $protected=array('nmkr_start_sync','nmkr_sync_progress','nmkr_stop_sync','nmkr_check_sync_health','nmkr_check_api_status','nmkr_store_active_metrics','nmkr_clear_all_logs','nmkr_analytics_kpis');
     foreach ($protected as $action) { if (!isset($GLOBALS['nmkr_hooks']['wp_ajax_'.$action]) || isset($GLOBALS['nmkr_hooks']['wp_ajax_nopriv_'.$action])) throw new Exception('registration_boundary_failed'); }
+    $core_source=file_get_contents(__DIR__.'/../includes/pages/dashboard/nmkr-dashboard-core.php');
+    $ui_source=file_get_contents(__DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ui.php');
+    if (substr_count($core_source, "\$can_manage_sync = current_user_can( 'nmkr_manage_sync' );") !== 1) throw new Exception('dashboard_authority_signal_missing');
+    if (strpos($ui_source, '<?php if ( $can_manage_sync ) : ?>') === false || strpos($ui_source, "action === 'nmkr_store_active_metrics'") === false || strpos($ui_source, 'jqXHR.abort();') === false) throw new Exception('dashboard_view_only_gating_missing');
+
+    ob_start(); nmkr_render_sync_data_panel('synthetic-dashboard-nonce', false); $view_sync=ob_get_clean();
+    if (strpos($view_sync, 'class="panel sync-data"') === false || strpos($view_sync, 'id="nmkr-sync-progress-container"') === false || strpos($view_sync, 'id="active-sync-metrics"') === false) throw new Exception('dashboard_view_only_observation_missing');
+    if (strpos($view_sync, 'id="nmkr-sync-button"') !== false || strpos($view_sync, 'id="nmkr-stop-sync-button"') !== false) throw new Exception('dashboard_view_only_sync_controls_present');
+    ob_start(); nmkr_render_sync_data_panel('synthetic-dashboard-nonce', true); $manager_sync=ob_get_clean();
+    if (strpos($manager_sync, 'id="nmkr-sync-button"') === false || strpos($manager_sync, 'id="nmkr-stop-sync-button"') === false) throw new Exception('dashboard_manager_sync_controls_missing');
+
+    $GLOBALS['nmkr_calls']=array();
+    ob_start(); nmkr_render_dashboard_scripts('synthetic-dashboard-nonce', false); $view_scripts=ob_get_clean();
+    if (strpos($view_scripts, 'const canManageSync = false;') === false || strpos($view_scripts, "action === 'nmkr_store_active_metrics'") === false || strpos($view_scripts, 'jqXHR.abort();') === false) throw new Exception('dashboard_view_only_caller_guard_missing');
+    ob_start(); nmkr_render_dashboard_scripts('synthetic-dashboard-nonce', true); $manager_scripts=ob_get_clean();
+    if (strpos($manager_scripts, 'const canManageSync = true;') === false || strpos($manager_scripts, "action: 'nmkr_store_active_metrics'") === false) throw new Exception('dashboard_manager_caller_missing');
+
+    $GLOBALS['nmkr_options']=array('nmkr_connect_options'=>array('log_to_dashboard'=>true));
+    ob_start(); nmkr_render_debug_logs_panel(false); $view_logs=ob_get_clean();
+    if (strpos($view_logs, 'class="panel debug-logs-panel"') === false || strpos($view_logs, 'clear-all-logs-btn') !== false || strpos($view_logs, 'clear-section-logs-btn') !== false) throw new Exception('dashboard_view_only_log_controls');
+    ob_start(); nmkr_render_debug_logs_panel(true); $manager_logs=ob_get_clean();
+    if (strpos($manager_logs, 'clear-all-logs-btn') === false || strpos($manager_logs, 'clear-section-logs-btn') === false) throw new Exception('dashboard_manager_log_controls_missing');
     // nmkr_analytics_event is deliberately public and registered by a different,
     // unloaded endpoint module.  Its absence here is not registration evidence.
     echo "Privileged AJAX guard regression: PASS\n";

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -46,7 +46,7 @@ require __DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ajax.php';
 require __DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ui.php';
 require __DIR__.'/../includes/pages/analytics/nmkr-analytics-ajax.php';
 
-function nmkr_test($name, $handler, $nonce, $caps, $expected, $forbidden) {
+function nmkr_test($name, $handler, $nonce, $caps, $expected, $forbidden, $expected_response = null) {
     $GLOBALS['nmkr_calls']=array(); $GLOBALS['nmkr_nonce_ok']=$nonce; $GLOBALS['nmkr_caps']=$caps;
     $_POST=array('nonce'=>'synthetic');
     if ($name === 'stop_cap') $_POST['run_id']='restricted-malformed-run-id';
@@ -55,6 +55,7 @@ function nmkr_test($name, $handler, $nonce, $caps, $expected, $forbidden) {
     foreach ($expected as $call) if (!in_array($call,$GLOBALS['nmkr_calls'],true)) throw new Exception($name.'_expected_guard_missing');
     foreach ($forbidden as $call) if (in_array($call,$GLOBALS['nmkr_calls'],true)) throw new Exception($name.'_downstream_reached');
     if ($nonce && empty($caps) && ($kind!=='error' || $status!==403)) throw new Exception($name.'_forbidden_shape');
+    if ($expected_response !== null && ($kind !== $expected_response['kind'] || $status !== $expected_response['status'] || $e->data !== $expected_response['data'])) throw new Exception($name.'_response_contract');
 }
 
 try {
@@ -65,7 +66,7 @@ try {
     nmkr_test('api_nonce','nmkr_check_api_status',false,array(),array('nonce:nmkr_dashboard_nonce:nonce'),array('cap:nmkr_view_dashboard','option','api'));
     nmkr_test('api_cap','nmkr_check_api_status',true,array(),array('cap:nmkr_view_dashboard'),array('option','api'));
     nmkr_test('metrics_nonce','nmkr_store_active_metrics_ajax',false,array(),array('nonce:nmkr_dashboard_nonce:nonce'),array('cap:nmkr_manage_sync','transient','transient-write','option','option-write','ui-log'));
-    nmkr_test('metrics_view_only','nmkr_store_active_metrics_ajax',true,array('nmkr_view_dashboard'=>true),array('nonce:nmkr_dashboard_nonce:nonce','cap:nmkr_manage_sync'),array('transient','transient-write','option','option-write','ui-log'));
+    nmkr_test('metrics_view_only','nmkr_store_active_metrics_ajax',true,array('nmkr_view_dashboard'=>true),array('nonce:nmkr_dashboard_nonce:nonce','cap:nmkr_manage_sync'),array('transient','transient-write','option','option-write','ui-log'),array('kind'=>'error','status'=>403,'data'=>array('message'=>'Forbidden')));
 
     $GLOBALS['nmkr_calls']=array(); $GLOBALS['nmkr_nonce_ok']=true; $GLOBALS['nmkr_caps']=array('nmkr_manage_sync'=>true);
     $_POST=array('nonce'=>'synthetic','metrics'=>array('average_response_time'=>'1.25','api_requests'=>'2','memory_usage'=>'3.5'));

--- a/tests/e2e/nmkr-ajax-security.regression.spec.ts
+++ b/tests/e2e/nmkr-ajax-security.regression.spec.ts
@@ -92,6 +92,7 @@ test('@negative privileged AJAX rejects anonymous, nonce, capability, and malfor
     for (const [action, nonce, run_id] of [['nmkr_start_sync',rr.syncNonce,''],['nmkr_sync_progress',rr.syncNonce,''],['nmkr_check_sync_health',rr.syncNonce,''],['nmkr_check_api_status',rr.dashboardNonce,''],['nmkr_stop_sync',rr.syncNonce,'restricted-malformed-run-id']]) {
       deniedCapability(await post(restrictedLogin.context, rr.ajaxUrl, { action, nonce, ...(run_id ? { run_id } : {}) }));
     }
+    deniedCapability(await post(restrictedLogin.context, rr.ajaxUrl, { action:'nmkr_store_active_metrics', nonce:rr.dashboardNonce, 'metrics[average_response_time]':'1.25', 'metrics[api_requests]':'2', 'metrics[memory_usage]':'3.5' }));
   } finally { await restrictedLogin.context.close(); }
   deniedMalformedStop(await post(context, admin.ajaxUrl, { action:'nmkr_stop_sync', nonce:admin.syncNonce, run_id:'not-a-valid-run-id' }));
   expect([...adminLedger, ...restrictedLogin.ledger], 'ajax_security_automatic_ajax_ledger').not.toContain('allowed-automatic-ajax');


### PR DESCRIPTION
### Motivation
- Fix an authorization gap where read-only dashboard users could trigger state-changing behavior via the `nmkr_store_active_metrics` AJAX endpoint. 
- Ensure mutation authority is separated from observation: a valid nonce is preserved for request-origin protection but is not used as an authorization substitute. 
- Align rendered dashboard controls and callers so view-only users keep observation/polling but cannot see or invoke mutation controls.

### Description
- Require `nmkr_manage_sync` in `nmkr_store_active_metrics_ajax()` while preserving the existing `nmkr_dashboard_nonce` check and returning the repository-standard internationalized `403 Forbidden` for denied callers. (`includes/pages/dashboard/nmkr-dashboard-ajax.php`)
- Derive a single server-side authority signal (`$can_manage_sync`) in `nmkr_connect_dashboard_page()` and pass it into sync panels, debug-logs panel, and scripts to avoid duplicated logic. (`includes/pages/dashboard/nmkr-dashboard-core.php`)
- Make Start/Stop sync buttons and log-clearing controls render only for users with `nmkr_manage_sync`, while keeping read-only UI elements, active metrics display, progress container, and dashboard nonces available for observation. (`includes/pages/dashboard/nmkr-dashboard-ui.php`)
- Add a client-side prefilter (`$.ajaxPrefilter`) bound to a server-provided `canManageSync` flag so the browser aborts attempts to send `nmkr_store_active_metrics` for view-only users, avoiding repeated `403` requests and preserving read-only polling. (`includes/pages/dashboard/nmkr-dashboard-ui.php`)
- Extend the public-safe synthetic regression `scripts/nmkr-ajax-guard-regression.php` to assert nonce-first failures, view-only denial with no transient/option/log side effects, the authorized manager path shape and side-effect pattern, registration of protected AJAX hooks, and that the UI renders observation-only controls for view users and manager controls for managers. (`scripts/nmkr-ajax-guard-regression.php`)

### Testing
- Ran `git diff --check` and lint checks with `php -l` on `includes/pages/dashboard/nmkr-dashboard-ajax.php`, `includes/pages/dashboard/nmkr-dashboard-core.php`, `includes/pages/dashboard/nmkr-dashboard-ui.php`, and `scripts/nmkr-ajax-guard-regression.php`; all reported no syntax or diff-check errors. 
- Executed the extended public-safe regression `php scripts/nmkr-ajax-guard-regression.php` which passed and validated: nonce ordering, view-only `403` semantics, absence of transient/option/log writes on denied calls, and the authorized manager path and response shape. 
- Ran the PHP 7.4 compatibility scan via `npm run test:php74` and observed no syntax or compatibility warnings for tracked PHP files. 
- Confirmed `nmkr_store_active_metrics_ajax()` now enforces `nmkr_manage_sync` while `nmkr_view_dashboard` still grants read-only observation and that the UI and JS prevent view-only clients from emitting mutation requests (verified by the regression harness assertions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a92af93930c8333826e9ecc9ce2fb26)