### PR TITLE
security: restrict progress recovery authority

### DIFF
--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -64,20 +64,38 @@ function nmkr_fail_nonterminal_sync_history($sync_stats_id, $error_message) {
     }
 
     $table_name = $wpdb->prefix . 'nmkr_sync_stats';
-    $history = $wpdb->get_row(
-        $wpdb->prepare("SELECT id, status, end_time FROM $table_name WHERE id = %d", $sync_stats_id),
-        ARRAY_A
+    $timestamp = nmkr_get_timestamp();
+    $terminal_statuses = nmkr_sync_terminal_statuses();
+    $terminal_placeholders = implode(', ', array_fill(0, count($terminal_statuses), '%s'));
+    $update_values = array_merge(
+        array('failed', $timestamp, $error_message, $timestamp, $sync_stats_id),
+        $terminal_statuses
     );
-    if (!$history || (int) ($history['id'] ?? 0) !== $sync_stats_id
-        || nmkr_is_sync_terminal_status($history['status'] ?? '')) {
+    $updated = $wpdb->query($wpdb->prepare(
+        "UPDATE $table_name
+         SET status = %s, end_time = %s, error_message = %s, updated_at = %s
+         WHERE id = %d
+           AND (status IS NULL OR LOWER(status) NOT IN ($terminal_placeholders))",
+        $update_values
+    ));
+    if ($updated !== 1) {
         return false;
     }
 
-    return nmkr_update_sync_stats($sync_stats_id, array(
-        'status' => 'failed',
-        'end_time' => nmkr_get_timestamp(),
-        'error_message' => $error_message,
-    ));
+    $history = $wpdb->get_row(
+        $wpdb->prepare(
+            "SELECT id, status, end_time, error_message, updated_at FROM $table_name WHERE id = %d LIMIT 1",
+            $sync_stats_id
+        ),
+        ARRAY_A
+    );
+
+    return is_array($history)
+        && (int) ($history['id'] ?? 0) === $sync_stats_id
+        && ($history['status'] ?? '') === 'failed'
+        && ($history['end_time'] ?? '') === $timestamp
+        && ($history['error_message'] ?? '') === $error_message
+        && ($history['updated_at'] ?? '') === $timestamp;
 }
 
 /** Return a fixed browser-safe message for a synchronization error code. */

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -100,9 +100,9 @@ function nmkr_fail_nonterminal_sync_history($sync_stats_id, $error_message) {
 
 /** Re-read and verify an ownerless terminal result after recovery loses a race. */
 function nmkr_get_verified_ownerless_terminal_sync_data() {
-    $current_owner = nmkr_get_sync_owner();
-    $current_sync_data = nmkr_get_sync_data();
-    if ($current_owner || !is_array($current_sync_data)) {
+    $current_owner = nmkr_get_uncached_option_value('nmkr_sync_owner', false);
+    $current_sync_data = nmkr_get_uncached_option_value('nmkr_sync_data', false);
+    if ($current_owner !== false || !is_array($current_sync_data)) {
         return false;
     }
 

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -78,7 +78,11 @@ function nmkr_fail_nonterminal_sync_history($sync_stats_id, $error_message) {
            AND (status IS NULL OR LOWER(status) NOT IN ($terminal_placeholders))",
         $update_values
     ));
-    if ($updated !== 1) {
+    // A zero-row result may be a retry after this exact recovery transition
+    // committed but before its runtime cleanup completed. Read back the row so
+    // that exact transition is idempotent without accepting another terminal
+    // outcome. Database errors remain fail-closed.
+    if ($updated !== 0 && $updated !== 1) {
         return false;
     }
 
@@ -93,9 +97,10 @@ function nmkr_fail_nonterminal_sync_history($sync_stats_id, $error_message) {
     return is_array($history)
         && (int) ($history['id'] ?? 0) === $sync_stats_id
         && ($history['status'] ?? '') === 'failed'
-        && ($history['end_time'] ?? '') === $timestamp
         && ($history['error_message'] ?? '') === $error_message
-        && ($history['updated_at'] ?? '') === $timestamp;
+        && !empty($history['end_time'])
+        && ($history['updated_at'] ?? '') === ($history['end_time'] ?? '')
+        && ($updated === 0 || ($history['end_time'] ?? '') === $timestamp);
 }
 
 /** Re-read and verify an ownerless terminal result after recovery loses a race. */

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -98,6 +98,30 @@ function nmkr_fail_nonterminal_sync_history($sync_stats_id, $error_message) {
         && ($history['updated_at'] ?? '') === $timestamp;
 }
 
+/** Re-read and verify an ownerless terminal result after recovery loses a race. */
+function nmkr_get_verified_ownerless_terminal_sync_data() {
+    $current_owner = nmkr_get_sync_owner();
+    $current_sync_data = nmkr_get_sync_data();
+    if ($current_owner || !is_array($current_sync_data)) {
+        return false;
+    }
+
+    $status = strtolower((string) ($current_sync_data['status'] ?? ''));
+    if (in_array($status, array('completed', 'success'), true)) {
+        $outcome = 'completed';
+    } elseif (in_array($status, array('failed', 'error'), true)) {
+        $outcome = 'failed';
+    } elseif ($status === 'stopped') {
+        $outcome = 'stopped';
+    } else {
+        return false;
+    }
+
+    return nmkr_verify_sync_terminal_result($current_sync_data, $outcome)
+        ? $current_sync_data
+        : false;
+}
+
 /** Return a fixed browser-safe message for a synchronization error code. */
 function nmkr_public_sync_error_message($code, $fallback) {
     $messages = array(
@@ -531,16 +555,26 @@ function nmkr_sync_progress_handler() {
             
             // Only mark as error if there are no jobs running
             if (!$has_running_jobs) {
-                update_option('nmkr_sync_error', 'Sync process stalled - no progress after multiple attempts');
-                $error = 'Sync process stalled - no progress after multiple attempts';
-                
                 // Update sync stats with error status
-                if (isset($sync_data['sync_stats_id'])) {
-                    nmkr_fail_nonterminal_sync_history(
+                $history_failed = isset($sync_data['sync_stats_id'])
+                    && nmkr_fail_nonterminal_sync_history(
                         $sync_data['sync_stats_id'],
                         'Sync process stalled - no progress after multiple attempts'
                     );
+
+                if (!$history_failed) {
+                    $terminal_sync_data = nmkr_get_verified_ownerless_terminal_sync_data();
+                    if ($terminal_sync_data !== false) {
+                        $sync_data = $terminal_sync_data;
+                        return true;
+                    }
+                    nmkr_log_data_sync('Stalled synchronization recovery could not verify history transition', 'error');
+                    $error = __('Synchronization recovery could not be verified.', 'nmkr-connect');
+                    return false;
                 }
+
+                update_option('nmkr_sync_error', 'Sync process stalled - no progress after multiple attempts');
+                $error = 'Sync process stalled - no progress after multiple attempts';
                 
                 // Clear the sync data to prevent further issues
                 nmkr_clear_sync_data();
@@ -572,16 +606,26 @@ function nmkr_sync_progress_handler() {
                     )
                 );
                 
-                update_option('nmkr_sync_error', 'Sync process stalled - no updates for an extended period');
-                $error = 'Sync process stalled - no updates for an extended period';
-                
                 // Update sync stats with error status
-                if (isset($sync_data['sync_stats_id'])) {
-                    nmkr_fail_nonterminal_sync_history(
+                $history_failed = isset($sync_data['sync_stats_id'])
+                    && nmkr_fail_nonterminal_sync_history(
                         $sync_data['sync_stats_id'],
                         'Sync process stalled - no updates for an extended period'
                     );
+
+                if (!$history_failed) {
+                    $terminal_sync_data = nmkr_get_verified_ownerless_terminal_sync_data();
+                    if ($terminal_sync_data !== false) {
+                        $sync_data = $terminal_sync_data;
+                        return true;
+                    }
+                    nmkr_log_data_sync('Inactive synchronization recovery could not verify history transition', 'error');
+                    $error = __('Synchronization recovery could not be verified.', 'nmkr-connect');
+                    return false;
                 }
+
+                update_option('nmkr_sync_error', 'Sync process stalled - no updates for an extended period');
+                $error = 'Sync process stalled - no updates for an extended period';
                 
                 // Clear the sync data to prevent further issues
                 nmkr_clear_sync_data();

--- a/includes/synchronization/nmkr-sync-ajax-handlers.php
+++ b/includes/synchronization/nmkr-sync-ajax-handlers.php
@@ -54,6 +54,32 @@ function nmkr_public_failed_terminal_progress_response($response_data) {
     return $response_data;
 }
 
+/** Mark an exact nonterminal synchronization history row failed during legacy recovery. */
+function nmkr_fail_nonterminal_sync_history($sync_stats_id, $error_message) {
+    global $wpdb;
+
+    $sync_stats_id = (int) $sync_stats_id;
+    if ($sync_stats_id <= 0) {
+        return false;
+    }
+
+    $table_name = $wpdb->prefix . 'nmkr_sync_stats';
+    $history = $wpdb->get_row(
+        $wpdb->prepare("SELECT id, status, end_time FROM $table_name WHERE id = %d", $sync_stats_id),
+        ARRAY_A
+    );
+    if (!$history || (int) ($history['id'] ?? 0) !== $sync_stats_id
+        || nmkr_is_sync_terminal_status($history['status'] ?? '')) {
+        return false;
+    }
+
+    return nmkr_update_sync_stats($sync_stats_id, array(
+        'status' => 'failed',
+        'end_time' => nmkr_get_timestamp(),
+        'error_message' => $error_message,
+    ));
+}
+
 /** Return a fixed browser-safe message for a synchronization error code. */
 function nmkr_public_sync_error_message($code, $fallback) {
     $messages = array(
@@ -233,12 +259,14 @@ function nmkr_sync_progress_handler() {
         wp_send_json_error( array( 'message' => __( 'Forbidden', 'nmkr-connect' ) ), 403 );
     }
 
+    $can_manage_sync = current_user_can( 'nmkr_manage_sync' );
+
     // Polling is an independently executable recovery trigger for an exact
     // stopped handoff whose dedicated resume option/event could not be
     // established by the consumed worker. Each request performs one bounded
     // attempt and leaves the durable pre-finalizing record intact on failure.
     $recovery_owner = nmkr_get_sync_owner();
-    if (is_array($recovery_owner) && ($recovery_owner['mode'] ?? '') === 'direct'
+    if ($can_manage_sync && is_array($recovery_owner) && ($recovery_owner['mode'] ?? '') === 'direct'
         && ($recovery_owner['state'] ?? '') === 'stop_requested') {
         nmkr_resume_stopped_sync_recovery(
             (string) ($recovery_owner['run_id'] ?? ''),
@@ -255,7 +283,10 @@ function nmkr_sync_progress_handler() {
     
     try {
         // ** ENHANCED ERROR HANDLING: Parameter Validation **
-        $is_recovery = isset($_POST['recovery']) && $_POST['recovery'];
+        $is_recovery = $can_manage_sync && isset($_POST['recovery'])
+            && is_scalar($_POST['recovery']) && !empty($_POST['recovery']);
+        $is_stalled_check = $can_manage_sync && isset($_POST['check_stalled'])
+            && is_scalar($_POST['check_stalled']) && !empty($_POST['check_stalled']);
         
         try {
             $progress_raw = get_transient('nmkr_sync_progress');
@@ -393,7 +424,7 @@ function nmkr_sync_progress_handler() {
     $min_progress_timeout = max(30, min(120, $batch_size * $batch_delay * 3)); // Between 30s-2 minutes
     
             // Verify if process is actually running or has stalled
-        if (($is_recovery || isset($_POST['check_stalled'])) &&
+        if (($is_recovery || $is_stalled_check) &&
             $progress > 0 && $progress < 100 && empty($error)) {
         nmkr_with_ownerless_legacy_recovery(function () use (&$error, &$sync_data, $progress, $has_running_jobs, $batch_size, $batch_delay, $no_jobs_timeout, $no_update_timeout) {
         
@@ -487,11 +518,10 @@ function nmkr_sync_progress_handler() {
                 
                 // Update sync stats with error status
                 if (isset($sync_data['sync_stats_id'])) {
-                    nmkr_update_sync_stats($sync_data['sync_stats_id'], [
-                        'status' => 'failed',
-                        'end_time' => nmkr_get_timestamp(),
-                        'error_message' => 'Sync process stalled - no progress after multiple attempts'
-                    ]);
+                    nmkr_fail_nonterminal_sync_history(
+                        $sync_data['sync_stats_id'],
+                        'Sync process stalled - no progress after multiple attempts'
+                    );
                 }
                 
                 // Clear the sync data to prevent further issues
@@ -529,11 +559,10 @@ function nmkr_sync_progress_handler() {
                 
                 // Update sync stats with error status
                 if (isset($sync_data['sync_stats_id'])) {
-                    nmkr_update_sync_stats($sync_data['sync_stats_id'], [
-                        'status' => 'failed',
-                        'end_time' => nmkr_get_timestamp(),
-                        'error_message' => 'Sync process stalled - no updates for an extended period'
-                    ]);
+                    nmkr_fail_nonterminal_sync_history(
+                        $sync_data['sync_stats_id'],
+                        'Sync process stalled - no updates for an extended period'
+                    );
                 }
                 
                 // Clear the sync data to prevent further issues

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -11,12 +11,14 @@ $GLOBALS['nmkr_hooks'] = array();
 $GLOBALS['nmkr_transients'] = array();
 $GLOBALS['nmkr_owner'] = false;
 $GLOBALS['nmkr_sync_data'] = false;
+$GLOBALS['nmkr_authoritative_options'] = array();
 $GLOBALS['nmkr_history'] = array();
 $GLOBALS['nmkr_concurrent_terminalization'] = false;
 $GLOBALS['nmkr_database_failure'] = false;
 
 class NmkrSyntheticWpdb {
     public $prefix = 'wp_';
+    public $options = 'wp_options';
     public function prepare($query, ...$values) {
         if (count($values) === 1 && is_array($values[0])) $values = $values[0];
         foreach ($values as $value) {
@@ -31,6 +33,14 @@ class NmkrSyntheticWpdb {
         $id = (int) ($matches[1] ?? 0);
         return $GLOBALS['nmkr_history'][$id] ?? null;
     }
+    public function get_var($query) {
+        preg_match("/option_name = '([^']+)'/", $query, $matches);
+        $name = str_replace("''", "'", $matches[1] ?? '');
+        $GLOBALS['nmkr_calls'][] = 'authoritative-option:' . $name;
+        return array_key_exists($name, $GLOBALS['nmkr_authoritative_options'])
+            ? serialize($GLOBALS['nmkr_authoritative_options'][$name])
+            : null;
+    }
     public function query($query) {
         $GLOBALS['nmkr_calls'][]='history-write';
         if (strpos($query, 'LOWER(status) NOT IN') === false) throw new Exception('history_update_not_atomic');
@@ -39,7 +49,7 @@ class NmkrSyntheticWpdb {
         if (($GLOBALS['nmkr_concurrent_terminalization']['id'] ?? 0) === $id) {
             $GLOBALS['nmkr_history'][$id] = $GLOBALS['nmkr_concurrent_terminalization']['row'];
             if (isset($GLOBALS['nmkr_concurrent_terminalization']['sync_data'])) {
-                $GLOBALS['nmkr_sync_data'] = $GLOBALS['nmkr_concurrent_terminalization']['sync_data'];
+                $GLOBALS['nmkr_authoritative_options']['nmkr_sync_data'] = $GLOBALS['nmkr_concurrent_terminalization']['sync_data'];
             }
             $GLOBALS['nmkr_concurrent_terminalization'] = false;
         }
@@ -68,6 +78,7 @@ function nocache_headers() { $GLOBALS['nmkr_calls'][]='headers'; }
 function status_header($status) { $GLOBALS['nmkr_calls'][]='status'; }
 function sanitize_text_field($v) { return (string)$v; }
 function wp_unslash($v) { return $v; }
+function maybe_unserialize($value) { return @unserialize($value); }
 function get_option($k, $d=false) { $GLOBALS['nmkr_calls'][]='option'; return array_key_exists($k, $GLOBALS['nmkr_options'] ?? array()) ? $GLOBALS['nmkr_options'][$k] : $d; }
 function update_option($k,$v,$a=null) { $GLOBALS['nmkr_calls'][]='option-write'; $GLOBALS['nmkr_calls'][]='option-write:'.$k; return true; }
 function delete_option($k) { $GLOBALS['nmkr_calls'][]='option-write'; $GLOBALS['nmkr_calls'][]='option-write:'.$k; return true; }
@@ -78,6 +89,11 @@ function wp_clear_scheduled_hook($h,$a=array()) { $GLOBALS['nmkr_calls'][]='cron
 function wp_schedule_single_event($t,$h,$a=array()) { $GLOBALS['nmkr_calls'][]='cron'; return true; }
 function nmkr_admit_sync_owner($id) { $GLOBALS['nmkr_calls'][]='admission'; return array(); }
 function nmkr_get_sync_owner() { $GLOBALS['nmkr_calls'][]='owner'; return $GLOBALS['nmkr_owner']; }
+function nmkr_get_uncached_option_value($name, $default=false) {
+    global $wpdb;
+    $serialized=$wpdb->get_var($wpdb->prepare("SELECT option_value FROM {$wpdb->options} WHERE option_name = %s",$name));
+    return $serialized===null ? $default : maybe_unserialize($serialized);
+}
 function nmkr_is_api_connected() { $GLOBALS['nmkr_calls'][]='api'; return false; }
 function nmkr_log_ui_status($message, $type) { $GLOBALS['nmkr_calls'][]='ui-log'; }
 function wp_json_encode($v) { return json_encode($v); }
@@ -130,6 +146,8 @@ function nmkr_test($name, $handler, $nonce, $caps, $expected, $forbidden, $expec
 function nmkr_progress_test($name, $nonce, $caps, $post, $owner, $expected, $forbidden, $sync_data=false, $execute_recovery=false, $expect_success=true) {
     $GLOBALS['nmkr_calls']=array(); $GLOBALS['nmkr_nonce_ok']=$nonce; $GLOBALS['nmkr_caps']=$caps;
     $GLOBALS['nmkr_owner']=$owner; $GLOBALS['nmkr_sync_data']=$sync_data; $GLOBALS['nmkr_execute_recovery']=$execute_recovery;
+    $GLOBALS['nmkr_authoritative_options']=array('nmkr_sync_data'=>$sync_data);
+    if ($owner !== false) $GLOBALS['nmkr_authoritative_options']['nmkr_sync_owner']=$owner;
     $GLOBALS['nmkr_transients']=array('nmkr_sync_progress'=>50);
     $_POST=array_merge(array('nonce'=>'synthetic'),$post); $_REQUEST=$_POST; $_SERVER['REQUEST_METHOD']='POST';
     try { nmkr_sync_progress_handler(); throw new Exception($name.'_no_termination'); }
@@ -184,27 +202,27 @@ try {
     $GLOBALS['nmkr_history'][52]=array('id'=>52,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
     $concurrent_data=array('sync_stats_id'=>52,'status'=>'stopped','end_time'=>'2026-01-02 03:04:04','run_id'=>'synthetic-run-0052');
     $GLOBALS['nmkr_concurrent_terminalization']=array('id'=>52,'row'=>array('id'=>52,'status'=>'stopped','end_time'=>'2026-01-02 03:04:04','error_message'=>'cooperative stop'),'sync_data'=>$concurrent_data);
-    nmkr_progress_test('stuck_concurrent_terminal',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','owner','sync-data','terminal-verify'),array(),$stale_sync_data,true);
+    nmkr_progress_test('stuck_concurrent_terminal',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','authoritative-option:nmkr_sync_owner','authoritative-option:nmkr_sync_data','terminal-verify'),array(),$stale_sync_data,true);
     nmkr_assert_no_stall_cleanup('stuck_concurrent_terminal');
-    if ($GLOBALS['nmkr_sync_data'] !== $concurrent_data) throw new Exception('stuck_concurrent_terminal_data_changed');
+    if ($GLOBALS['nmkr_sync_data'] !== $stale_sync_data || $GLOBALS['nmkr_authoritative_options']['nmkr_sync_data'] !== $concurrent_data) throw new Exception('stuck_concurrent_terminal_cache_boundary_changed');
 
     $GLOBALS['nmkr_options']['nmkr_last_progress_value']=50;
     $GLOBALS['nmkr_options']['nmkr_last_progress_update_time']=time();
     $stale_sync_data=array('sync_stats_id'=>53,'status'=>'processing_tokens','last_update_time'=>1);
     $GLOBALS['nmkr_history'][53]=array('id'=>53,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'original history');
     $GLOBALS['nmkr_database_failure']=true;
-    nmkr_progress_test('inactive_database_failure',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','owner','sync-data','data-log'),array('cleanup','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),$stale_sync_data,true,false);
+    nmkr_progress_test('inactive_database_failure',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','authoritative-option:nmkr_sync_owner','authoritative-option:nmkr_sync_data','data-log'),array('cleanup','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),$stale_sync_data,true,false);
     $GLOBALS['nmkr_database_failure']=false;
     nmkr_assert_no_stall_cleanup('inactive_database_failure');
-    if ($GLOBALS['nmkr_history'][53]['status'] !== 'processing_tokens' || $GLOBALS['nmkr_sync_data'] !== $stale_sync_data) throw new Exception('inactive_database_failure_state_changed');
+    if ($GLOBALS['nmkr_history'][53]['status'] !== 'processing_tokens' || $GLOBALS['nmkr_sync_data'] !== $stale_sync_data || $GLOBALS['nmkr_authoritative_options']['nmkr_sync_data'] !== $stale_sync_data) throw new Exception('inactive_database_failure_state_changed');
 
     $stale_sync_data['sync_stats_id']=54;
     $GLOBALS['nmkr_history'][54]=array('id'=>54,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
     $concurrent_data=array('sync_stats_id'=>54,'status'=>'failed','end_time'=>'2026-01-02 03:04:04','run_id'=>'synthetic-run-0054');
     $GLOBALS['nmkr_concurrent_terminalization']=array('id'=>54,'row'=>array('id'=>54,'status'=>'failed','end_time'=>'2026-01-02 03:04:04','error_message'=>'worker failure'),'sync_data'=>$concurrent_data);
-    nmkr_progress_test('inactive_concurrent_terminal',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','owner','sync-data','terminal-verify'),array(),$stale_sync_data,true);
+    nmkr_progress_test('inactive_concurrent_terminal',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','authoritative-option:nmkr_sync_owner','authoritative-option:nmkr_sync_data','terminal-verify'),array(),$stale_sync_data,true);
     nmkr_assert_no_stall_cleanup('inactive_concurrent_terminal');
-    if ($GLOBALS['nmkr_sync_data'] !== $concurrent_data) throw new Exception('inactive_concurrent_terminal_data_changed');
+    if ($GLOBALS['nmkr_sync_data'] !== $stale_sync_data || $GLOBALS['nmkr_authoritative_options']['nmkr_sync_data'] !== $concurrent_data) throw new Exception('inactive_concurrent_terminal_cache_boundary_changed');
 
     $stale_sync_data=array('sync_stats_id'=>55,'status'=>'processing_tokens','last_update_time'=>1);
     $GLOBALS['nmkr_history'][55]=array('id'=>55,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -13,6 +13,7 @@ $GLOBALS['nmkr_owner'] = false;
 $GLOBALS['nmkr_sync_data'] = false;
 $GLOBALS['nmkr_history'] = array();
 $GLOBALS['nmkr_concurrent_terminalization'] = false;
+$GLOBALS['nmkr_database_failure'] = false;
 
 class NmkrSyntheticWpdb {
     public $prefix = 'wp_';
@@ -37,8 +38,12 @@ class NmkrSyntheticWpdb {
         $id = (int)($id_match[1] ?? 0);
         if (($GLOBALS['nmkr_concurrent_terminalization']['id'] ?? 0) === $id) {
             $GLOBALS['nmkr_history'][$id] = $GLOBALS['nmkr_concurrent_terminalization']['row'];
+            if (isset($GLOBALS['nmkr_concurrent_terminalization']['sync_data'])) {
+                $GLOBALS['nmkr_sync_data'] = $GLOBALS['nmkr_concurrent_terminalization']['sync_data'];
+            }
             $GLOBALS['nmkr_concurrent_terminalization'] = false;
         }
+        if ($GLOBALS['nmkr_database_failure']) return false;
         if (!isset($GLOBALS['nmkr_history'][$id]) || nmkr_is_sync_terminal_status($GLOBALS['nmkr_history'][$id]['status'] ?? '')) return 0;
         preg_match("/SET status = '([^']*)', end_time = '([^']*)', error_message = '([^']*)', updated_at = '([^']*)'/", $query, $values);
         if (count($values) !== 5) return false;
@@ -64,11 +69,11 @@ function status_header($status) { $GLOBALS['nmkr_calls'][]='status'; }
 function sanitize_text_field($v) { return (string)$v; }
 function wp_unslash($v) { return $v; }
 function get_option($k, $d=false) { $GLOBALS['nmkr_calls'][]='option'; return array_key_exists($k, $GLOBALS['nmkr_options'] ?? array()) ? $GLOBALS['nmkr_options'][$k] : $d; }
-function update_option($k,$v,$a=null) { $GLOBALS['nmkr_calls'][]='option-write'; return true; }
-function delete_option($k) { $GLOBALS['nmkr_calls'][]='option-write'; return true; }
+function update_option($k,$v,$a=null) { $GLOBALS['nmkr_calls'][]='option-write'; $GLOBALS['nmkr_calls'][]='option-write:'.$k; return true; }
+function delete_option($k) { $GLOBALS['nmkr_calls'][]='option-write'; $GLOBALS['nmkr_calls'][]='option-write:'.$k; return true; }
 function get_transient($k) { $GLOBALS['nmkr_calls'][]='transient'; return array_key_exists($k, $GLOBALS['nmkr_transients']) ? $GLOBALS['nmkr_transients'][$k] : false; }
-function set_transient($k,$v,$t=0) { $GLOBALS['nmkr_calls'][]='transient-write'; return true; }
-function delete_transient($k) { $GLOBALS['nmkr_calls'][]='transient-write'; return true; }
+function set_transient($k,$v,$t=0) { $GLOBALS['nmkr_calls'][]='transient-write'; $GLOBALS['nmkr_calls'][]='transient-write:'.$k; return true; }
+function delete_transient($k) { $GLOBALS['nmkr_calls'][]='transient-write'; $GLOBALS['nmkr_calls'][]='transient-write:'.$k; return true; }
 function wp_clear_scheduled_hook($h,$a=array()) { $GLOBALS['nmkr_calls'][]='cron'; }
 function wp_schedule_single_event($t,$h,$a=array()) { $GLOBALS['nmkr_calls'][]='cron'; return true; }
 function nmkr_admit_sync_owner($id) { $GLOBALS['nmkr_calls'][]='admission'; return array(); }
@@ -92,12 +97,18 @@ function nmkr_is_sync_canonically_finished() { return false; }
 function nmkr_is_valid_sync_run_id($id) { return preg_match('/^[a-z0-9-]{8,}$/', $id) === 1; }
 function nmkr_sync_terminal_statuses() { return array('completed','success','failed','error','stopped','cancelled','aborted'); }
 function nmkr_is_sync_terminal_status($status) { return in_array(strtolower((string)$status), nmkr_sync_terminal_statuses(), true); }
-function nmkr_verify_sync_terminal_result() { return false; }
+function nmkr_verify_sync_terminal_result($sync_data, $outcome) {
+    $GLOBALS['nmkr_calls'][]='terminal-verify';
+    $id=(int)($sync_data['sync_stats_id'] ?? 0); $history=$GLOBALS['nmkr_history'][$id] ?? false;
+    $allowed=$outcome==='completed' ? array('completed','success') : ($outcome==='failed' ? array('failed','error') : array('stopped'));
+    return is_array($history) && in_array(strtolower((string)($history['status'] ?? '')),$allowed,true)
+        && (string)($history['end_time'] ?? '') === (string)($sync_data['end_time'] ?? '');
+}
 function nmkr_resume_stopped_sync_recovery($run_id, $sync_stats_id) { $GLOBALS['nmkr_calls'][]='stopped-recovery:'.$run_id.':'.$sync_stats_id; return true; }
 function nmkr_with_ownerless_legacy_recovery($callback) { $GLOBALS['nmkr_calls'][]='ownerless-recovery'; return !empty($GLOBALS['nmkr_execute_recovery']) ? $callback() : true; }
 function nmkr_get_timestamp() { return '2026-01-02 03:04:05'; }
-function nmkr_clear_sync_data() { $GLOBALS['nmkr_calls'][]='cleanup'; }
-function nmkr_clear_sync_jobs_ownerless($reason, $clear_scheduled, $clear_actions) { $GLOBALS['nmkr_calls'][]='cleanup'; }
+function nmkr_clear_sync_data() { $GLOBALS['nmkr_calls'][]='cleanup'; $GLOBALS['nmkr_calls'][]='cleanup-data'; }
+function nmkr_clear_sync_jobs_ownerless($reason, $clear_scheduled, $clear_actions) { $GLOBALS['nmkr_calls'][]='cleanup'; $GLOBALS['nmkr_calls'][]='cleanup-jobs'; }
 
 require __DIR__.'/../includes/synchronization/nmkr-sync-ajax-handlers.php';
 require __DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ajax.php';
@@ -129,6 +140,12 @@ function nmkr_progress_test($name, $nonce, $caps, $post, $owner, $expected, $for
     return array($kind,$status,$data);
 }
 
+function nmkr_assert_no_stall_cleanup($name) {
+    foreach (array('cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress') as $call) {
+        if (in_array($call,$GLOBALS['nmkr_calls'],true)) throw new Exception($name.'_destructive_'.$call);
+    }
+}
+
 try {
     $GLOBALS['nmkr_history'][48]=array('id'=>48,'status'=>'completed','end_time'=>'2026-01-01 00:00:00','error_message'=>'completed result','updated_at'=>'2026-01-01 00:00:01');
     $terminal_before=$GLOBALS['nmkr_history'][48];
@@ -157,16 +174,42 @@ try {
     if (count(array_filter($GLOBALS['nmkr_calls'],function($call){return $call==='stopped-recovery:synthetic-run-0001:41';})) !== 1) throw new Exception('progress_manager_stopped_duplicate');
     nmkr_progress_test('progress_manager_ownerless',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery'),array('stopped-recovery','history-write'));
 
-    $GLOBALS['nmkr_options']['nmkr_last_progress_update_time']=1;
-    $GLOBALS['nmkr_options']['nmkr_last_progress_value']=50;
+    $GLOBALS['nmkr_options']=array('nmkr_last_progress_update_time'=>1,'nmkr_last_progress_value'=>50);
     $stale_sync_data=array('sync_stats_id'=>51,'status'=>'processing_tokens','last_update_time'=>1);
-    $GLOBALS['nmkr_history'][51]=array('id'=>51,'status'=>'completed','end_time'=>'2026-01-01 00:00:00','error_message'=>'terminal fields');
-    nmkr_progress_test('terminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup'),array(),$stale_sync_data,true,false);
-    if ($GLOBALS['nmkr_history'][51]['status'] !== 'completed' || $GLOBALS['nmkr_history'][51]['end_time'] !== '2026-01-01 00:00:00' || $GLOBALS['nmkr_history'][51]['error_message'] !== 'terminal fields') throw new Exception('terminal_history_overwritten');
+    $GLOBALS['nmkr_history'][51]=array('id'=>51,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
+    nmkr_progress_test('stuck_successful_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),array(),$stale_sync_data,true,false);
+    if ($GLOBALS['nmkr_history'][51]['status'] !== 'failed') throw new Exception('stuck_successful_history_not_failed');
+
     $stale_sync_data['sync_stats_id']=52;
     $GLOBALS['nmkr_history'][52]=array('id'=>52,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
-    nmkr_progress_test('nonterminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','cleanup'),array(),$stale_sync_data,true,false);
-    if ($GLOBALS['nmkr_history'][52]['status'] !== 'failed' || $GLOBALS['nmkr_history'][52]['end_time'] !== '2026-01-02 03:04:05' || $GLOBALS['nmkr_history'][52]['updated_at'] !== '2026-01-02 03:04:05' || $GLOBALS['nmkr_history'][52]['error_message'] !== 'Sync process stalled - no progress after multiple attempts') throw new Exception('nonterminal_history_not_eligible');
+    $concurrent_data=array('sync_stats_id'=>52,'status'=>'stopped','end_time'=>'2026-01-02 03:04:04','run_id'=>'synthetic-run-0052');
+    $GLOBALS['nmkr_concurrent_terminalization']=array('id'=>52,'row'=>array('id'=>52,'status'=>'stopped','end_time'=>'2026-01-02 03:04:04','error_message'=>'cooperative stop'),'sync_data'=>$concurrent_data);
+    nmkr_progress_test('stuck_concurrent_terminal',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','owner','sync-data','terminal-verify'),array(),$stale_sync_data,true);
+    nmkr_assert_no_stall_cleanup('stuck_concurrent_terminal');
+    if ($GLOBALS['nmkr_sync_data'] !== $concurrent_data) throw new Exception('stuck_concurrent_terminal_data_changed');
+
+    $GLOBALS['nmkr_options']['nmkr_last_progress_value']=50;
+    $GLOBALS['nmkr_options']['nmkr_last_progress_update_time']=time();
+    $stale_sync_data=array('sync_stats_id'=>53,'status'=>'processing_tokens','last_update_time'=>1);
+    $GLOBALS['nmkr_history'][53]=array('id'=>53,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'original history');
+    $GLOBALS['nmkr_database_failure']=true;
+    nmkr_progress_test('inactive_database_failure',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','owner','sync-data','data-log'),array('cleanup','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),$stale_sync_data,true,false);
+    $GLOBALS['nmkr_database_failure']=false;
+    nmkr_assert_no_stall_cleanup('inactive_database_failure');
+    if ($GLOBALS['nmkr_history'][53]['status'] !== 'processing_tokens' || $GLOBALS['nmkr_sync_data'] !== $stale_sync_data) throw new Exception('inactive_database_failure_state_changed');
+
+    $stale_sync_data['sync_stats_id']=54;
+    $GLOBALS['nmkr_history'][54]=array('id'=>54,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
+    $concurrent_data=array('sync_stats_id'=>54,'status'=>'failed','end_time'=>'2026-01-02 03:04:04','run_id'=>'synthetic-run-0054');
+    $GLOBALS['nmkr_concurrent_terminalization']=array('id'=>54,'row'=>array('id'=>54,'status'=>'failed','end_time'=>'2026-01-02 03:04:04','error_message'=>'worker failure'),'sync_data'=>$concurrent_data);
+    nmkr_progress_test('inactive_concurrent_terminal',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','owner','sync-data','terminal-verify'),array(),$stale_sync_data,true);
+    nmkr_assert_no_stall_cleanup('inactive_concurrent_terminal');
+    if ($GLOBALS['nmkr_sync_data'] !== $concurrent_data) throw new Exception('inactive_concurrent_terminal_data_changed');
+
+    $stale_sync_data=array('sync_stats_id'=>55,'status'=>'processing_tokens','last_update_time'=>1);
+    $GLOBALS['nmkr_history'][55]=array('id'=>55,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
+    nmkr_progress_test('inactive_successful_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),array(),$stale_sync_data,true,false);
+    if ($GLOBALS['nmkr_history'][55]['status'] !== 'failed' || $GLOBALS['nmkr_history'][55]['error_message'] !== 'Sync process stalled - no updates for an extended period') throw new Exception('inactive_successful_history_not_failed');
 
     nmkr_test('start_nonce','nmkr_start_sync_handler',false,array(),array('nonce:nmkr_sync_nonce:nonce'),array('cap:nmkr_manage_sync','admission','option','transient','cron'));
     nmkr_test('start_cap','nmkr_start_sync_handler',true,array(),array('cap:nmkr_manage_sync'),array('admission','option','option-write','transient','transient-write','cron'));

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -173,6 +173,9 @@ try {
     if (!nmkr_fail_nonterminal_sync_history(49,'legacy recovery')) throw new Exception('atomic_nonterminal_update_failed');
     if ($GLOBALS['nmkr_history'][49] !== array('id'=>49,'status'=>'failed','end_time'=>'2026-01-02 03:04:05','error_message'=>'legacy recovery','updated_at'=>'2026-01-02 03:04:05')) throw new Exception('atomic_nonterminal_fields_mismatch');
 
+    if (!nmkr_fail_nonterminal_sync_history(49,'legacy recovery')) throw new Exception('atomic_committed_retry_not_recognized');
+    if ($GLOBALS['nmkr_history'][49] !== array('id'=>49,'status'=>'failed','end_time'=>'2026-01-02 03:04:05','error_message'=>'legacy recovery','updated_at'=>'2026-01-02 03:04:05')) throw new Exception('atomic_committed_retry_changed_history');
+
     $GLOBALS['nmkr_history'][50]=array('id'=>50,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'','updated_at'=>'2026-01-01 00:00:00');
     $concurrent_result=array('id'=>50,'status'=>'stopped','end_time'=>'2026-01-02 03:04:04','error_message'=>'cooperative stop','updated_at'=>'2026-01-02 03:04:04');
     $GLOBALS['nmkr_concurrent_terminalization']=array('id'=>50,'row'=>$concurrent_result);
@@ -197,6 +200,10 @@ try {
     $GLOBALS['nmkr_history'][51]=array('id'=>51,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
     nmkr_progress_test('stuck_successful_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),array(),$stale_sync_data,true,false);
     if ($GLOBALS['nmkr_history'][51]['status'] !== 'failed') throw new Exception('stuck_successful_history_not_failed');
+
+    $stale_sync_data['sync_stats_id']=56;
+    $GLOBALS['nmkr_history'][56]=array('id'=>56,'status'=>'failed','end_time'=>'2026-01-02 03:04:05','error_message'=>'Sync process stalled - no progress after multiple attempts','updated_at'=>'2026-01-02 03:04:05');
+    nmkr_progress_test('stuck_committed_retry',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),array('authoritative-option:nmkr_sync_data'),$stale_sync_data,true,false);
 
     $stale_sync_data['sync_stats_id']=52;
     $GLOBALS['nmkr_history'][52]=array('id'=>52,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
@@ -228,6 +235,10 @@ try {
     $GLOBALS['nmkr_history'][55]=array('id'=>55,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
     nmkr_progress_test('inactive_successful_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),array(),$stale_sync_data,true,false);
     if ($GLOBALS['nmkr_history'][55]['status'] !== 'failed' || $GLOBALS['nmkr_history'][55]['error_message'] !== 'Sync process stalled - no updates for an extended period') throw new Exception('inactive_successful_history_not_failed');
+
+    $stale_sync_data['sync_stats_id']=57;
+    $GLOBALS['nmkr_history'][57]=array('id'=>57,'status'=>'failed','end_time'=>'2026-01-02 03:04:05','error_message'=>'Sync process stalled - no updates for an extended period','updated_at'=>'2026-01-02 03:04:05');
+    nmkr_progress_test('inactive_committed_retry',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup-data','cleanup-jobs','option-write:nmkr_sync_error','option-write:nmkr_sync_in_progress','transient-write:nmkr_sync_in_progress'),array('authoritative-option:nmkr_sync_data'),$stale_sync_data,true,false);
 
     nmkr_test('start_nonce','nmkr_start_sync_handler',false,array(),array('nonce:nmkr_sync_nonce:nonce'),array('cap:nmkr_manage_sync','admission','option','transient','cron'));
     nmkr_test('start_cap','nmkr_start_sync_handler',true,array(),array('cap:nmkr_manage_sync'),array('admission','option','option-write','transient','transient-write','cron'));

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -3,12 +3,28 @@
 define('ABSPATH', __DIR__ . '/synthetic/');
 define('DAY_IN_SECONDS', 86400);
 define('NMKR_SYNC_TRANSIENT_TTL', 3600);
+define('ARRAY_A', 'ARRAY_A');
 $GLOBALS['nmkr_calls'] = array();
 $GLOBALS['nmkr_nonce_ok'] = false;
 $GLOBALS['nmkr_caps'] = array();
 $GLOBALS['nmkr_hooks'] = array();
+$GLOBALS['nmkr_transients'] = array();
+$GLOBALS['nmkr_owner'] = false;
+$GLOBALS['nmkr_sync_data'] = false;
+$GLOBALS['nmkr_history'] = array();
 
-class NmkrAjaxTermination extends Exception { public $kind; public $status; public $data; public function __construct($kind, $status = 0, $data = null) { parent::__construct($kind); $this->kind=$kind; $this->status=$status; $this->data=$data; } }
+class NmkrSyntheticWpdb {
+    public $prefix = 'wp_';
+    public function prepare($query, $value) { return str_replace('%d', (string) (int) $value, $query); }
+    public function get_row($query, $format=null) {
+        preg_match('/WHERE id = ([0-9]+)/', $query, $matches);
+        $id = (int) ($matches[1] ?? 0);
+        return $GLOBALS['nmkr_history'][$id] ?? null;
+    }
+}
+$GLOBALS['wpdb'] = new NmkrSyntheticWpdb();
+
+class NmkrAjaxTermination extends Error { public $kind; public $status; public $data; public function __construct($kind, $status = 0, $data = null) { parent::__construct($kind); $this->kind=$kind; $this->status=$status; $this->data=$data; } }
 function add_action($hook, $callback) { $GLOBALS['nmkr_hooks'][$hook] = $callback; }
 function check_ajax_referer($action, $field) { $GLOBALS['nmkr_calls'][]='nonce:'.$action.':'.$field; if (!$GLOBALS['nmkr_nonce_ok']) throw new NmkrAjaxTermination('nonce'); }
 function wp_verify_nonce($nonce, $action) { $GLOBALS['nmkr_calls'][]='nonce:'.$action.':nonce'; return $GLOBALS['nmkr_nonce_ok']; }
@@ -24,13 +40,13 @@ function wp_unslash($v) { return $v; }
 function get_option($k, $d=false) { $GLOBALS['nmkr_calls'][]='option'; return array_key_exists($k, $GLOBALS['nmkr_options'] ?? array()) ? $GLOBALS['nmkr_options'][$k] : $d; }
 function update_option($k,$v,$a=null) { $GLOBALS['nmkr_calls'][]='option-write'; return true; }
 function delete_option($k) { $GLOBALS['nmkr_calls'][]='option-write'; return true; }
-function get_transient($k) { $GLOBALS['nmkr_calls'][]='transient'; return false; }
+function get_transient($k) { $GLOBALS['nmkr_calls'][]='transient'; return array_key_exists($k, $GLOBALS['nmkr_transients']) ? $GLOBALS['nmkr_transients'][$k] : false; }
 function set_transient($k,$v,$t=0) { $GLOBALS['nmkr_calls'][]='transient-write'; return true; }
 function delete_transient($k) { $GLOBALS['nmkr_calls'][]='transient-write'; return true; }
 function wp_clear_scheduled_hook($h,$a=array()) { $GLOBALS['nmkr_calls'][]='cron'; }
 function wp_schedule_single_event($t,$h,$a=array()) { $GLOBALS['nmkr_calls'][]='cron'; return true; }
 function nmkr_admit_sync_owner($id) { $GLOBALS['nmkr_calls'][]='admission'; return array(); }
-function nmkr_get_sync_owner() { $GLOBALS['nmkr_calls'][]='owner'; return false; }
+function nmkr_get_sync_owner() { $GLOBALS['nmkr_calls'][]='owner'; return $GLOBALS['nmkr_owner']; }
 function nmkr_is_api_connected() { $GLOBALS['nmkr_calls'][]='api'; return false; }
 function nmkr_log_ui_status($message, $type) { $GLOBALS['nmkr_calls'][]='ui-log'; }
 function wp_json_encode($v) { return json_encode($v); }
@@ -40,6 +56,22 @@ function wp_create_nonce($action) { return 'synthetic-nonce'; }
 function esc_attr($value) { return (string)$value; }
 function esc_html($value) { return (string)$value; }
 function nmkr_get_log_retention_limit() { return 20; }
+function nmkr_safe_getpid() { return 1; }
+function nmkr_log_data_sync($message, $type='info', $context=array()) { $GLOBALS['nmkr_calls'][]='data-log'; }
+function wp_next_scheduled($hook) { $GLOBALS['nmkr_calls'][]='cron-read'; return false; }
+function nmkr_get_sync_data() { $GLOBALS['nmkr_calls'][]='sync-data'; return $GLOBALS['nmkr_sync_data']; }
+function nmkr_should_throttle_logs() { return true; }
+function nmkr_sync_finalization_resume_pending($id) { return false; }
+function nmkr_is_sync_canonically_finished() { return false; }
+function nmkr_is_valid_sync_run_id($id) { return preg_match('/^[a-z0-9-]{8,}$/', $id) === 1; }
+function nmkr_is_sync_terminal_status($status) { return in_array(strtolower((string)$status), array('completed','success','failed','error','stopped','cancelled','aborted'), true); }
+function nmkr_verify_sync_terminal_result() { return false; }
+function nmkr_resume_stopped_sync_recovery($run_id, $sync_stats_id) { $GLOBALS['nmkr_calls'][]='stopped-recovery:'.$run_id.':'.$sync_stats_id; return true; }
+function nmkr_with_ownerless_legacy_recovery($callback) { $GLOBALS['nmkr_calls'][]='ownerless-recovery'; return !empty($GLOBALS['nmkr_execute_recovery']) ? $callback() : true; }
+function nmkr_get_timestamp() { return '2026-01-02 03:04:05'; }
+function nmkr_update_sync_stats($id, $data) { $GLOBALS['nmkr_calls'][]='history-write'; $GLOBALS['nmkr_history'][$id]=array_merge($GLOBALS['nmkr_history'][$id],$data); return true; }
+function nmkr_clear_sync_data() { $GLOBALS['nmkr_calls'][]='cleanup'; }
+function nmkr_clear_sync_jobs_ownerless($reason, $clear_scheduled, $clear_actions) { $GLOBALS['nmkr_calls'][]='cleanup'; }
 
 require __DIR__.'/../includes/synchronization/nmkr-sync-ajax-handlers.php';
 require __DIR__.'/../includes/pages/dashboard/nmkr-dashboard-ajax.php';
@@ -58,7 +90,44 @@ function nmkr_test($name, $handler, $nonce, $caps, $expected, $forbidden, $expec
     if ($expected_response !== null && ($kind !== $expected_response['kind'] || $status !== $expected_response['status'] || $e->data !== $expected_response['data'])) throw new Exception($name.'_response_contract');
 }
 
+function nmkr_progress_test($name, $nonce, $caps, $post, $owner, $expected, $forbidden, $sync_data=false, $execute_recovery=false, $expect_success=true) {
+    $GLOBALS['nmkr_calls']=array(); $GLOBALS['nmkr_nonce_ok']=$nonce; $GLOBALS['nmkr_caps']=$caps;
+    $GLOBALS['nmkr_owner']=$owner; $GLOBALS['nmkr_sync_data']=$sync_data; $GLOBALS['nmkr_execute_recovery']=$execute_recovery;
+    $GLOBALS['nmkr_transients']=array('nmkr_sync_progress'=>50);
+    $_POST=array_merge(array('nonce'=>'synthetic'),$post); $_REQUEST=$_POST; $_SERVER['REQUEST_METHOD']='POST';
+    try { nmkr_sync_progress_handler(); throw new Exception($name.'_no_termination'); }
+    catch (NmkrAjaxTermination $e) { $kind=$e->kind; $status=$e->status; $data=$e->data; }
+    foreach ($expected as $call) if (!in_array($call,$GLOBALS['nmkr_calls'],true)) throw new Exception($name.'_expected_path_missing_'.$call);
+    foreach ($forbidden as $call) if (in_array($call,$GLOBALS['nmkr_calls'],true)) throw new Exception($name.'_forbidden_path_'.$call);
+    if ($expect_success && $nonce && !empty($caps['nmkr_view_dashboard']) && ($kind!=='success' || !is_array($data) || !array_key_exists('progress',$data))) throw new Exception($name.'_observation_unavailable_'.($data['error_code'] ?? $kind));
+    return array($kind,$status,$data);
+}
+
 try {
+    nmkr_progress_test('progress_nonce',false,array(),array(),false,array('headers','nonce:nmkr_sync_nonce:nonce'),array('cap:nmkr_view_dashboard','cap:nmkr_manage_sync','owner','option','transient','stopped-recovery','ownerless-recovery'));
+    $denied=nmkr_progress_test('progress_view_cap',true,array(),array(),false,array('cap:nmkr_view_dashboard'),array('cap:nmkr_manage_sync','owner','option','transient','history-write','cron'));
+    if ($denied[0] !== 'error' || $denied[1] !== 403) throw new Exception('progress_view_cap_forbidden_shape');
+    nmkr_progress_test('progress_view_only',true,array('nmkr_view_dashboard'=>true),array(),false,array('cap:nmkr_manage_sync','sync-data'),array('ownerless-recovery','history-write','option-write','transient-write','cron','stopped-recovery'));
+    $stopped_owner=array('mode'=>'direct','state'=>'stop_requested','run_id'=>'synthetic-run-0001','sync_stats_id'=>41);
+    nmkr_progress_test('progress_view_stopped',true,array('nmkr_view_dashboard'=>true),array(),$stopped_owner,array('sync-data'),array('stopped-recovery:synthetic-run-0001:41','ownerless-recovery','history-write','option-write','transient-write','cron'));
+    foreach (array(array('recovery'=>'1'),array('check_stalled'=>'1'),array('recovery'=>array('1')),array('check_stalled'=>array('1'))) as $index=>$crafted) {
+        nmkr_progress_test('progress_view_crafted_'.$index,true,array('nmkr_view_dashboard'=>true),$crafted,false,array('sync-data'),array('ownerless-recovery','history-write','option-write','transient-write','cron','stopped-recovery'));
+    }
+    nmkr_progress_test('progress_manager_stopped',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array(),$stopped_owner,array('stopped-recovery:synthetic-run-0001:41','sync-data'),array('ownerless-recovery','history-write'));
+    if (count(array_filter($GLOBALS['nmkr_calls'],function($call){return $call==='stopped-recovery:synthetic-run-0001:41';})) !== 1) throw new Exception('progress_manager_stopped_duplicate');
+    nmkr_progress_test('progress_manager_ownerless',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery'),array('stopped-recovery','history-write'));
+
+    $GLOBALS['nmkr_options']['nmkr_last_progress_update_time']=1;
+    $GLOBALS['nmkr_options']['nmkr_last_progress_value']=50;
+    $stale_sync_data=array('sync_stats_id'=>51,'status'=>'processing_tokens','last_update_time'=>1);
+    $GLOBALS['nmkr_history'][51]=array('id'=>51,'status'=>'completed','end_time'=>'2026-01-01 00:00:00','error_message'=>'terminal fields');
+    nmkr_progress_test('terminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','cleanup'),array('history-write'),$stale_sync_data,true,false);
+    if ($GLOBALS['nmkr_history'][51]['status'] !== 'completed' || $GLOBALS['nmkr_history'][51]['end_time'] !== '2026-01-01 00:00:00' || $GLOBALS['nmkr_history'][51]['error_message'] !== 'terminal fields') throw new Exception('terminal_history_overwritten');
+    $stale_sync_data['sync_stats_id']=52;
+    $GLOBALS['nmkr_history'][52]=array('id'=>52,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
+    nmkr_progress_test('nonterminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','cleanup'),array(),$stale_sync_data,true,false);
+    if ($GLOBALS['nmkr_history'][52]['status'] !== 'failed' || empty($GLOBALS['nmkr_history'][52]['end_time'])) throw new Exception('nonterminal_history_not_eligible');
+
     nmkr_test('start_nonce','nmkr_start_sync_handler',false,array(),array('nonce:nmkr_sync_nonce:nonce'),array('cap:nmkr_manage_sync','admission','option','transient','cron'));
     nmkr_test('start_cap','nmkr_start_sync_handler',true,array(),array('cap:nmkr_manage_sync'),array('admission','option','option-write','transient','transient-write','cron'));
     nmkr_test('progress_cap','nmkr_sync_progress_handler',true,array(),array('cap:nmkr_view_dashboard'),array('owner','option','transient'));

--- a/scripts/nmkr-ajax-guard-regression.php
+++ b/scripts/nmkr-ajax-guard-regression.php
@@ -12,14 +12,40 @@ $GLOBALS['nmkr_transients'] = array();
 $GLOBALS['nmkr_owner'] = false;
 $GLOBALS['nmkr_sync_data'] = false;
 $GLOBALS['nmkr_history'] = array();
+$GLOBALS['nmkr_concurrent_terminalization'] = false;
 
 class NmkrSyntheticWpdb {
     public $prefix = 'wp_';
-    public function prepare($query, $value) { return str_replace('%d', (string) (int) $value, $query); }
+    public function prepare($query, ...$values) {
+        if (count($values) === 1 && is_array($values[0])) $values = $values[0];
+        foreach ($values as $value) {
+            $query = preg_replace_callback('/%[ds]/', function($match) use ($value) {
+                return $match[0] === '%d' ? (string)(int)$value : "'".str_replace("'", "''", (string)$value)."'";
+            }, $query, 1);
+        }
+        return $query;
+    }
     public function get_row($query, $format=null) {
         preg_match('/WHERE id = ([0-9]+)/', $query, $matches);
         $id = (int) ($matches[1] ?? 0);
         return $GLOBALS['nmkr_history'][$id] ?? null;
+    }
+    public function query($query) {
+        $GLOBALS['nmkr_calls'][]='history-write';
+        if (strpos($query, 'LOWER(status) NOT IN') === false) throw new Exception('history_update_not_atomic');
+        preg_match('/WHERE id = ([0-9]+)/', $query, $id_match);
+        $id = (int)($id_match[1] ?? 0);
+        if (($GLOBALS['nmkr_concurrent_terminalization']['id'] ?? 0) === $id) {
+            $GLOBALS['nmkr_history'][$id] = $GLOBALS['nmkr_concurrent_terminalization']['row'];
+            $GLOBALS['nmkr_concurrent_terminalization'] = false;
+        }
+        if (!isset($GLOBALS['nmkr_history'][$id]) || nmkr_is_sync_terminal_status($GLOBALS['nmkr_history'][$id]['status'] ?? '')) return 0;
+        preg_match("/SET status = '([^']*)', end_time = '([^']*)', error_message = '([^']*)', updated_at = '([^']*)'/", $query, $values);
+        if (count($values) !== 5) return false;
+        $GLOBALS['nmkr_history'][$id] = array_merge($GLOBALS['nmkr_history'][$id], array(
+            'status'=>$values[1], 'end_time'=>$values[2], 'error_message'=>$values[3], 'updated_at'=>$values[4],
+        ));
+        return 1;
     }
 }
 $GLOBALS['wpdb'] = new NmkrSyntheticWpdb();
@@ -64,12 +90,12 @@ function nmkr_should_throttle_logs() { return true; }
 function nmkr_sync_finalization_resume_pending($id) { return false; }
 function nmkr_is_sync_canonically_finished() { return false; }
 function nmkr_is_valid_sync_run_id($id) { return preg_match('/^[a-z0-9-]{8,}$/', $id) === 1; }
-function nmkr_is_sync_terminal_status($status) { return in_array(strtolower((string)$status), array('completed','success','failed','error','stopped','cancelled','aborted'), true); }
+function nmkr_sync_terminal_statuses() { return array('completed','success','failed','error','stopped','cancelled','aborted'); }
+function nmkr_is_sync_terminal_status($status) { return in_array(strtolower((string)$status), nmkr_sync_terminal_statuses(), true); }
 function nmkr_verify_sync_terminal_result() { return false; }
 function nmkr_resume_stopped_sync_recovery($run_id, $sync_stats_id) { $GLOBALS['nmkr_calls'][]='stopped-recovery:'.$run_id.':'.$sync_stats_id; return true; }
 function nmkr_with_ownerless_legacy_recovery($callback) { $GLOBALS['nmkr_calls'][]='ownerless-recovery'; return !empty($GLOBALS['nmkr_execute_recovery']) ? $callback() : true; }
 function nmkr_get_timestamp() { return '2026-01-02 03:04:05'; }
-function nmkr_update_sync_stats($id, $data) { $GLOBALS['nmkr_calls'][]='history-write'; $GLOBALS['nmkr_history'][$id]=array_merge($GLOBALS['nmkr_history'][$id],$data); return true; }
 function nmkr_clear_sync_data() { $GLOBALS['nmkr_calls'][]='cleanup'; }
 function nmkr_clear_sync_jobs_ownerless($reason, $clear_scheduled, $clear_actions) { $GLOBALS['nmkr_calls'][]='cleanup'; }
 
@@ -104,6 +130,20 @@ function nmkr_progress_test($name, $nonce, $caps, $post, $owner, $expected, $for
 }
 
 try {
+    $GLOBALS['nmkr_history'][48]=array('id'=>48,'status'=>'completed','end_time'=>'2026-01-01 00:00:00','error_message'=>'completed result','updated_at'=>'2026-01-01 00:00:01');
+    $terminal_before=$GLOBALS['nmkr_history'][48];
+    if (nmkr_fail_nonterminal_sync_history(48,'legacy recovery') !== false || $GLOBALS['nmkr_history'][48] !== $terminal_before) throw new Exception('atomic_terminal_history_changed');
+
+    $GLOBALS['nmkr_history'][49]=array('id'=>49,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'','updated_at'=>'2026-01-01 00:00:00');
+    if (!nmkr_fail_nonterminal_sync_history(49,'legacy recovery')) throw new Exception('atomic_nonterminal_update_failed');
+    if ($GLOBALS['nmkr_history'][49] !== array('id'=>49,'status'=>'failed','end_time'=>'2026-01-02 03:04:05','error_message'=>'legacy recovery','updated_at'=>'2026-01-02 03:04:05')) throw new Exception('atomic_nonterminal_fields_mismatch');
+
+    $GLOBALS['nmkr_history'][50]=array('id'=>50,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'','updated_at'=>'2026-01-01 00:00:00');
+    $concurrent_result=array('id'=>50,'status'=>'stopped','end_time'=>'2026-01-02 03:04:04','error_message'=>'cooperative stop','updated_at'=>'2026-01-02 03:04:04');
+    $GLOBALS['nmkr_concurrent_terminalization']=array('id'=>50,'row'=>$concurrent_result);
+    if (nmkr_fail_nonterminal_sync_history(50,'legacy recovery') !== false) throw new Exception('atomic_lost_race_returned_success');
+    if ($GLOBALS['nmkr_history'][50] !== $concurrent_result) throw new Exception('atomic_lost_race_overwritten');
+
     nmkr_progress_test('progress_nonce',false,array(),array(),false,array('headers','nonce:nmkr_sync_nonce:nonce'),array('cap:nmkr_view_dashboard','cap:nmkr_manage_sync','owner','option','transient','stopped-recovery','ownerless-recovery'));
     $denied=nmkr_progress_test('progress_view_cap',true,array(),array(),false,array('cap:nmkr_view_dashboard'),array('cap:nmkr_manage_sync','owner','option','transient','history-write','cron'));
     if ($denied[0] !== 'error' || $denied[1] !== 403) throw new Exception('progress_view_cap_forbidden_shape');
@@ -121,12 +161,12 @@ try {
     $GLOBALS['nmkr_options']['nmkr_last_progress_value']=50;
     $stale_sync_data=array('sync_stats_id'=>51,'status'=>'processing_tokens','last_update_time'=>1);
     $GLOBALS['nmkr_history'][51]=array('id'=>51,'status'=>'completed','end_time'=>'2026-01-01 00:00:00','error_message'=>'terminal fields');
-    nmkr_progress_test('terminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','cleanup'),array('history-write'),$stale_sync_data,true,false);
+    nmkr_progress_test('terminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('recovery'=>'1'),false,array('ownerless-recovery','history-write','cleanup'),array(),$stale_sync_data,true,false);
     if ($GLOBALS['nmkr_history'][51]['status'] !== 'completed' || $GLOBALS['nmkr_history'][51]['end_time'] !== '2026-01-01 00:00:00' || $GLOBALS['nmkr_history'][51]['error_message'] !== 'terminal fields') throw new Exception('terminal_history_overwritten');
     $stale_sync_data['sync_stats_id']=52;
     $GLOBALS['nmkr_history'][52]=array('id'=>52,'status'=>'processing_tokens','end_time'=>null,'error_message'=>'');
     nmkr_progress_test('nonterminal_history_recovery',true,array('nmkr_view_dashboard'=>true,'nmkr_manage_sync'=>true),array('check_stalled'=>'1'),false,array('ownerless-recovery','history-write','cleanup'),array(),$stale_sync_data,true,false);
-    if ($GLOBALS['nmkr_history'][52]['status'] !== 'failed' || empty($GLOBALS['nmkr_history'][52]['end_time'])) throw new Exception('nonterminal_history_not_eligible');
+    if ($GLOBALS['nmkr_history'][52]['status'] !== 'failed' || $GLOBALS['nmkr_history'][52]['end_time'] !== '2026-01-02 03:04:05' || $GLOBALS['nmkr_history'][52]['updated_at'] !== '2026-01-02 03:04:05' || $GLOBALS['nmkr_history'][52]['error_message'] !== 'Sync process stalled - no progress after multiple attempts') throw new Exception('nonterminal_history_not_eligible');
 
     nmkr_test('start_nonce','nmkr_start_sync_handler',false,array(),array('nonce:nmkr_sync_nonce:nonce'),array('cap:nmkr_manage_sync','admission','option','transient','cron'));
     nmkr_test('start_cap','nmkr_start_sync_handler',true,array(),array('cap:nmkr_manage_sync'),array('admission','option','option-write','transient','transient-write','cron'));


### PR DESCRIPTION
### Motivation
- Close an authorization gap where `nmkr_sync_progress_handler()` could perform recovery mutations for callers that only had `nmkr_view_dashboard`.
- Preserve progress as a read-only dashboard-observation endpoint while requiring `nmkr_manage_sync` for lifecycle recovery.
- Protect terminal synchronization history and fail closed around concurrent finalization, database failures, and interrupted cleanup.

### Implementation
- Derive management authority after the existing dashboard-view guard and require it for direct `stop_requested` recovery and ownerless legacy recovery.
- Treat `recovery` and `check_stalled` as capability-aware scalar inputs; view-only callers retain the ordinary progress response and cannot trigger recovery mutations.
- Atomically transition only nonterminal history rows to `failed` using prepared SQL and the canonical terminal-status set.
- Verify the exact history write before cleanup; preserve state when the write or readback cannot be verified.
- Use authoritative uncached owner/sync-data reads when a concurrent terminalizer may have won.
- Recognize an exact previously committed recovery failure on retry so interrupted cleanup can finish idempotently, while rejecting different terminal outcomes.
- Extend the public-safe synthetic regression harness for nonce/capability boundaries, view-only behavior, authorized recovery, atomic history protection, concurrent terminalization, database failure, stale option-cache behavior, and retryable cleanup.

### Exact repository state
- Base branch: `main`
- Base SHA: `a3a4fdad90df76fbcef66c929ac4f03a13c5a042`
- Branch: `codex/implement-milestone-4-by-restricting-recovery-authority`
- Final head SHA: `eb1a9d537cae76a220594e0d480fd7eb05e4abe9`

### Changed files
- `includes/synchronization/nmkr-sync-ajax-handlers.php`
- `scripts/nmkr-ajax-guard-regression.php`

### Validation
- PHP syntax checks passed for both changed files.
- `php scripts/nmkr-ajax-guard-regression.php` passed.
- `bash scripts/nmkr-sync-terminalization-regression.sh` passed.
- `bash scripts/nmkr-sync-owner-regression.sh` passed.
- `git diff --check` passed.
- Exact-head Phase 4 CI run `33258466402` passed.
- The full public suite was intentionally not run locally; PR CI supplied broad public checks.

### Review status
- All actionable Codex findings were corrected.
- The final exact-head Codex finding was classified as non-actionable because it depended on unreachable code after the unconditional return in the inert legacy batch compatibility handler.
- All inline threads are resolved.

### Scope and safety
- No JavaScript, permanent roles, nonce names, schema, dependencies, workflows, generated files, or documentation changed.
- No private environment or deployment was used.
- No real NMKR synchronization or live NMKR traffic occurred.
- Exact-head private DEV validation remains required before merge because this PR affects synchronization recovery, persistent history, concurrency, and cleanup.